### PR TITLE
Check Core watch firmware updates against the PebbleOS GitHub releases

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -22,25 +22,6 @@ and the watch's own bootloader validation with recovery fallback
 backstops a bad install. This entry leaves the file when a single-slot
 watch runs the end-to-end pass.
 
-## Watch health sync not yet exercised end to end after the Firebase strip
-
-**Status: deferred to the first watch-paired e2e pass.**
-
-The Firebase strip excluded the GMS Google Fit transitives from health-kmp
-and rerouted manager creation through a fork seam that pins
-`useGoogleFit=false`, which reshapes the runtime inputs under the live
-Health Connect sync path. Verification so far is static plus test-level:
-APK dex checks show no GMS classes, an instrumented seam test
-(`HealthSeamTest`) resolves the production Koin module in a forced
-Health-Connect-unavailable environment and asserts the Google Fit backend
-is never chosen, and a bytecode scan of health-kmp 1.4.0 found no
-live-path references into the `-dontwarn` namespaces. What has not run is
-an actual watch health sync
-against the built APK, because no watch has been paired to the test device
-yet. Deferred, not skipped: the sync e2e is part of the watch-paired
-verification pass, and this entry leaves the file when that pass is
-recorded.
-
 ## On-device STT model downloads have no integrity verification
 
 **Status: deferred to a dedicated STT hardening branch.**

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -4,6 +4,24 @@ Deliberately deferred issues, each with the rationale and threat-model
 context, per the fork rule that nothing is deferred silently. An entry
 leaves this file when the fix lands.
 
+## GitHub firmware update path not hardware-tested on single-slot watches
+
+**Status: deferred until single-slot Core hardware is available.**
+
+Core watch firmware updates are checked against the public PebbleOS GitHub
+releases and verified before install (API-declared SHA-256 digest and
+size, manifest hardware/type/version cross-checks, inner CRCs), then
+handed to upstream's existing sideload flow. Unit tests cover both
+firmware bundle layouts, including the single-slot shape, and the
+dual-slot path gets a hardware end-to-end pass on a Core Time 2 as part
+of this branch's verification. No single-slot (asterix-class) watch is
+available, so that hardware pass is deferred. Risk is bounded: the
+phone-side code path is identical for both layouts up to the sideload
+handoff, past which transfer and install are upstream's unchanged flow,
+and the watch's own bootloader validation with recovery fallback
+backstops a bad install. This entry leaves the file when a single-slot
+watch runs the end-to-end pass.
+
 ## Watch health sync not yet exercised end to end after the Firebase strip
 
 **Status: deferred to the first watch-paired e2e pass.**

--- a/README.md
+++ b/README.md
@@ -62,10 +62,11 @@ lands piece by piece:
   request, the firmware asset is picked on the phone, and every download
   is verified against the GitHub-declared SHA-256 digest and size plus the
   firmware bundle's own manifest and CRCs before it is handed to the
-  watch. The default channel offers a release once it has been public for
-  a week; a debug-settings toggle ("Early PebbleOS updates") offers the
-  newest release immediately. Legacy Pebble watches keep using the Rebble
-  cohorts endpoint.
+  watch. The default channel offers a release line once its first release
+  has been public for a week, and picks up later hotfix patches within
+  that line immediately; a debug-settings toggle ("Early PebbleOS
+  updates") offers the newest release immediately. Legacy Pebble watches
+  keep using the Rebble cohorts endpoint.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ lands piece by piece:
 - [x] Manual weather location entry
 - [x] Telemetry strip (Crashlytics, analytics, firmware-diagnostics relay)
 - [x] Google Play services / Firebase removal
+- [x] Core watch firmware updates from the public PebbleOS GitHub releases
 - [ ] Third-party microphone API
 
 ## Building (Android)
@@ -50,12 +51,21 @@ lands piece by piece:
 - For a release build signed with the debug key, set
   `LOCAL_RELEASE_BUILD=true` in the root `local.properties`, then
   `./gradlew :composeApp:assembleRelease`.
-- The optional `memfaultToken` Gradle property routes Core-device firmware
-  update checks through Memfault. Those checks periodically send the watch
-  serial number (or a MAC-derived identifier), hardware revision, and
-  firmware version to `api.memfault.com` in the background. Fork builds
-  ship no token and make no Memfault requests; firmware updates still work
-  through the cohorts endpoint.
+- Fork builds ship no Memfault token and make no Memfault requests.
+  Upstream's optional `memfaultToken` Gradle property would route Core
+  watch update checks through `api.memfault.com`, periodically sending the
+  watch serial number (or a MAC-derived identifier), hardware revision,
+  and firmware version in the background.
+- Core watch firmware updates come from the official
+  [PebbleOS GitHub releases](https://github.com/coredevices/PebbleOS/releases):
+  the release list is fetched anonymously with no device data in the
+  request, the firmware asset is picked on the phone, and every download
+  is verified against the GitHub-declared SHA-256 digest and size plus the
+  firmware bundle's own manifest and CRCs before it is handed to the
+  watch. The default channel offers a release once it has been public for
+  a week; a debug-settings toggle ("Early PebbleOS updates") offers the
+  newest release immediately. Legacy Pebble watches keep using the Rebble
+  cohorts endpoint.
 
 ## Architecture
 

--- a/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/WatchOnboardingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/WatchOnboardingScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import co.touchlab.kermit.Logger
 import coredevices.pebble.Platform
+import coredevices.pebble.firmware.VerifiedFirmwareInstaller
 import coredevices.pebble.services.AppStoreHomeResult
 import coredevices.pebble.services.LanguagePackRepository
 import coredevices.pebble.services.PebbleWebServices
@@ -191,16 +192,22 @@ fun WatchOnboardingScreen(
                             return@Scaffold
                         }
 
+                        // Fork: verified install path (sha256 + manifest checks).
+                        val forkInstaller: VerifiedFirmwareInstaller = koinInject()
                         LaunchedEffect(haveStartedFwupSinceLastConnection) {
                             if (!haveStartedFwupSinceLastConnection) {
                                 logger.d { "Starting firmware update from onboarding screen" }
                                 haveStartedFwupSinceLastConnection = true
                                 haveUpdatedFirmware = true
-                                connectedWatch.updateFirmware(firmwareUpdateAvailable)
+                                forkInstaller.install(connectedWatch, firmwareUpdateAvailable)
                             }
                         }
 
                         SectionText("Updating your watch to the latest version of PebbleOS...")
+                        // Fork: surface download/verify phases and failures, which
+                        // happen before upstream's progress state exists.
+                        val forkInstallState by forkInstaller.stateFor(connectedWatch.identifier).collectAsState()
+                        forkInstallState.describe()?.let { SectionText(it) }
                         Spacer(modifier = Modifier.height(15.dp))
                         val progress = (connectedWatch.firmwareUpdateState as? FirmwareUpdater.FirmwareUpdateStatus.InProgress)?.progress?.collectAsState()
                         if (progress != null) {

--- a/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/WatchOnboardingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/WatchOnboardingScreen.kt
@@ -59,6 +59,7 @@ import coredevices.pebble.services.PebbleWebServices
 import coredevices.pebble.services.StoreOnboarding
 import coredevices.pebble.ui.CommonAppType
 import coredevices.pebble.ui.LanguageDialog
+import coredevices.pebble.ui.installStateFor
 import coredevices.pebble.ui.NativeLockerAddUtil
 import coredevices.pebble.ui.NativeWatchfaceMainContent
 import coredevices.pebble.ui.SettingsIds.EnableActivityInsights
@@ -206,7 +207,7 @@ fun WatchOnboardingScreen(
                         SectionText("Updating your watch to the latest version of PebbleOS...")
                         // Fork: surface download/verify phases and failures, which
                         // happen before upstream's progress state exists.
-                        val forkInstallState by forkInstaller.stateFor(connectedWatch.identifier).collectAsState()
+                        val forkInstallState by forkInstaller.installStateFor(connectedWatch)
                         forkInstallState.describe()?.let { SectionText(it) }
                         Spacer(modifier = Modifier.height(15.dp))
                         val progress = (connectedWatch.firmwareUpdateState as? FirmwareUpdater.FirmwareUpdateStatus.InProgress)?.progress?.collectAsState()

--- a/pebble/build.gradle.kts
+++ b/pebble/build.gradle.kts
@@ -102,6 +102,10 @@ kotlin {
                 implementation(libs.paging.compose)
                 implementation(compose.components.uiToolingPreview)
                 implementation(libs.kotlinx.io.core)
+                // Fork: multiplatform sha256 (HashingSink) for the verified
+                // firmware installer; already in the runtime graph via
+                // libpebble3's zip handling, declared here for direct use.
+                implementation(libs.okio)
                 implementation(libs.kermit)
                 implementation(project(":util"))
                 implementation(libs.serialization)

--- a/pebble/src/androidUnitTest/kotlin/coredevices/pebble/firmware/FirmwareUpdateUiTrackerTest.kt
+++ b/pebble/src/androidUnitTest/kotlin/coredevices/pebble/firmware/FirmwareUpdateUiTrackerTest.kt
@@ -1,0 +1,94 @@
+package coredevices.pebble.firmware
+
+import com.russhwolf.settings.MapSettings
+import coredevices.util.CoreConfig
+import coredevices.util.CoreConfigFlow
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.rebble.libpebblecommon.connection.AppContext
+import io.rebble.libpebblecommon.connection.FakeConnectedDevice
+import io.rebble.libpebblecommon.connection.FakeLibPebble
+import io.rebble.libpebblecommon.connection.FirmwareUpdateCheckResult
+import io.rebble.libpebblecommon.connection.FirmwareUpdateCheckState
+import io.rebble.libpebblecommon.connection.PebbleDevice
+import io.rebble.libpebblecommon.connection.asPebbleBleIdentifier
+import io.rebble.libpebblecommon.connection.endpointmanager.FirmwareUpdater.FirmwareUpdateStatus
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+import kotlinx.io.files.Path
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertIs
+
+/**
+ * Pins the security-relevant routing in RealFirmwareUpdateUiTracker: a
+ * notification-triggered install must enter the fork's verified pipeline.
+ * An upstream merge resolving updateWatchNow back to the raw
+ * updateFirmware(update) call would compile cleanly and silently bypass
+ * every verification layer; this test fails instead.
+ */
+class FirmwareUpdateUiTrackerTest {
+
+    // AppContext's Android actual wraps a real Context that updateWatchNow
+    // never dereferences; allocating it without running the constructor
+    // avoids pulling in Robolectric for a field the tested path cannot
+    // touch.
+    private fun bareAppContext(): AppContext {
+        val field = sun.misc.Unsafe::class.java.getDeclaredField("theUnsafe")
+        field.isAccessible = true
+        val unsafe = field.get(null) as sun.misc.Unsafe
+        return unsafe.allocateInstance(AppContext::class.java) as AppContext
+    }
+
+    @Test
+    fun notificationTapRoutesThroughTheVerifiedInstaller() = runTest {
+        val tempDir = Path(Files.createTempDirectory("fork-fw-tracker-test").toString())
+        val installer = VerifiedFirmwareInstaller(
+            httpClient = HttpClient(MockEngine { respond("gone", HttpStatusCode.NotFound) }),
+            expectations = FirmwareArtifactExpectations(),
+            downloadDirectory = { tempDir },
+            watchUpdateStates = {
+                MutableStateFlow<FirmwareUpdateStatus?>(FirmwareUpdateStatus.NotInProgress.Idle())
+            },
+            scope = backgroundScope,
+        )
+        val update = FirmwareUpdateCheckResult.FoundUpdate(
+            version = testFwVersion("v4.31.1"),
+            url = "https://release-assets.example.com/normal_asterix_v4.31.1.pbz",
+            notes = "",
+        )
+        val watch = FakeConnectedDevice(
+            identifier = "00:11:22:33:44:55".asPebbleBleIdentifier(),
+            firmwareUpdateAvailable = FirmwareUpdateCheckState(checkingForUpdates = false, result = update),
+            firmwareUpdateState = FirmwareUpdateStatus.NotInProgress.Idle(),
+            name = "Test Watch",
+            nickname = null,
+            connectionFailureInfo = null,
+        )
+        val libPebble = FakeLibPebble()
+        @Suppress("UNCHECKED_CAST")
+        (libPebble.watches as MutableStateFlow<List<PebbleDevice>>).value = listOf(watch)
+
+        val tracker = RealFirmwareUpdateUiTracker(
+            settings = MapSettings(),
+            clock = fixedTestClock,
+            appContext = bareAppContext(),
+            coreConfigFlow = CoreConfigFlow(MutableStateFlow(CoreConfig())),
+            installer = installer,
+        )
+        tracker.updateWatchNow(libPebble, watch.identifier.asString)
+
+        // Entering the pipeline is observable at its first fail-closed gate:
+        // nothing recorded an expectation for this URL, so the fork install
+        // state for exactly this watch must become the refusal.
+        val failed = withTimeout(5_000) {
+            installer.stateFor(watch.identifier).first { it is ForkFirmwareInstallState.Failed }
+        }
+        assertContains(assertIs<ForkFirmwareInstallState.Failed>(failed).reason, "no integrity data")
+    }
+}

--- a/pebble/src/androidUnitTest/kotlin/coredevices/pebble/firmware/VerifiedFirmwareInstallerTest.kt
+++ b/pebble/src/androidUnitTest/kotlin/coredevices/pebble/firmware/VerifiedFirmwareInstallerTest.kt
@@ -18,6 +18,7 @@ import io.rebble.libpebblecommon.util.Crc32Calculator
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
@@ -294,6 +295,61 @@ class VerifiedFirmwareInstallerTest {
     }
 
     @Test
+    fun nullSizeExpectationInstallsAndSkipsOnlyTheSizeChecks() = runTest {
+        // Cohorts records no size, so the null-size path is the entire
+        // install path for legacy watches: the cap falls back to the
+        // constant, the exact-size check is skipped, nothing else loosens.
+        val pbz = singleSlotPbz()
+        record(pbz, size = null)
+        handoffSucceeds()
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        assertNotNull(sideloadedPath)
+        assertContentEquals(pbz, sideloadedBytes)
+        assertEquals(ForkFirmwareInstallState.Idle, installer.stateValueFor("watch1"))
+        assertTrue(forkFilesLeft().isEmpty())
+    }
+
+    @Test
+    fun nullSizeExpectationStillEnforcesTheChecksum() = runTest {
+        val pbz = singleSlotPbz()
+        record(pbz, sha256 = "0".repeat(64), size = null)
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "checksum mismatch")
+        assertNull(sideloadedPath)
+        assertTrue(forkFilesLeft().isEmpty())
+    }
+
+    @Test
+    fun nonZipPayloadFailsClosedAndDeletesTheFile() = runTest {
+        // The expectation hash is computed over whatever the source
+        // published, so a garbage artifact passes the transport layer and
+        // only the parse layer can refuse it.
+        val garbage = ByteArray(700) { (it % 31).toByte() }
+        record(garbage)
+        val installer = installer(backgroundScope, serving(garbage))
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "could not verify")
+        assertNull(sideloadedPath)
+        assertTrue(forkFilesLeft().isEmpty())
+    }
+
+    @Test
+    fun zipWithoutAManifestFailsClosedAndDeletesTheFile() = runTest {
+        val pbz = zip(mapOf("pebbleos.bin" to firmwareBytes))
+        record(pbz)
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "could not verify")
+        assertNull(sideloadedPath)
+        assertTrue(forkFilesLeft().isEmpty())
+    }
+
+    @Test
     fun httpErrorFails() = runTest {
         val pbz = singleSlotPbz()
         record(pbz)
@@ -448,7 +504,11 @@ class VerifiedFirmwareInstallerTest {
         assertEquals(1, requests.get())
         installer.runInstall(target(), update())
         assertEquals(1, requests.get(), "second install must not start a second download")
-        first.cancel()
+        first.cancelAndJoin()
+        // Cancellation cleanup: the partial download is deleted and the fork
+        // state resets, so the UI cannot stay stuck on Downloading.
+        assertTrue(forkFilesLeft().isEmpty(), "cancelled install must not leak its partial file")
+        assertEquals(ForkFirmwareInstallState.Idle, installer.stateValueFor("watch1"))
     }
 
     @Test
@@ -467,8 +527,11 @@ class VerifiedFirmwareInstallerTest {
         val second = backgroundScope.launch { installer.runInstall(target(key = "watchB"), update()) }
         bothRequested.await()
         assertEquals(2, requests.get(), "each watch gets its own download")
-        first.cancel()
-        second.cancel()
+        first.cancelAndJoin()
+        second.cancelAndJoin()
+        assertTrue(forkFilesLeft().isEmpty(), "cancelled installs must not leak partial files")
+        assertEquals(ForkFirmwareInstallState.Idle, installer.stateValueFor("watchA"))
+        assertEquals(ForkFirmwareInstallState.Idle, installer.stateValueFor("watchB"))
     }
 
     @Test

--- a/pebble/src/androidUnitTest/kotlin/coredevices/pebble/firmware/VerifiedFirmwareInstallerTest.kt
+++ b/pebble/src/androidUnitTest/kotlin/coredevices/pebble/firmware/VerifiedFirmwareInstallerTest.kt
@@ -17,6 +17,7 @@ import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
 import io.rebble.libpebblecommon.util.Crc32Calculator
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
@@ -27,6 +28,7 @@ import kotlinx.io.readByteArray
 import java.io.ByteArrayOutputStream
 import java.nio.file.Files
 import java.security.MessageDigest
+import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
@@ -37,6 +39,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -127,7 +130,6 @@ class VerifiedFirmwareInstallerTest {
     private var sideloadedBytes: ByteArray? = null
     private var sideloadedPath: Path? = null
     private var onSideload: (Path) -> Unit = {}
-    private var updaterState: FirmwareUpdateStatus = FirmwareUpdateStatus.NotInProgress.Idle()
 
     private fun installer(
         scope: CoroutineScope,
@@ -149,7 +151,6 @@ class VerifiedFirmwareInstallerTest {
     ) = VerifiedFirmwareInstaller.InstallTarget(
         identifierKey = key,
         platform = platform,
-        currentUpdateState = { updaterState },
         sideload = { path ->
             sideloadedPath = path
             // Read immediately: the installer deletes the file once the
@@ -236,11 +237,25 @@ class VerifiedFirmwareInstallerTest {
     fun refusesWhenAnUpstreamUpdateIsAlreadyRunning() = runTest {
         val pbz = singleSlotPbz()
         record(pbz)
-        updaterState = FirmwareUpdateStatus.WaitingToStart(update())
+        // The gate reads the live per-watch state flow, so an update that
+        // started after the device snapshot was taken still blocks.
+        watchStates.value = FirmwareUpdateStatus.WaitingToStart(update())
         val installer = installer(backgroundScope, serving(pbz))
         installer.runInstall(target(), update())
         val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
         assertContains(state.reason, "already in progress")
+        assertEquals(0, requests.get())
+    }
+
+    @Test
+    fun vanishedWatchIsRefusedBeforeDownloading() = runTest {
+        val pbz = singleSlotPbz()
+        record(pbz)
+        watchStates.value = null
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "not connected")
         assertEquals(0, requests.get())
     }
 
@@ -454,6 +469,93 @@ class VerifiedFirmwareInstallerTest {
         assertEquals(2, requests.get(), "each watch gets its own download")
         first.cancel()
         second.cancel()
+    }
+
+    @Test
+    fun staleErrorStartingFromAPreviousAttemptIsNotReadAsThisInstallsOutcome() = runTest {
+        // Upstream keeps ErrorStarting until the NEXT sideload gets past its
+        // parse, and the state flow replays it to new collectors; the
+        // handoff watcher must not treat the replay as this attempt's
+        // outcome, and must not delete the archive while the freshly
+        // launched sideload coroutine still needs it.
+        val pbz = singleSlotPbz()
+        record(pbz)
+        watchStates.value = FirmwareUpdateStatus.NotInProgress.ErrorStarting(
+            FirmwareUpdateErrorStarting.ErrorParsingPbz,
+        )
+        val sideloadStarted = CompletableDeferred<Unit>()
+        onSideload = { sideloadStarted.complete(Unit) } // upstream parse still running
+        val installer = installer(backgroundScope, serving(pbz))
+        val install = backgroundScope.launch { installer.runInstall(target(), update()) }
+        // The scheduler is single threaded, so once await() resumes here the
+        // install coroutine has already seen the replayed stale value and is
+        // suspended waiting for a genuinely new emission.
+        sideloadStarted.await()
+        assertEquals(1, forkFilesLeft().size, "file must survive while the sideload parse runs")
+        assertEquals(ForkFirmwareInstallState.HandedOff, installer.stateValueFor("watch1"))
+        // The retry's parse succeeds and the transfer runs to completion.
+        watchStates.value = FirmwareUpdateStatus.WaitingToStart(update())
+        watchStates.value = FirmwareUpdateStatus.WaitingForReboot(update())
+        install.join()
+        assertEquals(ForkFirmwareInstallState.Idle, installer.stateValueFor("watch1"))
+        assertTrue(forkFilesLeft().isEmpty())
+    }
+
+    @Test
+    fun staleErrorStartingWithASilentRejectionFailsAsNotStarted() = runTest {
+        // Degraded corner of the stale-state defense: the retry fails with
+        // an identical error, which a StateFlow cannot re-emit, so the only
+        // safe outcome is the start timeout (fail closed, file cleaned up
+        // after the upstream parse window, not during it).
+        val pbz = singleSlotPbz()
+        record(pbz)
+        watchStates.value = FirmwareUpdateStatus.NotInProgress.ErrorStarting(
+            FirmwareUpdateErrorStarting.ErrorParsingPbz,
+        )
+        onSideload = {} // upstream re-fails identically: no state change at all
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "did not start")
+        assertTrue(forkFilesLeft().isEmpty())
+    }
+
+    @Test
+    fun timeoutWithTheTransferStillRunningLeavesTheFileAlone() = runTest {
+        // The transfer wait giving up must not delete the zip mid-transfer:
+        // PutBytes lazily re-opens it by path (the resources stream opens
+        // only after the firmware stream completes), so deletion would kill
+        // a slow-but-alive transfer partway. The stale sweep reclaims the
+        // file in the next process instead.
+        val pbz = singleSlotPbz()
+        record(pbz)
+        onSideload = { watchStates.value = FirmwareUpdateStatus.WaitingToStart(update()) }
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        assertEquals(1, forkFilesLeft().size, "file must outlive a transfer that is still running")
+        assertEquals(ForkFirmwareInstallState.Idle, installer.stateValueFor("watch1"))
+    }
+
+    @Test
+    fun concurrentFirstAccessesShareOneStateFlowInstance() {
+        // Real threads, not runTest: this pins the exact production race
+        // (install coroutine on Dispatchers.Default vs a main-thread Compose
+        // read doing the first access for a watch). Both must get the same
+        // instance, or the UI collects a flow the install never writes to.
+        val installer = installer(CoroutineScope(SupervisorJob()), serving(singleSlotPbz()))
+        repeat(500) { i ->
+            val key = "race-$i"
+            val barrier = CyclicBarrier(2)
+            val results = arrayOfNulls<Any>(2)
+            val threads = (0..1).map { t ->
+                Thread {
+                    barrier.await()
+                    results[t] = installer.stateFlowFor(key)
+                }.apply { start() }
+            }
+            threads.forEach { it.join() }
+            assertSame(results[0], results[1], "both threads must get the same flow for $key")
+        }
     }
 
     @Test

--- a/pebble/src/androidUnitTest/kotlin/coredevices/pebble/firmware/VerifiedFirmwareInstallerTest.kt
+++ b/pebble/src/androidUnitTest/kotlin/coredevices/pebble/firmware/VerifiedFirmwareInstallerTest.kt
@@ -1,0 +1,478 @@
+package coredevices.pebble.firmware
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
+import io.ktor.http.HttpStatusCode
+import io.ktor.utils.io.ByteChannel
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.writeFully
+import io.rebble.libpebblecommon.connection.FirmwareUpdateCheckResult
+import io.rebble.libpebblecommon.connection.endpointmanager.FirmwareUpdateErrorStarting
+import io.rebble.libpebblecommon.connection.endpointmanager.FirmwareUpdater.FirmwareUpdateStatus
+import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
+import io.rebble.libpebblecommon.util.Crc32Calculator
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readByteArray
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the verified install pipeline end to end against synthetic PBZ
+ * archives: every fail-closed branch (missing expectation, https, checksum,
+ * size, stall, manifest hardware/tag/type, inner CRC) must refuse the
+ * install, never call sideload, and leave no file behind; the happy path
+ * must hand libpebble3 the exact verified bytes. Lives in androidUnitTest
+ * because the fixtures are built with java.util.zip.
+ */
+class VerifiedFirmwareInstallerTest {
+
+    private val tempDir = Path(Files.createTempDirectory("fork-fw-test").toString())
+    private val url = "https://release-assets.example.com/normal_asterix_v4.31.1.pbz"
+
+    // --- Synthetic PBZ fixtures ---
+
+    @OptIn(ExperimentalUnsignedTypes::class)
+    private fun crcOf(bytes: ByteArray): Long =
+        Crc32Calculator().apply { addBytes(bytes.toUByteArray()) }.finalize().toLong()
+
+    private fun manifestJson(
+        hwrev: String,
+        firmware: ByteArray,
+        resources: ByteArray,
+        versionTag: String?,
+        type: String,
+        slot: Int?,
+        corruptCrc: Boolean,
+    ): ByteArray = buildString {
+        append("""{"manifestVersion":2,"generatedAt":1785364975,"debug":{},"firmware":{""")
+        append(""""name":"pebbleos.bin","type":"$type","timestamp":1785364659,"commit":"abc123",""")
+        append(""""hwrev":"$hwrev","size":${firmware.size},"crc":${crcOf(firmware) + if (corruptCrc) 1 else 0}""")
+        if (versionTag != null) append(""","versionTag":"$versionTag"""")
+        if (slot != null) append(""","slot":$slot""")
+        append("""},"resources":{"name":"system_resources.pbpack","timestamp":1785364659,""")
+        append(""""size":${resources.size},"crc":${crcOf(resources)}},"type":"firmware"}""")
+    }.encodeToByteArray()
+
+    private fun zip(entries: Map<String, ByteArray>): ByteArray {
+        val out = ByteArrayOutputStream()
+        ZipOutputStream(out).use { zos ->
+            entries.forEach { (name, bytes) ->
+                zos.putNextEntry(ZipEntry(name))
+                zos.write(bytes)
+                zos.closeEntry()
+            }
+        }
+        return out.toByteArray()
+    }
+
+    private val firmwareBytes = ByteArray(600) { (it % 251).toByte() }
+    private val resourceBytes = ByteArray(400) { (it % 127).toByte() }
+
+    private fun singleSlotPbz(
+        hwrev: String = "asterix",
+        versionTag: String? = "v4.31.1",
+        type: String = "normal",
+        corruptCrc: Boolean = false,
+    ): ByteArray = zip(
+        mapOf(
+            "manifest.json" to manifestJson(hwrev, firmwareBytes, resourceBytes, versionTag, type, slot = null, corruptCrc = corruptCrc),
+            "pebbleos.bin" to firmwareBytes,
+            "system_resources.pbpack" to resourceBytes,
+        ),
+    )
+
+    private fun dualSlotPbz(hwrevSlot0: String, hwrevSlot1: String): ByteArray = zip(
+        mapOf(
+            "slot0/manifest.json" to manifestJson(hwrevSlot0, firmwareBytes, resourceBytes, "v4.31.1", "normal", slot = 0, corruptCrc = false),
+            "slot0/pebbleos.bin" to firmwareBytes,
+            "slot0/system_resources.pbpack" to resourceBytes,
+            "slot1/manifest.json" to manifestJson(hwrevSlot1, firmwareBytes, resourceBytes, "v4.31.1", "normal", slot = 1, corruptCrc = false),
+            "slot1/pebbleos.bin" to firmwareBytes,
+            "slot1/system_resources.pbpack" to resourceBytes,
+        ),
+    )
+
+    private fun sha256Hex(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+
+    // --- Harness ---
+
+    private val requests = AtomicInteger(0)
+    private val expectations = FirmwareArtifactExpectations()
+    private val watchStates = MutableStateFlow<FirmwareUpdateStatus?>(FirmwareUpdateStatus.NotInProgress.Idle())
+
+    private var sideloadedBytes: ByteArray? = null
+    private var sideloadedPath: Path? = null
+    private var onSideload: (Path) -> Unit = {}
+    private var updaterState: FirmwareUpdateStatus = FirmwareUpdateStatus.NotInProgress.Idle()
+
+    private fun installer(
+        scope: CoroutineScope,
+        handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData,
+    ): VerifiedFirmwareInstaller = VerifiedFirmwareInstaller(
+        httpClient = HttpClient(MockEngine { request ->
+            requests.incrementAndGet()
+            handler(request)
+        }),
+        expectations = expectations,
+        downloadDirectory = { tempDir },
+        watchUpdateStates = { watchStates },
+        scope = scope,
+    )
+
+    private fun target(
+        key: String = "watch1",
+        platform: WatchHardwarePlatform = WatchHardwarePlatform.CORE_ASTERIX,
+    ) = VerifiedFirmwareInstaller.InstallTarget(
+        identifierKey = key,
+        platform = platform,
+        currentUpdateState = { updaterState },
+        sideload = { path ->
+            sideloadedPath = path
+            // Read immediately: the installer deletes the file once the
+            // (test-driven) transfer reaches a terminal state.
+            sideloadedBytes = SystemFileSystem.source(path).buffered().use { it.readByteArray() }
+            onSideload(path)
+        },
+    )
+
+    private fun update(tag: String = "v4.31.1") = FirmwareUpdateCheckResult.FoundUpdate(
+        version = testFwVersion(tag),
+        url = url,
+        notes = "",
+    )
+
+    private suspend fun record(pbz: ByteArray, tag: String = "v4.31.1", sha256: String = sha256Hex(pbz), size: Long? = pbz.size.toLong()) {
+        expectations.record(url, ExpectedFirmwareArtifact(sha256, size, tag))
+    }
+
+    private fun serving(pbz: ByteArray): suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData =
+        { respond(ByteReadChannel(pbz), HttpStatusCode.OK) }
+
+    private fun forkFilesLeft(): List<Path> =
+        SystemFileSystem.list(tempDir).filter { it.name.startsWith("fork-fw-") }
+
+    private fun handoffSucceeds() {
+        onSideload = {
+            watchStates.value = FirmwareUpdateStatus.WaitingForReboot(update())
+        }
+    }
+
+    // --- Tests ---
+
+    @Test
+    fun happyPathVerifiesAndSideloadsExactBytes() = runTest {
+        val pbz = singleSlotPbz()
+        record(pbz)
+        handoffSucceeds()
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        assertNotNull(sideloadedPath)
+        assertContentEquals(pbz, sideloadedBytes)
+        assertEquals(ForkFirmwareInstallState.Idle, installer.stateValueFor("watch1"))
+        assertTrue(forkFilesLeft().isEmpty(), "temp file should be deleted after the transfer ends")
+    }
+
+    @Test
+    fun staleDownloadsAreSweptBeforeTheFirstDownload() = runTest {
+        val stale = Path(tempDir, "fork-fw-stale-999.pbz")
+        SystemFileSystem.sink(stale).buffered().use { it.write(ByteArray(10)) }
+        val pbz = singleSlotPbz()
+        record(pbz)
+        handoffSucceeds()
+        installer(backgroundScope, serving(pbz)).runInstall(target(), update())
+        assertTrue(forkFilesLeft().isEmpty(), "stale file from a previous process should be swept")
+    }
+
+    @Test
+    fun missingExpectationFailsClosedWithoutTouchingTheNetwork() = runTest {
+        val installer = installer(backgroundScope, serving(singleSlotPbz()))
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "no integrity data")
+        assertEquals(0, requests.get())
+        assertNull(sideloadedPath)
+    }
+
+    @Test
+    fun nonHttpsUrlIsRefused() = runTest {
+        val httpUrl = "http://release-assets.example.com/fw.pbz"
+        val pbz = singleSlotPbz()
+        expectations.record(httpUrl, ExpectedFirmwareArtifact(sha256Hex(pbz), pbz.size.toLong(), "v4.31.1"))
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(
+            target(),
+            FirmwareUpdateCheckResult.FoundUpdate(testFwVersion("v4.31.1"), httpUrl, ""),
+        )
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "non-https")
+        assertEquals(0, requests.get())
+    }
+
+    @Test
+    fun refusesWhenAnUpstreamUpdateIsAlreadyRunning() = runTest {
+        val pbz = singleSlotPbz()
+        record(pbz)
+        updaterState = FirmwareUpdateStatus.WaitingToStart(update())
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "already in progress")
+        assertEquals(0, requests.get())
+    }
+
+    @Test
+    fun checksumMismatchRefusesAndDeletesTheFile() = runTest {
+        val pbz = singleSlotPbz()
+        record(pbz, sha256 = "0".repeat(64))
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "checksum mismatch")
+        assertNull(sideloadedPath)
+        assertTrue(forkFilesLeft().isEmpty())
+    }
+
+    @Test
+    fun shortDownloadFailsTheSizeCheck() = runTest {
+        val pbz = singleSlotPbz()
+        record(pbz, size = pbz.size.toLong() + 5)
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "size mismatch")
+        assertTrue(forkFilesLeft().isEmpty())
+    }
+
+    @Test
+    fun oversizeStreamIsAbortedMidDownload() = runTest {
+        val pbz = singleSlotPbz()
+        record(pbz, size = 10L)
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "larger than expected")
+        assertTrue(forkFilesLeft().isEmpty())
+    }
+
+    @Test
+    fun httpErrorFails() = runTest {
+        val pbz = singleSlotPbz()
+        record(pbz)
+        val installer = installer(backgroundScope) { respond("gone", HttpStatusCode.NotFound) }
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "404")
+    }
+
+    @Test
+    fun stalledDownloadFails() = runTest {
+        val pbz = singleSlotPbz()
+        record(pbz)
+        val installer = installer(backgroundScope) {
+            val channel = ByteChannel()
+            channel.writeFully(pbz, 0, 16)
+            channel.flush()
+            // Never closed: the per-read stall timeout must fire.
+            respond(channel, HttpStatusCode.OK)
+        }
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "stalled")
+        assertTrue(forkFilesLeft().isEmpty())
+    }
+
+    @Test
+    fun wrongHardwareRevisionIsRefused() = runTest {
+        val pbz = singleSlotPbz(hwrev = "silk")
+        record(pbz)
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "not this watch")
+        assertNull(sideloadedPath)
+        assertTrue(forkFilesLeft().isEmpty())
+    }
+
+    @Test
+    fun versionTagMismatchIsRefused() = runTest {
+        val pbz = singleSlotPbz(versionTag = "v9.9.9")
+        record(pbz)
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "does not match release")
+        assertNull(sideloadedPath)
+    }
+
+    @Test
+    fun taglessManifestSkipsTheTagCheckOnly() = runTest {
+        // Sources that never wrote a versionTag must not be broken by the
+        // tag cross-check; the byte hash still pins the exact content.
+        val pbz = singleSlotPbz(versionTag = null)
+        record(pbz)
+        handoffSucceeds()
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        assertNotNull(sideloadedPath)
+        assertEquals(ForkFirmwareInstallState.Idle, installer.stateValueFor("watch1"))
+    }
+
+    @Test
+    fun recoveryTypeArchiveIsRefused() = runTest {
+        // The checkers only ever offer normal firmware; a recovery archive
+        // reaching this pipeline means the selection went wrong.
+        val pbz = singleSlotPbz(type = "recovery")
+        record(pbz)
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "unexpected firmware type")
+    }
+
+    @Test
+    fun innerCrcMismatchIsRefusedEvenWhenTheHashMatches() = runTest {
+        // The expectation hash is computed over the corrupt archive, so the
+        // download-integrity layer passes and only the CRC cross-check can
+        // catch the source-corrupt content.
+        val pbz = singleSlotPbz(corruptCrc = true)
+        record(pbz)
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "CRC")
+        assertNull(sideloadedPath)
+    }
+
+    @Test
+    fun dualSlotArchivesCheckEveryManifest() = runTest {
+        // A wrong hardware revision hiding in slot1 must fail even though
+        // slot0 is fine.
+        val bad = dualSlotPbz(hwrevSlot0 = "asterix", hwrevSlot1 = "silk")
+        record(bad)
+        val installer = installer(backgroundScope, serving(bad))
+        installer.runInstall(target(), update())
+        assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertNull(sideloadedPath)
+
+        val good = dualSlotPbz(hwrevSlot0 = "asterix", hwrevSlot1 = "asterix")
+        expectations.record(url, ExpectedFirmwareArtifact(sha256Hex(good), good.size.toLong(), "v4.31.1"))
+        handoffSucceeds()
+        installer(backgroundScope, serving(good)).runInstall(target(key = "watch2"), update())
+        assertNotNull(sideloadedPath)
+    }
+
+    @Test
+    fun handoffThatNeverStartsFailsAndCleansUp() = runTest {
+        val pbz = singleSlotPbz()
+        record(pbz)
+        onSideload = {} // upstream stays Idle: silent mutex rejection
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        val state = assertIs<ForkFirmwareInstallState.Failed>(installer.stateValueFor("watch1"))
+        assertContains(state.reason, "did not start")
+        assertTrue(forkFilesLeft().isEmpty())
+    }
+
+    @Test
+    fun upstreamErrorStartingIsNotDoubleReported() = runTest {
+        // libpebble3 already renders ErrorStarting in the watch state line;
+        // the fork state must go Idle instead of showing a second failure.
+        val pbz = singleSlotPbz()
+        record(pbz)
+        onSideload = {
+            watchStates.value = FirmwareUpdateStatus.NotInProgress.ErrorStarting(
+                FirmwareUpdateErrorStarting.ErrorParsingPbz,
+            )
+        }
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        assertEquals(ForkFirmwareInstallState.Idle, installer.stateValueFor("watch1"))
+        assertTrue(forkFilesLeft().isEmpty())
+    }
+
+    @Test
+    fun secondInstallForTheSameWatchIsIgnoredWhileOneIsRunning() = runTest {
+        val pbz = singleSlotPbz()
+        record(pbz)
+        // The engine handles requests off the test scheduler, so completion
+        // is signalled from the handler instead of assuming scheduler order.
+        val firstRequestStarted = CompletableDeferred<Unit>()
+        val installer = installer(backgroundScope) {
+            firstRequestStarted.complete(Unit)
+            val channel = ByteChannel()
+            channel.writeFully(pbz, 0, 16)
+            channel.flush()
+            respond(channel, HttpStatusCode.OK)
+        }
+        val first = backgroundScope.launch { installer.runInstall(target(), update()) }
+        firstRequestStarted.await()
+        assertEquals(1, requests.get())
+        installer.runInstall(target(), update())
+        assertEquals(1, requests.get(), "second install must not start a second download")
+        first.cancel()
+    }
+
+    @Test
+    fun distinctWatchesCanInstallConcurrently() = runTest {
+        val pbz = singleSlotPbz()
+        record(pbz)
+        val bothRequested = CompletableDeferred<Unit>()
+        val installer = installer(backgroundScope) {
+            if (requests.get() >= 2) bothRequested.complete(Unit)
+            val channel = ByteChannel()
+            channel.writeFully(pbz, 0, 16)
+            channel.flush()
+            respond(channel, HttpStatusCode.OK)
+        }
+        val first = backgroundScope.launch { installer.runInstall(target(key = "watchA"), update()) }
+        val second = backgroundScope.launch { installer.runInstall(target(key = "watchB"), update()) }
+        bothRequested.await()
+        assertEquals(2, requests.get(), "each watch gets its own download")
+        first.cancel()
+        second.cancel()
+    }
+
+    @Test
+    fun sequentialInstallsUseDistinctFilenames() = runTest {
+        val pbz = singleSlotPbz()
+        record(pbz)
+        handoffSucceeds()
+        val paths = mutableListOf<Path>()
+        val previousOnSideload = onSideload
+        onSideload = { path ->
+            paths += path
+            previousOnSideload(path)
+        }
+        val installer = installer(backgroundScope, serving(pbz))
+        installer.runInstall(target(), update())
+        watchStates.value = FirmwareUpdateStatus.NotInProgress.Idle()
+        record(pbz)
+        installer.runInstall(target(), update())
+        assertEquals(2, paths.size)
+        assertTrue(paths[0].name != paths[1].name, "each install must write to a fresh file")
+    }
+}

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/Cohorts.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/Cohorts.kt
@@ -16,6 +16,8 @@ import kotlin.time.Instant
 class Cohorts(
     private val httpClient: PebbleHttpClient,
     private val appVersion: CoreAppVersion,
+    // Fork: carries the response's sha-256 to the verified installer.
+    private val expectations: FirmwareArtifactExpectations,
 ) {
     private val logger = Logger.withTag("Cohorts")
 
@@ -58,6 +60,23 @@ class Cohorts(
             return FirmwareUpdateCheckResult.UpdateCheckFailed("Failed to check for PebbleOS update")
         }
         if (watch.runningFwVersion.isRecovery || latestFwVersion > watch.runningFwVersion) {
+            // Fork: upstream parses sha-256 but never consumes it. Record it so
+            // the verified installer holds legacy downloads to it too; if the
+            // server ever stops sending a real sha256 hex the installer will
+            // refuse the download (fail closed) rather than skip verification.
+            val sha256Hex = normalizeSha256Hex(normalFw.sha256)
+            if (sha256Hex != null) {
+                expectations.record(
+                    normalFw.url,
+                    ExpectedFirmwareArtifact(
+                        sha256Hex = sha256Hex,
+                        sizeBytes = null,
+                        versionTag = normalFw.friendlyVersion,
+                    ),
+                )
+            } else {
+                logger.w { "Cohorts sha-256 is not a sha256 hex string; install will be refused" }
+            }
             return FirmwareUpdateCheckResult.FoundUpdate(
                 version = latestFwVersion,
                 url = normalFw.url,

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareArtifactExpectations.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareArtifactExpectations.kt
@@ -1,0 +1,63 @@
+package coredevices.pebble.firmware
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/** What a firmware download at a given URL must turn out to be before it may
+ * reach the watch. */
+data class ExpectedFirmwareArtifact(
+    /** Lowercase 64-char hex sha256 of the exact artifact bytes. */
+    val sha256Hex: String,
+    /** Exact artifact size when the source publishes one (GitHub does; cohorts does not). */
+    val sizeBytes: Long?,
+    /** Release tag the artifact belongs to, cross-checked against the PBZ manifest. */
+    val versionTag: String,
+)
+
+/**
+ * Check-time integrity metadata, keyed by download URL, for the verified
+ * installer to enforce at install time.
+ *
+ * Exists because upstream's FoundUpdate carries only (version, url, notes):
+ * there is no field for a hash to travel in, and widening that type would put
+ * a fork diff in libpebble3. Checkers record what their source declares and
+ * the installer refuses any download it has no expectation for (fail closed).
+ * This state is process-lifetime by design, the same lifetime as the
+ * update-check cache and the availableUpdates flows a FoundUpdate lives in,
+ * so a lookup miss is a bug or a process restart, never a legitimate state.
+ */
+class FirmwareArtifactExpectations {
+    private val mutex = Mutex()
+    private val entries = LinkedHashMap<String, ExpectedFirmwareArtifact>()
+
+    suspend fun record(url: String, expected: ExpectedFirmwareArtifact) {
+        mutex.withLock {
+            // Re-insert so eviction order follows recording order; the cap is
+            // hygiene only, a few watches need one live entry each.
+            entries.remove(url)
+            entries[url] = expected
+            while (entries.size > MAX_ENTRIES) {
+                entries.remove(entries.keys.first())
+            }
+        }
+    }
+
+    suspend fun lookup(url: String): ExpectedFirmwareArtifact? =
+        mutex.withLock { entries[url] }
+
+    companion object {
+        private const val MAX_ENTRIES = 16
+    }
+}
+
+/**
+ * Normalizes a hash string to lowercase 64-hex, accepting an optional
+ * "sha256:" prefix (GitHub's asset digest format; cohorts publishes bare
+ * hex). Returns null for anything else so callers skip recording instead of
+ * recording something the installer could never verify against.
+ */
+fun normalizeSha256Hex(value: String?): String? {
+    val hex = value?.trim()?.removePrefix("sha256:")?.lowercase() ?: return null
+    if (hex.length != 64 || !hex.all { it in '0'..'9' || it in 'a'..'f' }) return null
+    return hex
+}

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareReleaseSelection.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareReleaseSelection.kt
@@ -1,5 +1,6 @@
 package coredevices.pebble.firmware
 
+import coredevices.util.CoreConfig
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Instant
@@ -80,6 +81,14 @@ enum class FirmwareUpdateChannel {
     /** Newest main-line tag: the tier Core's internal testers run. */
     Early,
 }
+
+/**
+ * The persisted setting is a plain boolean (a two-state toggle in watch
+ * settings); the mapping lives here so the DI wiring and tests share one
+ * definition of which state means which channel.
+ */
+fun CoreConfig.firmwareUpdateChannel(): FirmwareUpdateChannel =
+    if (firmwareUpdatesEarlyChannel) FirmwareUpdateChannel.Early else FirmwareUpdateChannel.Soaked
 
 /** One GitHub release reduced to what selection needs. */
 data class SelectableRelease(

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareReleaseSelection.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareReleaseSelection.kt
@@ -1,0 +1,137 @@
+package coredevices.pebble.firmware
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
+
+/**
+ * Firmware version parsed from a PebbleOS release tag or a watch-reported
+ * version string, keeping up to four numeric components.
+ *
+ * Fork-owned on purpose, separate from libpebble3's FirmwareVersion: that
+ * parser matches an un-anchored prefix, so a four-component factory tag like
+ * "v4.9.142.3" silently loses its fourth component, and its comparison falls
+ * through to a timestamp tiebreak when the truncated components are equal.
+ * Release selection needs to (a) recognize factory-line tags structurally so
+ * they are never offered, and (b) compare the running firmware against a
+ * candidate such that an equal version is never re-offered (a timestamp
+ * tiebreak would re-offer the installed build forever, because a release's
+ * publish time is always later than the firmware's build time).
+ */
+data class ReleaseTagVersion(
+    val major: Int,
+    val minor: Int,
+    val patch: Int,
+    val fourth: Int,
+    val componentCount: Int,
+    val raw: String,
+) : Comparable<ReleaseTagVersion> {
+    /**
+     * The manufacturing line uses four-component tags (v4.9.142.x today).
+     * Its post-branch commits are factory-test work only, so those builds
+     * must never be offered as an update, however new their publish date.
+     */
+    val isFactoryLine: Boolean get() = componentCount >= 4
+
+    /** Suffixes are ignored: main-line release tags carry none, and recovery
+     * suffixes on watch-reported versions are handled via isRecovery flags. */
+    override fun compareTo(other: ReleaseTagVersion): Int = compareValuesBy(
+        this, other,
+        { it.major }, { it.minor }, { it.patch }, { it.fourth },
+    )
+
+    companion object {
+        // Anchored via matchEntire below: a string that does not wholly match
+        // (allowing an optional "-suffix") is rejected instead of being
+        // prefix-truncated the way libpebble3's regex find() would.
+        private val TAG_REGEX = Regex("""v?(\d+)\.(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-(.*))?""")
+
+        fun from(tag: String): ReleaseTagVersion? {
+            val trimmed = tag.trim()
+            val match = TAG_REGEX.matchEntire(trimmed) ?: return null
+            val components = (1..4).map { match.groupValues[it].toIntOrNull() }
+            return ReleaseTagVersion(
+                major = components[0] ?: return null,
+                minor = components[1] ?: return null,
+                patch = components[2] ?: 0,
+                fourth = components[3] ?: 0,
+                componentCount = components.count { it != null },
+                raw = trimmed,
+            )
+        }
+    }
+}
+
+/**
+ * Which tier of PebbleOS releases to offer. Background (verified 2026-07-31):
+ * Core's CI deploys every tag only to the internal Memfault cohort; the
+ * public rollout is a manually promoted main-line release that lags the
+ * newest tag by roughly 2 to 7 days, and some tags are never promoted.
+ */
+enum class FirmwareUpdateChannel {
+    /**
+     * Approximate the public rollout: newest main-line minor whose first
+     * release has soaked at least [SOAK_WINDOW], but the highest patch within
+     * that minor immediately (a fresh hotfix stabilizes the promoted build,
+     * so delaying it would keep users on the build it fixes).
+     */
+    Soaked,
+
+    /** Newest main-line tag: the tier Core's internal testers run. */
+    Early,
+}
+
+/** One GitHub release reduced to what selection needs. */
+data class SelectableRelease(
+    val version: ReleaseTagVersion,
+    val publishedAt: Instant,
+    /** Whether this release publishes a normal-firmware asset for the target hardware. */
+    val hasAsset: Boolean,
+)
+
+/**
+ * Picks the release to offer for one watch, or null when nothing qualifies
+ * (callers surface that as a failed check, never as a silent fallback).
+ *
+ * Never trust GitHub's "latest" badge or publish dates for ordering: the
+ * release workflow sets no make_latest, so the badge just tracks the most
+ * recently published tag of either line, and a factory tag would capture it.
+ * Selection is structural instead: factory-line tags are dropped, and
+ * main-line candidates are ordered by parsed version.
+ *
+ * Hardware ramp: a new board revision only gains assets from some release
+ * onward, so when the policy's pick predates the hardware, walk forward to
+ * the nearest newer release that has the asset rather than offering nothing.
+ */
+fun selectRelease(
+    releases: List<SelectableRelease>,
+    channel: FirmwareUpdateChannel,
+    now: Instant,
+    soak: Duration = SOAK_WINDOW,
+): SelectableRelease? {
+    val mainLine = releases.filter { !it.version.isFactoryLine }
+    return when (channel) {
+        FirmwareUpdateChannel.Early -> mainLine.filter { it.hasAsset }.maxByOrNull { it.version }
+        FirmwareUpdateChannel.Soaked -> {
+            val byMinor = mainLine.groupBy { it.version.major to it.version.minor }
+            val soakedMinors = byMinor.filterValues { minor ->
+                minor.minOf { it.publishedAt } + soak <= now
+            }
+            val target = soakedMinors.values.flatten().maxByOrNull { it.version } ?: return null
+            if (target.hasAsset) {
+                target
+            } else {
+                mainLine
+                    .filter { it.hasAsset && it.version > target.version }
+                    .minByOrNull { it.version }
+            }
+        }
+    }
+}
+
+/**
+ * How long a minor must have been public before the Soaked channel offers it.
+ * Chosen from the observed public-changelog promotion lag of 2 to 7 days;
+ * a documented constant so it can be tuned deliberately, not incidentally.
+ */
+val SOAK_WINDOW: Duration = 7.days

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheck.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheck.kt
@@ -19,9 +19,16 @@ class FirmwareUpdateCheck(
     private val cohorts: Cohorts,
     // Fork: GitHub-releases checker for Core watches; see doCheck.
     private val githubReleases: GithubReleases,
+    // Fork: user-configurable channel for the GitHub checker, re-read on
+    // every check, exactly once per check; see checkForUpdates.
+    private val channel: () -> FirmwareUpdateChannel,
     private val clock: Clock = Clock.System,
 ) {
     private val logger = Logger.withTag("FirmwareUpdateCheck")
+
+    // Fork: which source serves this watch. Computed once per check so the
+    // cache key can mirror the routing exactly instead of re-deriving it.
+    private enum class Route { UnknownPlatform, Memfault, GithubReleases, Cohorts }
 
     private data class CacheKey(
         val platform: WatchHardwarePlatform,
@@ -31,8 +38,8 @@ class FirmwareUpdateCheck(
         // Fork: the channel changes what the GitHub checker returns, so it
         // must key the cache, or a channel toggle would keep serving the
         // other channel's cached result until the TTL expires. Null for
-        // non-Core watches: cohorts ignores the channel, so a toggle flip
-        // must not evict their cached result.
+        // every other route: their results ignore the channel, so a toggle
+        // flip must not fragment or evict their cached entries.
         val channel: FirmwareUpdateChannel?,
     )
 
@@ -45,12 +52,18 @@ class FirmwareUpdateCheck(
     private val cache = mutableMapOf<CacheKey, CacheEntry>()
 
     suspend fun checkForUpdates(watch: WatchInfo, force: Boolean): FirmwareUpdateCheckResult {
+        val route = routeFor(watch)
+        // One read serves both the cache key and the release selection: a
+        // toggle flip while a check is in flight must not cache one
+        // channel's selection under the other channel's key.
+        val channelForCheck =
+            if (route == Route.GithubReleases) channel() else null
         val key = CacheKey(
             platform = watch.platform,
             serial = watch.serial,
             fwVersion = watch.runningFwVersion.stringVersion,
             isRecovery = watch.runningFwVersion.isRecovery,
-            channel = if (watch.platform.isCoreDevice()) githubReleases.currentChannel() else null,
+            channel = channelForCheck,
         )
         val now = clock.now()
         if (!force) {
@@ -61,9 +74,9 @@ class FirmwareUpdateCheck(
                 }
             }
         }
-        val result = doCheck(watch)
-        // Only cache definitive answers — transient failures (network, rate limit)
-        // must retry on the next connect, not be locked in for the TTL.
+        val result = doCheck(watch, route, channelForCheck)
+        // Only cache definitive answers: transient failures (network, rate
+        // limit) must retry on the next connect, not be locked in for the TTL.
         if (result !is FirmwareUpdateCheckResult.UpdateCheckFailed) {
             mutex.withLock {
                 cache[key] = CacheEntry(result, now + CACHE_TTL)
@@ -72,15 +85,27 @@ class FirmwareUpdateCheck(
         return result
     }
 
-    private suspend fun doCheck(watch: WatchInfo): FirmwareUpdateCheckResult = when {
-        watch.platform == UNKNOWN -> FirmwareUpdateCheckResult.UpdateCheckFailed("Unknown platform")
-        watch.platform.isCoreDevice() && CommonBuildKonfig.MEMFAULT_TOKEN != null -> memfault.getLatestFirmware(watch)
+    private fun routeFor(watch: WatchInfo): Route = when {
+        watch.platform == UNKNOWN -> Route.UnknownPlatform
+        watch.platform.isCoreDevice() && CommonBuildKonfig.MEMFAULT_TOKEN != null -> Route.Memfault
         // Fork: fork builds ship no Memfault token and cohorts rejects every
         // Core hardware revision, so Core watches check the public PebbleOS
         // GitHub releases instead. Legacy watches keep cohorts, which serves
         // them fine.
-        watch.platform.isCoreDevice() -> githubReleases.getLatestFirmware(watch)
-        else -> cohorts.getLatestFirmware(watch)
+        watch.platform.isCoreDevice() -> Route.GithubReleases
+        else -> Route.Cohorts
+    }
+
+    private suspend fun doCheck(
+        watch: WatchInfo,
+        route: Route,
+        channelForCheck: FirmwareUpdateChannel?,
+    ): FirmwareUpdateCheckResult = when (route) {
+        Route.UnknownPlatform -> FirmwareUpdateCheckResult.UpdateCheckFailed("Unknown platform")
+        Route.Memfault -> memfault.getLatestFirmware(watch)
+        Route.GithubReleases ->
+            githubReleases.getLatestFirmware(watch, checkNotNull(channelForCheck))
+        Route.Cohorts -> cohorts.getLatestFirmware(watch)
     }
 
     companion object {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheck.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheck.kt
@@ -28,6 +28,12 @@ class FirmwareUpdateCheck(
         val serial: String,
         val fwVersion: String,
         val isRecovery: Boolean,
+        // Fork: the channel changes what the GitHub checker returns, so it
+        // must key the cache, or a channel toggle would keep serving the
+        // other channel's cached result until the TTL expires. Null for
+        // non-Core watches: cohorts ignores the channel, so a toggle flip
+        // must not evict their cached result.
+        val channel: FirmwareUpdateChannel?,
     )
 
     private data class CacheEntry(
@@ -44,6 +50,7 @@ class FirmwareUpdateCheck(
             serial = watch.serial,
             fwVersion = watch.runningFwVersion.stringVersion,
             isRecovery = watch.runningFwVersion.isRecovery,
+            channel = if (watch.platform.isCoreDevice()) githubReleases.currentChannel() else null,
         )
         val now = clock.now()
         if (!force) {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheck.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheck.kt
@@ -17,6 +17,8 @@ import kotlin.time.Instant
 class FirmwareUpdateCheck(
     private val memfault: Memfault,
     private val cohorts: Cohorts,
+    // Fork: GitHub-releases checker for Core watches; see doCheck.
+    private val githubReleases: GithubReleases,
     private val clock: Clock = Clock.System,
 ) {
     private val logger = Logger.withTag("FirmwareUpdateCheck")
@@ -66,6 +68,11 @@ class FirmwareUpdateCheck(
     private suspend fun doCheck(watch: WatchInfo): FirmwareUpdateCheckResult = when {
         watch.platform == UNKNOWN -> FirmwareUpdateCheckResult.UpdateCheckFailed("Unknown platform")
         watch.platform.isCoreDevice() && CommonBuildKonfig.MEMFAULT_TOKEN != null -> memfault.getLatestFirmware(watch)
+        // Fork: fork builds ship no Memfault token and cohorts rejects every
+        // Core hardware revision, so Core watches check the public PebbleOS
+        // GitHub releases instead. Legacy watches keep cohorts, which serves
+        // them fine.
+        watch.platform.isCoreDevice() -> githubReleases.getLatestFirmware(watch)
         else -> cohorts.getLatestFirmware(watch)
     }
 

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareUpdateUiTracker.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/FirmwareUpdateUiTracker.kt
@@ -9,6 +9,7 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
 
 import coredevices.util.CoreConfigFlow
+import io.rebble.libpebblecommon.connection.CommonConnectedDevice
 import io.rebble.libpebblecommon.connection.ConnectedPebble
 import io.rebble.libpebblecommon.connection.LibPebble
 import kotlin.time.Duration.Companion.seconds
@@ -26,6 +27,8 @@ class RealFirmwareUpdateUiTracker(
     private val clock: Clock,
     private val appContext: AppContext,
     private val coreConfigFlow: CoreConfigFlow,
+    // Fork: notification-triggered installs go through the verified installer.
+    private val installer: VerifiedFirmwareInstaller,
 ) : FirmwareUpdateUiTracker {
     private val logger = Logger.withTag("FirmwareUpdateUiTracker")
     private var lastUiUpdateMs: Long = settings.getLong(KEY_LAST_UI_UPDATE_CHECK_MS, 0)
@@ -94,13 +97,15 @@ class RealFirmwareUpdateUiTracker(
             logger.w { "No update available for $watch" }
             return
         }
-        val updater = watch as? ConnectedPebble.Firmware
-        if (updater == null) {
+        // Fork: verified install path (sha256 + manifest checks) instead of
+        // upstream's unverified download.
+        val device = watch as? CommonConnectedDevice
+        if (device == null) {
             logger.w { "Can't update firmware for $watch" }
             return
         }
         logger.d { "Starting update for $identifier to $update" }
-        updater.updateFirmware(update)
+        installer.install(device, update)
     }
 
     companion object {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/GithubReleases.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/GithubReleases.kt
@@ -67,26 +67,31 @@ class GithubReleases(
             logger.w { "No selectable PebbleOS release for '$revision' among ${releases.size} releases" }
             return FirmwareUpdateCheckResult.UpdateCheckFailed(GENERIC_FAILURE)
         }
-        val chosen = candidates.first { it.selectable === selected }
+        // Structural match: distinct releases cannot produce equal
+        // selectables (tags are unique per release), and equality still
+        // holds if selection ever returns a copy instead of the same
+        // instance.
+        val chosen = candidates.first { it.selectable == selected }
         // Strictly newer only: equality must never re-offer (see
         // ReleaseTagVersion), and a channel switch back from Early must never
         // offer a downgrade.
         if (!watch.runningFwVersion.isRecovery && running != null && chosen.selectable.version <= running) {
             return FirmwareUpdateCheckResult.FoundNoUpdate
         }
+        val chosenTag = chosen.selectable.version.raw
         val displayVersion = FirmwareVersion.from(
-            tag = chosen.tagName,
+            tag = chosenTag,
             isRecovery = false,
             gitHash = "",
             // Display payload only. The offer decision above compares tags;
             // feeding publishedAt into a FirmwareVersion comparison would
             // re-offer equal versions on its timestamp tiebreak.
-            timestamp = chosen.publishedAt,
+            timestamp = chosen.selectable.publishedAt,
             isDualSlot = false, // not used from here
             isSlot0 = false, // not used from here
         )
         if (displayVersion == null) {
-            logger.e { "Couldn't build display version from '${chosen.tagName}'" }
+            logger.e { "Couldn't build display version from '$chosenTag'" }
             return FirmwareUpdateCheckResult.UpdateCheckFailed(GENERIC_FAILURE)
         }
         expectations.record(
@@ -94,7 +99,7 @@ class GithubReleases(
             ExpectedFirmwareArtifact(
                 sha256Hex = checkNotNull(chosen.digestHex),
                 sizeBytes = checkNotNull(chosen.assetSize),
-                versionTag = chosen.tagName,
+                versionTag = chosenTag,
             ),
         )
         return FirmwareUpdateCheckResult.FoundUpdate(
@@ -159,18 +164,17 @@ class GithubReleases(
         val usable = asset != null && digestHex != null && asset.size > 0
         return Candidate(
             selectable = SelectableRelease(version, published, hasAsset = usable),
-            tagName = tagName,
-            publishedAt = published,
             assetUrl = asset?.browserDownloadUrl,
             assetSize = asset?.size,
             digestHex = digestHex,
         )
     }
 
+    // Only carries what selection cannot: the asset coordinates. The tag and
+    // publish date live in the selectable (version.raw is the trimmed tag),
+    // so there is a single source of truth per release.
     private data class Candidate(
         val selectable: SelectableRelease,
-        val tagName: String,
-        val publishedAt: Instant,
         val assetUrl: String?,
         val assetSize: Long?,
         val digestHex: String?,

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/GithubReleases.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/GithubReleases.kt
@@ -35,17 +35,18 @@ import kotlin.time.Instant
 class GithubReleases(
     private val httpClient: HttpClient,
     private val expectations: FirmwareArtifactExpectations,
-    // Provider, not a value: the channel is user-configurable and must be
-    // re-read on every check.
-    private val channel: () -> FirmwareUpdateChannel,
     private val clock: Clock,
 ) {
     private val logger = Logger.withTag("GithubReleases")
 
-    /** Current channel value, exposed so the check cache can key on it. */
-    fun currentChannel(): FirmwareUpdateChannel = channel()
-
-    suspend fun getLatestFirmware(watch: WatchInfo): FirmwareUpdateCheckResult {
+    // The channel is a parameter, not a constructor dependency, so one check
+    // uses one channel value throughout: the caller keys its result cache on
+    // the same value it passes here, and a mid-check toggle flip cannot make
+    // the selection disagree with the cache key.
+    suspend fun getLatestFirmware(
+        watch: WatchInfo,
+        channel: FirmwareUpdateChannel,
+    ): FirmwareUpdateCheckResult {
         val runningRaw = watch.runningFwVersion.stringVersion
         val running = ReleaseTagVersion.from(runningRaw)
         if (running == null && !watch.runningFwVersion.isRecovery) {
@@ -61,7 +62,7 @@ class GithubReleases(
         }
         val revision = watch.platform.revision
         val candidates = releases.mapNotNull { it.toCandidate(revision) }
-        val selected = selectRelease(candidates.map { it.selectable }, channel(), clock.now())
+        val selected = selectRelease(candidates.map { it.selectable }, channel, clock.now())
         if (selected == null) {
             logger.w { "No selectable PebbleOS release for '$revision' among ${releases.size} releases" }
             return FirmwareUpdateCheckResult.UpdateCheckFailed(GENERIC_FAILURE)

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/GithubReleases.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/GithubReleases.kt
@@ -1,0 +1,205 @@
+package coredevices.pebble.firmware
+
+import co.touchlab.kermit.Logger
+import io.ktor.client.HttpClient
+import io.ktor.client.call.NoTransformationFoundException
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
+import io.ktor.serialization.ContentConvertException
+import io.rebble.libpebblecommon.connection.FirmwareUpdateCheckResult
+import io.rebble.libpebblecommon.services.FirmwareVersion
+import io.rebble.libpebblecommon.services.WatchInfo
+import kotlinx.io.IOException
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+/**
+ * Update checker for Core watches backed by the public PebbleOS GitHub
+ * releases (fork builds ship no Memfault token, and cohorts rejects every
+ * Core hardware revision, so upstream has no working source for these
+ * watches here).
+ *
+ * Privacy: the request names no hardware, serial, or version; the asset is
+ * chosen client-side from the release list. Verification: the API declares a
+ * sha256 digest and exact size per asset, which are recorded in
+ * [FirmwareArtifactExpectations] for the installer to enforce; a release
+ * whose asset lacks a usable digest is treated as having no asset at all.
+ * Selection and comparison rules live in FirmwareReleaseSelection.kt.
+ */
+class GithubReleases(
+    private val httpClient: HttpClient,
+    private val expectations: FirmwareArtifactExpectations,
+    // Provider, not a value: the channel is user-configurable and must be
+    // re-read on every check.
+    private val channel: () -> FirmwareUpdateChannel,
+    private val clock: Clock,
+) {
+    private val logger = Logger.withTag("GithubReleases")
+
+    suspend fun getLatestFirmware(watch: WatchInfo): FirmwareUpdateCheckResult {
+        val runningRaw = watch.runningFwVersion.stringVersion
+        val running = ReleaseTagVersion.from(runningRaw)
+        if (running == null && !watch.runningFwVersion.isRecovery) {
+            // Fail closed: with an incomparable running version any offer
+            // could be a downgrade or a same-version loop. Recovery is exempt
+            // because it always gets an offer regardless of comparison.
+            logger.e { "Cannot parse running firmware version '$runningRaw'" }
+            return FirmwareUpdateCheckResult.UpdateCheckFailed(GENERIC_FAILURE)
+        }
+        val releases = when (val fetched = fetchReleases()) {
+            is Fetched.Failure -> return FirmwareUpdateCheckResult.UpdateCheckFailed(fetched.message)
+            is Fetched.Success -> fetched.releases
+        }
+        val revision = watch.platform.revision
+        val candidates = releases.mapNotNull { it.toCandidate(revision) }
+        val selected = selectRelease(candidates.map { it.selectable }, channel(), clock.now())
+        if (selected == null) {
+            logger.w { "No selectable PebbleOS release for '$revision' among ${releases.size} releases" }
+            return FirmwareUpdateCheckResult.UpdateCheckFailed(GENERIC_FAILURE)
+        }
+        val chosen = candidates.first { it.selectable === selected }
+        // Strictly newer only: equality must never re-offer (see
+        // ReleaseTagVersion), and a channel switch back from Early must never
+        // offer a downgrade.
+        if (!watch.runningFwVersion.isRecovery && running != null && chosen.selectable.version <= running) {
+            return FirmwareUpdateCheckResult.FoundNoUpdate
+        }
+        val displayVersion = FirmwareVersion.from(
+            tag = chosen.tagName,
+            isRecovery = false,
+            gitHash = "",
+            // Display payload only. The offer decision above compares tags;
+            // feeding publishedAt into a FirmwareVersion comparison would
+            // re-offer equal versions on its timestamp tiebreak.
+            timestamp = chosen.publishedAt,
+            isDualSlot = false, // not used from here
+            isSlot0 = false, // not used from here
+        )
+        if (displayVersion == null) {
+            logger.e { "Couldn't build display version from '${chosen.tagName}'" }
+            return FirmwareUpdateCheckResult.UpdateCheckFailed(GENERIC_FAILURE)
+        }
+        expectations.record(
+            checkNotNull(chosen.assetUrl),
+            ExpectedFirmwareArtifact(
+                sha256Hex = checkNotNull(chosen.digestHex),
+                sizeBytes = checkNotNull(chosen.assetSize),
+                versionTag = chosen.tagName,
+            ),
+        )
+        return FirmwareUpdateCheckResult.FoundUpdate(
+            version = displayVersion,
+            url = checkNotNull(chosen.assetUrl),
+            // Release bodies are empty upstream; the dialog and notification
+            // already carry the version string.
+            notes = "",
+        )
+    }
+
+    private sealed class Fetched {
+        data class Success(val releases: List<GithubReleaseDto>) : Fetched()
+        data class Failure(val message: String) : Fetched()
+    }
+
+    private suspend fun fetchReleases(): Fetched {
+        val response = try {
+            httpClient.get(RELEASES_URL) {
+                parameter("per_page", PAGE_SIZE)
+                header("Accept", "application/vnd.github+json")
+                header("X-GitHub-Api-Version", GITHUB_API_VERSION)
+            }
+        } catch (e: IOException) {
+            logger.w(e) { "Network error fetching PebbleOS releases" }
+            return Fetched.Failure(GENERIC_FAILURE)
+        }
+        if (response.status == HttpStatusCode.Forbidden || response.status == HttpStatusCode.TooManyRequests) {
+            // Unauthenticated GitHub quota is per-IP and the in-app check
+            // cache keeps normal usage far below it, so this is transient.
+            logger.w { "PebbleOS release fetch rate limited: ${response.status}" }
+            return Fetched.Failure(RATE_LIMITED_FAILURE)
+        }
+        if (!response.status.isSuccess()) {
+            logger.w { "PebbleOS release fetch failed: ${response.status}" }
+            return Fetched.Failure(GENERIC_FAILURE)
+        }
+        return try {
+            Fetched.Success(response.body<List<GithubReleaseDto>>())
+        } catch (e: NoTransformationFoundException) {
+            logger.w(e) { "Unexpected content fetching PebbleOS releases" }
+            Fetched.Failure(GENERIC_FAILURE)
+        } catch (e: ContentConvertException) {
+            logger.w(e) { "Malformed PebbleOS release list" }
+            Fetched.Failure(GENERIC_FAILURE)
+        }
+    }
+
+    private fun GithubReleaseDto.toCandidate(revision: String): Candidate? {
+        if (draft || prerelease) return null
+        val version = ReleaseTagVersion.from(tagName)
+        if (version == null) {
+            logger.w { "Skipping unparseable release tag '$tagName'" }
+            return null
+        }
+        val published = publishedAt?.let { raw -> runCatching { Instant.parse(raw) }.getOrNull() }
+            ?: return null
+        val asset = assets.firstOrNull { it.name == "normal_${revision}_${tagName}.pbz" }
+        val digestHex = normalizeSha256Hex(asset?.digest)
+        // An asset the fork cannot verify is treated as absent, so selection
+        // walks to a release it can verify instead of offering this one.
+        val usable = asset != null && digestHex != null && asset.size > 0
+        return Candidate(
+            selectable = SelectableRelease(version, published, hasAsset = usable),
+            tagName = tagName,
+            publishedAt = published,
+            assetUrl = asset?.browserDownloadUrl,
+            assetSize = asset?.size,
+            digestHex = digestHex,
+        )
+    }
+
+    private data class Candidate(
+        val selectable: SelectableRelease,
+        val tagName: String,
+        val publishedAt: Instant,
+        val assetUrl: String?,
+        val assetSize: Long?,
+        val digestHex: String?,
+    )
+
+    companion object {
+        private const val RELEASES_URL = "https://api.github.com/repos/coredevices/PebbleOS/releases"
+
+        // ~20 releases spans several weeks of both tag lines: enough history
+        // for the soak policy and for the asset walk-forward on new hardware.
+        private const val PAGE_SIZE = 20
+        private const val GITHUB_API_VERSION = "2022-11-28"
+        private const val GENERIC_FAILURE = "Failed to check for PebbleOS update"
+        private const val RATE_LIMITED_FAILURE = "PebbleOS update check is rate limited, try again later"
+    }
+}
+
+@Serializable
+data class GithubReleaseDto(
+    @SerialName("tag_name")
+    val tagName: String,
+    val draft: Boolean = false,
+    val prerelease: Boolean = false,
+    @SerialName("published_at")
+    val publishedAt: String? = null,
+    val assets: List<GithubReleaseAssetDto> = emptyList(),
+)
+
+@Serializable
+data class GithubReleaseAssetDto(
+    val name: String,
+    @SerialName("browser_download_url")
+    val browserDownloadUrl: String,
+    val digest: String? = null,
+    val size: Long = 0,
+)

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/GithubReleases.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/GithubReleases.kt
@@ -42,6 +42,9 @@ class GithubReleases(
 ) {
     private val logger = Logger.withTag("GithubReleases")
 
+    /** Current channel value, exposed so the check cache can key on it. */
+    fun currentChannel(): FirmwareUpdateChannel = channel()
+
     suspend fun getLatestFirmware(watch: WatchInfo): FirmwareUpdateCheckResult {
         val runningRaw = watch.runningFwVersion.stringVersion
         val running = ReleaseTagVersion.from(runningRaw)

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/VerifiedFirmwareInstaller.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/VerifiedFirmwareInstaller.kt
@@ -274,6 +274,10 @@ class VerifiedFirmwareInstaller(
         platform: WatchHardwarePlatform,
     ) {
         val manifests = PbzFirmware(path).manifests
+        // libpebble3's manifest parsing throws on a manifest-less archive
+        // today (that lands in the generic catch as "could not verify
+        // firmware archive"), and never returns an empty list; this guard is
+        // an independent backstop in case that contract ever changes.
         if (manifests.isEmpty()) {
             throw InstallFailure("firmware archive contains no manifest")
         }

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/VerifiedFirmwareInstaller.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/VerifiedFirmwareInstaller.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -109,7 +110,10 @@ class VerifiedFirmwareInstaller(
 ) {
     private val logger = Logger.withTag("VerifiedFirmwareInstaller")
     private val stateMutex = Mutex()
-    private val states = mutableMapOf<String, MutableStateFlow<ForkFirmwareInstallState>>()
+    // Immutable map behind a StateFlow so stateFlowFor can be lock-free and
+    // callable from non-suspend contexts (Compose); see that function.
+    private val states =
+        MutableStateFlow(mapOf<String, MutableStateFlow<ForkFirmwareInstallState>>())
     private val activeInstalls = mutableSetOf<String>()
     private var nextFileId = 0
     private var sweptStaleFiles = false
@@ -124,7 +128,6 @@ class VerifiedFirmwareInstaller(
         val target = InstallTarget(
             identifierKey = device.identifier.asString,
             platform = device.watchInfo.platform,
-            currentUpdateState = { device.firmwareUpdateState },
             sideload = device::sideloadFirmware,
         )
         scope.launch { runInstall(target, update) }
@@ -134,7 +137,6 @@ class VerifiedFirmwareInstaller(
     internal data class InstallTarget(
         val identifierKey: String,
         val platform: WatchHardwarePlatform,
-        val currentUpdateState: () -> FirmwareUpdateStatus,
         val sideload: (Path) -> Unit,
     )
 
@@ -161,24 +163,40 @@ class VerifiedFirmwareInstaller(
             if (!update.url.startsWith("https://")) {
                 throw InstallFailure("refusing non-https download")
             }
-            if (target.currentUpdateState() !is FirmwareUpdateStatus.NotInProgress) {
-                throw InstallFailure("an install is already in progress")
+            val updateStates = watchUpdateStates(target.identifierKey)
+            // Gate on the live upstream state, not a snapshot captured when
+            // the device object was created: a snapshot could miss an update
+            // that started since.
+            when (updateStates.first()) {
+                null -> throw InstallFailure("watch is not connected")
+                is FirmwareUpdateStatus.NotInProgress -> Unit
+                else -> throw InstallFailure("an install is already in progress")
             }
-            path = newDownloadPath(target.identifierKey)
-            val actualSha256 = downloadTo(path, update.url, expected) { progress ->
+            val downloaded = newDownloadPath(target.identifierKey)
+            path = downloaded
+            val actualSha256 = downloadTo(downloaded, update.url, expected) { progress ->
                 state.value = ForkFirmwareInstallState.Downloading(progress)
             }
             state.value = ForkFirmwareInstallState.Verifying
             if (actualSha256 != expected.sha256Hex) {
                 throw InstallFailure("checksum mismatch")
             }
-            verifyPbz(path, expected, target.platform)
+            verifyPbz(downloaded, expected, target.platform)
             state.value = ForkFirmwareInstallState.HandedOff
-            target.sideload(path)
-            awaitHandoffOutcome(target, state)
-            // Terminal either way by now (transfer ended, upstream error
-            // shown, or watch gone): the temp file is no longer needed.
-            deleteQuietly(path)
+            // Captured before sideload so the outcome watcher can tell a
+            // state this attempt caused from one left over before it.
+            val preHandoffState = updateStates.first()
+            target.sideload(downloaded)
+            when (awaitHandoffOutcome(updateStates, preHandoffState, state)) {
+                // Transfer ended, upstream error shown, or watch gone: the
+                // temp file is no longer needed.
+                HandoffOutcome.FileReleased -> deleteQuietly(downloaded)
+                // Still transferring when the wait gave up: the file must
+                // outlive the transfer (PutBytes lazily re-reads the zip),
+                // so leave it; the stale sweep reclaims it next process.
+                HandoffOutcome.TransferStillRunning ->
+                    logger.w { "Transfer still running after $TRANSFER_TIMEOUT; leaving ${downloaded.name} to it" }
+            }
         } catch (e: CancellationException) {
             path?.let { deleteQuietly(it) }
             state.value = ForkFirmwareInstallState.Idle
@@ -322,35 +340,51 @@ class VerifiedFirmwareInstaller(
         }
     }
 
+    /** Whether the handoff released the temp file or still needs it. */
+    private enum class HandoffOutcome { FileReleased, TransferStillRunning }
+
     /**
      * The sideload entry point rejects silently when another update holds
      * its mutex and reports parse failures through the upstream state flow,
      * so observe that flow: fail if nothing starts, and once the transfer is
      * running let the upstream states drive the UI (fork state goes Idle).
      * The temp file must outlive the whole transfer because PutBytes lazily
-     * re-reads the zip while streaming.
+     * re-reads the zip while streaming; only [HandoffOutcome.FileReleased]
+     * means it is safe to delete.
+     *
+     * The flow replays its current value to a new collector, so a terminal
+     * state left over from an earlier attempt (upstream never resets
+     * ErrorStarting until the next sideload gets past its parse) would read
+     * as this attempt's outcome, and the archive would be deleted under the
+     * freshly launched sideload coroutine, failing its parse and re-arming
+     * the same misread for every retry on this connection. Dropping values
+     * equal to [preHandoffState] attributes only genuinely new emissions to
+     * this attempt; if upstream re-enters an identical state (which a
+     * StateFlow cannot re-emit anyway), the start timeout reports "did not
+     * start", which is fail-closed and does not delete the file early.
      */
     private suspend fun awaitHandoffOutcome(
-        target: InstallTarget,
+        updateStates: Flow<FirmwareUpdateStatus?>,
+        preHandoffState: FirmwareUpdateStatus?,
         state: MutableStateFlow<ForkFirmwareInstallState>,
-    ) {
-        val updateStates = watchUpdateStates(target.identifierKey)
+    ): HandoffOutcome {
         val started = withTimeoutOrNull(HANDOFF_START_TIMEOUT) {
-            updateStates.first {
+            updateStates.dropWhile { it == preHandoffState }.first {
                 it is FirmwareUpdateStatus.Active || it is FirmwareUpdateStatus.NotInProgress.ErrorStarting
             }
         }
-        when (started) {
+        return when (started) {
             null -> throw InstallFailure("install did not start")
             is FirmwareUpdateStatus.NotInProgress.ErrorStarting -> {
                 // The upstream error state is already user-visible; going
                 // Idle here avoids rendering the failure twice.
                 logger.w { "libpebble3 rejected the sideload: ${started.error}" }
                 state.value = ForkFirmwareInstallState.Idle
+                HandoffOutcome.FileReleased
             }
             else -> {
                 state.value = ForkFirmwareInstallState.Idle
-                withTimeoutOrNull(TRANSFER_TIMEOUT) {
+                val terminal = withTimeoutOrNull(TRANSFER_TIMEOUT) {
                     updateStates.first {
                         // null: the watch vanished from the device list
                         // (disconnect or post-update reboot).
@@ -359,16 +393,31 @@ class VerifiedFirmwareInstaller(
                             it is FirmwareUpdateStatus.WaitingForReboot
                     }
                 }
+                if (terminal == null) {
+                    HandoffOutcome.TransferStillRunning
+                } else {
+                    HandoffOutcome.FileReleased
+                }
             }
         }
     }
 
-    private fun stateFlowFor(identifierKey: String): MutableStateFlow<ForkFirmwareInstallState> {
-        // Plain synchronized access is not available in common code; the map
-        // is only touched from install paths and Compose reads, both of
-        // which tolerate a racy first-creation (worst case an extra flow
-        // instance is briefly created and dropped).
-        return states.getOrPut(identifierKey) { MutableStateFlow(ForkFirmwareInstallState.Idle) }
+    internal fun stateFlowFor(identifierKey: String): MutableStateFlow<ForkFirmwareInstallState> {
+        // First access races between install coroutines (Dispatchers.Default)
+        // and Compose reads on the main thread, and both sides must end up
+        // holding the SAME instance: runInstall captures its flow once for
+        // the whole install, so losing a getOrPut race would leave the UI
+        // collecting a flow nobody writes to (no progress, no failure
+        // rendering). A compare-and-set loop over an immutable map gives an
+        // atomic get-or-create without needing a lock in common code.
+        while (true) {
+            val current = states.value
+            current[identifierKey]?.let { return it }
+            val created = MutableStateFlow<ForkFirmwareInstallState>(ForkFirmwareInstallState.Idle)
+            if (states.compareAndSet(current, current + (identifierKey to created))) {
+                return created
+            }
+        }
     }
 
     private suspend fun newDownloadPath(identifierKey: String): Path {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/VerifiedFirmwareInstaller.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/firmware/VerifiedFirmwareInstaller.kt
@@ -1,0 +1,434 @@
+package coredevices.pebble.firmware
+
+import co.touchlab.kermit.Logger
+import io.ktor.client.HttpClient
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.contentLength
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.readAvailable
+import io.rebble.libpebblecommon.connection.CommonConnectedDevice
+import io.rebble.libpebblecommon.connection.FirmwareUpdateCheckResult
+import io.rebble.libpebblecommon.connection.PebbleIdentifier
+import io.rebble.libpebblecommon.connection.endpointmanager.FirmwareUpdater.FirmwareUpdateStatus
+import io.rebble.libpebblecommon.disk.pbz.PbzFirmware
+import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
+import io.rebble.libpebblecommon.metadata.pbz.manifest.PbzManifestWrapper
+import io.rebble.libpebblecommon.util.Crc32Calculator
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.io.IOException
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readAtMostTo
+import okio.Buffer
+import okio.HashingSink
+import okio.blackholeSink
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Install-time progress of the fork's verified install pipeline. Only the
+ * fork phases live here; once the file is handed to libpebble3 the upstream
+ * FirmwareUpdateStatus drives the UI and this returns to Idle.
+ */
+sealed class ForkFirmwareInstallState {
+    data object Idle : ForkFirmwareInstallState()
+    data class Downloading(val progress: Float?) : ForkFirmwareInstallState()
+    data object Verifying : ForkFirmwareInstallState()
+    data object HandedOff : ForkFirmwareInstallState()
+    data class Failed(val reason: String) : ForkFirmwareInstallState()
+
+    val isActive: Boolean
+        get() = this is Downloading || this is Verifying || this is HandedOff
+
+    /** User-facing description, or null when there is nothing to show. */
+    fun describe(): String? = when (this) {
+        is Idle -> null
+        is Downloading -> when {
+            progress != null -> "Downloading PebbleOS update (${(progress * 100).toInt()}%)"
+            else -> "Downloading PebbleOS update"
+        }
+        is Verifying -> "Verifying PebbleOS update"
+        is HandedOff -> "Starting PebbleOS install"
+        is Failed -> "PebbleOS install failed: $reason"
+    }
+}
+
+/**
+ * Downloads a firmware update itself, verifies it, and only then hands the
+ * file to libpebble3's sideload entry point, which re-runs its own safety
+ * checks and drives the transfer.
+ *
+ * Exists because the upstream install path (FirmwareDownloader inside
+ * libpebble3's isolated Koin graph) performs no integrity checking at all:
+ * no hash, no size, a shared fixed filename, and a 30 second timeout for the
+ * whole download. There is no seam to fix that from the app side, so the
+ * fork replaces the download step and enters libpebble3 through
+ * sideloadFirmware(path) instead, keeping every upstream check intact.
+ *
+ * Verification, all fail closed (no expectation recorded, or any mismatch,
+ * refuses the install and deletes the file):
+ *  1. sha256(downloaded bytes) and exact size against what the update source
+ *     declared at check time ([FirmwareArtifactExpectations]). Defends the
+ *     download transport and CDN, not a compromised source account.
+ *  2. Every manifest in the PBZ: hardware revision matches this watch,
+ *     firmware type is "normal", version tag matches the release the checker
+ *     selected (skipped when a manifest carries no tag).
+ *  3. Pebble-CRC32 and size of the firmware and resources streams inside the
+ *     zip against the manifest's own values. Upstream streams these to the
+ *     watch without ever comparing them (its transfer CRC is computed over
+ *     whatever bytes it reads), so a source-corrupt archive would otherwise
+ *     install garbage.
+ * The verified file stays in app-private storage between verification and
+ * transfer; anything able to rewrite it there already controls the app.
+ *
+ * The install itself then runs exactly as upstream sideloads do, including
+ * performSafetyChecks, dual-slot manifest selection, and progress states.
+ */
+class VerifiedFirmwareInstaller(
+    private val httpClient: HttpClient,
+    private val expectations: FirmwareArtifactExpectations,
+    // Both seams are injected narrowly so tests can fake them without
+    // constructing platform contexts or a full LibPebble.
+    private val downloadDirectory: () -> Path,
+    private val watchUpdateStates: (identifierKey: String) -> Flow<FirmwareUpdateStatus?>,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) {
+    private val logger = Logger.withTag("VerifiedFirmwareInstaller")
+    private val stateMutex = Mutex()
+    private val states = mutableMapOf<String, MutableStateFlow<ForkFirmwareInstallState>>()
+    private val activeInstalls = mutableSetOf<String>()
+    private var nextFileId = 0
+    private var sweptStaleFiles = false
+
+    fun stateFor(identifier: PebbleIdentifier): StateFlow<ForkFirmwareInstallState> =
+        stateFlowFor(identifier.asString).asStateFlow()
+
+    internal fun stateValueFor(identifierKey: String): ForkFirmwareInstallState =
+        stateFlowFor(identifierKey).value
+
+    fun install(device: CommonConnectedDevice, update: FirmwareUpdateCheckResult.FoundUpdate) {
+        val target = InstallTarget(
+            identifierKey = device.identifier.asString,
+            platform = device.watchInfo.platform,
+            currentUpdateState = { device.firmwareUpdateState },
+            sideload = device::sideloadFirmware,
+        )
+        scope.launch { runInstall(target, update) }
+    }
+
+    /** Narrow view of a watch, so tests can drive the pipeline directly. */
+    internal data class InstallTarget(
+        val identifierKey: String,
+        val platform: WatchHardwarePlatform,
+        val currentUpdateState: () -> FirmwareUpdateStatus,
+        val sideload: (Path) -> Unit,
+    )
+
+    internal suspend fun runInstall(
+        target: InstallTarget,
+        update: FirmwareUpdateCheckResult.FoundUpdate,
+    ) {
+        val state = stateFlowFor(target.identifierKey)
+        stateMutex.withLock {
+            if (target.identifierKey in activeInstalls) {
+                logger.w { "Install already running for ${target.identifierKey}" }
+                return
+            }
+            activeInstalls += target.identifierKey
+        }
+        var path: Path? = null
+        try {
+            state.value = ForkFirmwareInstallState.Downloading(progress = null)
+            // Fail closed rather than fall back to the unverified upstream
+            // download: expectations share the process lifetime of the
+            // FoundUpdate itself, so a miss here is a bug, not bad luck.
+            val expected = expectations.lookup(update.url)
+                ?: throw InstallFailure("no integrity data recorded for this download")
+            if (!update.url.startsWith("https://")) {
+                throw InstallFailure("refusing non-https download")
+            }
+            if (target.currentUpdateState() !is FirmwareUpdateStatus.NotInProgress) {
+                throw InstallFailure("an install is already in progress")
+            }
+            path = newDownloadPath(target.identifierKey)
+            val actualSha256 = downloadTo(path, update.url, expected) { progress ->
+                state.value = ForkFirmwareInstallState.Downloading(progress)
+            }
+            state.value = ForkFirmwareInstallState.Verifying
+            if (actualSha256 != expected.sha256Hex) {
+                throw InstallFailure("checksum mismatch")
+            }
+            verifyPbz(path, expected, target.platform)
+            state.value = ForkFirmwareInstallState.HandedOff
+            target.sideload(path)
+            awaitHandoffOutcome(target, state)
+            // Terminal either way by now (transfer ended, upstream error
+            // shown, or watch gone): the temp file is no longer needed.
+            deleteQuietly(path)
+        } catch (e: CancellationException) {
+            path?.let { deleteQuietly(it) }
+            state.value = ForkFirmwareInstallState.Idle
+            throw e
+        } catch (e: InstallFailure) {
+            logger.w { "Install failed for ${target.identifierKey}: ${e.reason}" }
+            path?.let { deleteQuietly(it) }
+            state.value = ForkFirmwareInstallState.Failed(e.reason)
+        } catch (e: Exception) {
+            // PbzFirmware/zip parsing throws unspecific exceptions; anything
+            // unexpected still fails closed with the file removed.
+            logger.e(e) { "Install failed for ${target.identifierKey}" }
+            path?.let { deleteQuietly(it) }
+            state.value = ForkFirmwareInstallState.Failed("could not verify firmware archive")
+        } finally {
+            stateMutex.withLock { activeInstalls -= target.identifierKey }
+        }
+    }
+
+    /**
+     * Streams the download to [path] while hashing, enforcing the expected
+     * size as a hard cap, and failing on stalls instead of using upstream's
+     * whole-download timeout (30s does not fit a multi-MB transfer on a slow
+     * link). Returns the lowercase hex sha256 of the written bytes.
+     */
+    private suspend fun downloadTo(
+        path: Path,
+        url: String,
+        expected: ExpectedFirmwareArtifact,
+        onProgress: (Float?) -> Unit,
+    ): String {
+        val sizeCap = expected.sizeBytes ?: MAX_DOWNLOAD_BYTES
+        val hashingSink = HashingSink.sha256(blackholeSink())
+        val hashBuffer = Buffer()
+        var received = 0L
+        try {
+            httpClient.prepareGet(url).execute { response ->
+                if (!response.status.isSuccess()) {
+                    throw InstallFailure("download failed (${response.status.value})")
+                }
+                val total = expected.sizeBytes ?: response.contentLength()
+                val channel = response.bodyAsChannel()
+                SystemFileSystem.sink(path).buffered().use { fileSink ->
+                    val buffer = ByteArray(DOWNLOAD_CHUNK_BYTES)
+                    while (true) {
+                        val read = withTimeoutOrNull(READ_STALL_TIMEOUT) {
+                            channel.readAvailable(buffer, 0, buffer.size)
+                        } ?: throw InstallFailure("download stalled")
+                        if (read == -1) break
+                        if (read == 0) continue
+                        received += read
+                        if (received > sizeCap) {
+                            throw InstallFailure("download larger than expected")
+                        }
+                        fileSink.write(buffer, startIndex = 0, endIndex = read)
+                        hashBuffer.write(buffer, 0, read)
+                        hashingSink.write(hashBuffer, hashBuffer.size)
+                        onProgress(total?.let { (received.toDouble() / it).toFloat() })
+                    }
+                }
+            }
+        } catch (e: IOException) {
+            throw InstallFailure("download failed (network error)")
+        }
+        if (expected.sizeBytes != null && received != expected.sizeBytes) {
+            throw InstallFailure("download size mismatch")
+        }
+        return hashingSink.hash.hex()
+    }
+
+    /** Cross-checks every manifest in the archive; see the class KDoc. */
+    internal fun verifyPbz(
+        path: Path,
+        expected: ExpectedFirmwareArtifact,
+        platform: WatchHardwarePlatform,
+    ) {
+        val manifests = PbzFirmware(path).manifests
+        if (manifests.isEmpty()) {
+            throw InstallFailure("firmware archive contains no manifest")
+        }
+        manifests.forEach { wrapper ->
+            val firmware = wrapper.manifest.firmware
+            if (firmware.type != "normal") {
+                throw InstallFailure("unexpected firmware type '${firmware.type}'")
+            }
+            if (firmware.hwRev != platform) {
+                throw InstallFailure(
+                    "firmware is for '${firmware.hwRev.revision}', not this watch",
+                )
+            }
+            val manifestTag = firmware.versionTag
+            if (manifestTag != null) {
+                if (!versionTagMatches(expected.versionTag, manifestTag)) {
+                    throw InstallFailure(
+                        "firmware version '$manifestTag' does not match release '${expected.versionTag}'",
+                    )
+                }
+            } else {
+                // Tag equality is a selection-bug guard on top of the byte
+                // hash, so a tagless manifest downgrades gracefully instead
+                // of breaking sources that never wrote one.
+                logger.w { "Manifest has no versionTag; skipping tag cross-check" }
+            }
+            checkStreamCrc(wrapper, isResources = false)
+            if (wrapper.manifest.resources != null) {
+                checkStreamCrc(wrapper, isResources = true)
+            }
+        }
+    }
+
+    /**
+     * Pebble-CRC32 and byte count of an inner archive stream against the
+     * manifest's declared values, using the same CRC implementation the
+     * transfer layer uses.
+     */
+    @OptIn(ExperimentalUnsignedTypes::class)
+    private fun checkStreamCrc(wrapper: PbzManifestWrapper, isResources: Boolean) {
+        val (label, declaredCrc, declaredSize) = if (isResources) {
+            val resources = checkNotNull(wrapper.manifest.resources)
+            Triple("resources", resources.crc, resources.size)
+        } else {
+            Triple("firmware", wrapper.manifest.firmware.crc, wrapper.manifest.firmware.size)
+        }
+        val source = (if (isResources) checkNotNull(wrapper.getResources()) else wrapper.getFirmware()).buffered()
+        val crc = Crc32Calculator()
+        var totalBytes = 0L
+        source.use {
+            val buffer = ByteArray(DOWNLOAD_CHUNK_BYTES)
+            while (true) {
+                val read = it.readAtMostTo(buffer, 0, buffer.size)
+                if (read == -1) break
+                totalBytes += read
+                crc.addBytes(buffer.asUByteArray().copyOfRange(0, read))
+            }
+        }
+        if (totalBytes != declaredSize) {
+            throw InstallFailure("$label size does not match its manifest")
+        }
+        if (crc.finalize() != declaredCrc.toUInt()) {
+            throw InstallFailure("$label failed its manifest CRC check")
+        }
+    }
+
+    /**
+     * The sideload entry point rejects silently when another update holds
+     * its mutex and reports parse failures through the upstream state flow,
+     * so observe that flow: fail if nothing starts, and once the transfer is
+     * running let the upstream states drive the UI (fork state goes Idle).
+     * The temp file must outlive the whole transfer because PutBytes lazily
+     * re-reads the zip while streaming.
+     */
+    private suspend fun awaitHandoffOutcome(
+        target: InstallTarget,
+        state: MutableStateFlow<ForkFirmwareInstallState>,
+    ) {
+        val updateStates = watchUpdateStates(target.identifierKey)
+        val started = withTimeoutOrNull(HANDOFF_START_TIMEOUT) {
+            updateStates.first {
+                it is FirmwareUpdateStatus.Active || it is FirmwareUpdateStatus.NotInProgress.ErrorStarting
+            }
+        }
+        when (started) {
+            null -> throw InstallFailure("install did not start")
+            is FirmwareUpdateStatus.NotInProgress.ErrorStarting -> {
+                // The upstream error state is already user-visible; going
+                // Idle here avoids rendering the failure twice.
+                logger.w { "libpebble3 rejected the sideload: ${started.error}" }
+                state.value = ForkFirmwareInstallState.Idle
+            }
+            else -> {
+                state.value = ForkFirmwareInstallState.Idle
+                withTimeoutOrNull(TRANSFER_TIMEOUT) {
+                    updateStates.first {
+                        // null: the watch vanished from the device list
+                        // (disconnect or post-update reboot).
+                        it == null ||
+                            it is FirmwareUpdateStatus.NotInProgress ||
+                            it is FirmwareUpdateStatus.WaitingForReboot
+                    }
+                }
+            }
+        }
+    }
+
+    private fun stateFlowFor(identifierKey: String): MutableStateFlow<ForkFirmwareInstallState> {
+        // Plain synchronized access is not available in common code; the map
+        // is only touched from install paths and Compose reads, both of
+        // which tolerate a racy first-creation (worst case an extra flow
+        // instance is briefly created and dropped).
+        return states.getOrPut(identifierKey) { MutableStateFlow(ForkFirmwareInstallState.Idle) }
+    }
+
+    private suspend fun newDownloadPath(identifierKey: String): Path {
+        val dir = downloadDirectory()
+        stateMutex.withLock {
+            if (!sweptStaleFiles) {
+                sweptStaleFiles = true
+                sweepStaleDownloads(dir)
+            }
+            val safeKey = identifierKey.filter { it.isLetterOrDigit() }
+            return Path(dir, "$FILE_PREFIX$safeKey-${nextFileId++}.pbz")
+        }
+    }
+
+    /**
+     * Downloads from previous processes (crash, force stop) are dead weight:
+     * expectations do not survive the process, so they can never be
+     * installed. One sweep per process, before the first download.
+     */
+    private fun sweepStaleDownloads(dir: Path) {
+        try {
+            SystemFileSystem.list(dir)
+                .filter { it.name.startsWith(FILE_PREFIX) && it.name.endsWith(".pbz") }
+                .forEach { deleteQuietly(it) }
+        } catch (e: IOException) {
+            logger.w(e) { "Couldn't sweep stale firmware downloads" }
+        }
+    }
+
+    private fun deleteQuietly(path: Path) {
+        try {
+            SystemFileSystem.delete(path, mustExist = false)
+        } catch (e: IOException) {
+            logger.w(e) { "Couldn't delete $path" }
+        }
+    }
+
+    private class InstallFailure(val reason: String) : Exception(reason)
+
+    private fun versionTagMatches(expectedTag: String, manifestTag: String): Boolean {
+        val expected = ReleaseTagVersion.from(expectedTag)
+        val manifest = ReleaseTagVersion.from(manifestTag)
+        // Numeric comparison tolerates cosmetic differences like a suffix;
+        // exact string equality is the fallback when either side is exotic.
+        return if (expected != null && manifest != null) {
+            expected.compareTo(manifest) == 0
+        } else {
+            expectedTag == manifestTag
+        }
+    }
+
+    companion object {
+        private const val FILE_PREFIX = "fork-fw-"
+        private const val DOWNLOAD_CHUNK_BYTES = 64 * 1024
+
+        // Only applies when the source declared no size (cohorts): far above
+        // any real PBZ (about 2 MB today) but still bounds a runaway stream.
+        private const val MAX_DOWNLOAD_BYTES = 64L * 1024 * 1024
+        private val READ_STALL_TIMEOUT = 30.seconds
+        private val HANDOFF_START_TIMEOUT = 30.seconds
+        private val TRANSFER_TIMEOUT = 30.minutes
+    }
+}

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/DebugFirmwareSideload.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/DebugFirmwareSideload.kt
@@ -229,8 +229,11 @@ fun DebugFirmwareSideload(watchIdentifier: String, coreNav: CoreNav) {
                                         doFirmwareUpdate {
                                             logger.d { "doFirmwareUpdate: $availableUpdate" }
                                             // Fork: verified install path.
-                                            (this as? CommonConnectedDevice)?.let {
-                                                forkInstaller.install(it, availableUpdate)
+                                            val device = this as? CommonConnectedDevice
+                                            if (device == null) {
+                                                logger.w { "Can't update firmware for $this" }
+                                            } else {
+                                                forkInstaller.install(device, availableUpdate)
                                             }
                                         }
                                     } else {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/DebugFirmwareSideload.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/DebugFirmwareSideload.kt
@@ -34,9 +34,11 @@ import androidx.compose.ui.unit.dp
 import co.touchlab.kermit.Logger
 import coreapp.util.generated.resources.Res
 import coreapp.util.generated.resources.back
+import coredevices.pebble.firmware.VerifiedFirmwareInstaller
 import coredevices.pebble.rememberLibPebble
 import coredevices.ui.CoreLinearProgressIndicator
 import io.rebble.libpebblecommon.connection.AppContext
+import io.rebble.libpebblecommon.connection.CommonConnectedDevice
 import io.rebble.libpebblecommon.connection.ConnectedPebble
 import io.rebble.libpebblecommon.connection.ConnectedPebbleDevice
 import io.rebble.libpebblecommon.connection.ConnectedPebbleDeviceInRecovery
@@ -97,6 +99,9 @@ fun DebugFirmwareSideload(watchIdentifier: String, coreNav: CoreNav) {
     Box(modifier = Modifier.background(MaterialTheme.colorScheme.background)) {
         val libPebble = rememberLibPebble()
         val appContext = koinInject<AppContext>()
+        // Fork: the "Update FW" button routes through the verified installer;
+        // the file-picker sideload below stays raw on purpose (developer tool).
+        val forkInstaller = koinInject<VerifiedFirmwareInstaller>()
         val scope = rememberCoroutineScope()
         val watchFlow = remember(watchIdentifier) {
             libPebble.watches
@@ -223,7 +228,10 @@ fun DebugFirmwareSideload(watchIdentifier: String, coreNav: CoreNav) {
                                         setUpdateState(UiFirmwareUpdateStatus.Starting)
                                         doFirmwareUpdate {
                                             logger.d { "doFirmwareUpdate: $availableUpdate" }
-                                            updateFirmware(availableUpdate)
+                                            // Fork: verified install path.
+                                            (this as? CommonConnectedDevice)?.let {
+                                                forkInstaller.install(it, availableUpdate)
+                                            }
                                         }
                                     } else {
                                         logger.d { "availableUpdate is null" }

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/ForkFirmwareInstallUi.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/ForkFirmwareInstallUi.kt
@@ -1,0 +1,40 @@
+package coredevices.pebble.ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import coredevices.pebble.firmware.ForkFirmwareInstallState
+import coredevices.pebble.firmware.VerifiedFirmwareInstaller
+import coredevices.ui.CoreLinearProgressIndicator
+import io.rebble.libpebblecommon.connection.PebbleDevice
+
+/**
+ * Compose glue between the fork's verified installer and the upstream watch
+ * UI. Kept in its own file so the edits inside upstream screens stay tiny
+ * (fewer merge conflicts).
+ */
+@Composable
+fun VerifiedFirmwareInstaller.installStateFor(watch: PebbleDevice): State<ForkFirmwareInstallState> =
+    stateFor(watch.identifier).collectAsState()
+
+/** Suffix for the watch state line, matching upstream's " - ..." style. */
+fun ForkFirmwareInstallState.stateTextSuffix(): String =
+    describe()?.let { " - $it" } ?: ""
+
+/** Download progress bar in the same style as the upstream transfer bar. */
+@Composable
+fun ForkInstallProgressBar(state: ForkFirmwareInstallState) {
+    if (state is ForkFirmwareInstallState.Downloading) {
+        val progress = state.progress
+        if (progress != null) {
+            CoreLinearProgressIndicator(
+                progress = { progress },
+                modifier = Modifier.fillMaxWidth().padding(vertical = 7.dp),
+            )
+        }
+    }
+}

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/ForkFirmwareInstallUi.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/ForkFirmwareInstallUi.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import coredevices.pebble.firmware.ForkFirmwareInstallState
@@ -18,8 +19,13 @@ import io.rebble.libpebblecommon.connection.PebbleDevice
  * (fewer merge conflicts).
  */
 @Composable
-fun VerifiedFirmwareInstaller.installStateFor(watch: PebbleDevice): State<ForkFirmwareInstallState> =
-    stateFor(watch.identifier).collectAsState()
+fun VerifiedFirmwareInstaller.installStateFor(watch: PebbleDevice): State<ForkFirmwareInstallState> {
+    // stateFor mints a fresh read-only wrapper per call; without remember,
+    // every recomposition would hand collectAsState a new flow identity and
+    // restart its collection coroutine.
+    val flow = remember(this, watch.identifier) { stateFor(watch.identifier) }
+    return flow.collectAsState()
+}
 
 /** Suffix for the watch state line, matching upstream's " - ..." style. */
 fun ForkFirmwareInstallState.stateTextSuffix(): String =

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -1686,7 +1686,7 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                 // Fork: channel toggle for the GitHub-releases update path.
                 basicSettingsToggleItem(
                     title = "Early PebbleOS updates",
-                    description = "Offer the newest PebbleOS release immediately (the tier Core's internal testers run) instead of one that has soaked for a week",
+                    description = "Offer the newest PebbleOS release immediately (the tier Core's internal testers run) instead of one from a release line that has soaked for a week",
                     topLevelType = TopLevelType.Phone,
                     section = Section.Debug,
                     checked = coreConfig.firmwareUpdatesEarlyChannel,

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -1683,6 +1683,22 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                     },
                     isDebugSetting = true,
                 ),
+                // Fork: channel toggle for the GitHub-releases update path.
+                basicSettingsToggleItem(
+                    title = "Early PebbleOS updates",
+                    description = "Offer the newest PebbleOS release immediately (the tier Core's internal testers run) instead of one that has soaked for a week",
+                    topLevelType = TopLevelType.Phone,
+                    section = Section.Debug,
+                    checked = coreConfig.firmwareUpdatesEarlyChannel,
+                    onCheckChanged = {
+                        coreConfigHolder.update(
+                            coreConfig.copy(
+                                firmwareUpdatesEarlyChannel = it
+                            )
+                        )
+                    },
+                    isDebugSetting = true,
+                ),
                 basicSettingsActionItem(
                     title = "Do immediate background sync",
                     description = "Sync firmware updates, locker, etc manually now (happens regularly automatically)",

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchesScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchesScreen.kt
@@ -136,6 +136,7 @@ import coredevices.pebble.PebbleDeepLinkHandler
 import coredevices.pebble.PebbleFeatures
 import coredevices.pebble.account.PebbleAccount
 import coredevices.pebble.firmware.FirmwareUpdateUiTracker
+import coredevices.pebble.firmware.VerifiedFirmwareInstaller
 import coredevices.pebble.firmware.isCoreDevice
 import coredevices.pebble.rememberLibPebble
 import coredevices.pebble.services.LanguagePack
@@ -1937,12 +1938,19 @@ fun WatchDetails(
             FirmwareUpdater.FirmwareUpdateStatus.NotInProgress.Idle()
         }
     }
+    // Fork: the verified installer downloads and verifies before libpebble3
+    // is involved; merge its phases into the in-progress gate so the Update
+    // button hides and fork failures render in the state line.
+    val forkInstaller = koinInject<VerifiedFirmwareInstaller>()
+    val forkInstallState by forkInstaller.installStateFor(watch)
     val firmwareUpdateInProgress =
-        firmwareUpdateState !is FirmwareUpdater.FirmwareUpdateStatus.NotInProgress
+        firmwareUpdateState !is FirmwareUpdater.FirmwareUpdateStatus.NotInProgress ||
+            forkInstallState.isActive
     val languagePackInstallState = (watch as? ConnectedPebble.LanguageState)?.languagePackInstallState ?: LanguagePackInstallState.Idle()
     Row {
         Text(
-            text = watch.stateText(firmwareUpdateState, languagePackInstallState, coreConfig),
+            text = watch.stateText(firmwareUpdateState, languagePackInstallState, coreConfig) +
+                forkInstallState.stateTextSuffix(),
             fontWeight = when {
                 watch.isActive() -> FontWeight.Bold
                 else -> FontWeight.Normal
@@ -1959,6 +1967,7 @@ fun WatchDetails(
                 modifier = Modifier.fillMaxWidth().padding(vertical = 7.dp),
             )
         }
+        ForkInstallProgressBar(forkInstallState)
     } else if (languagePackInstallState is LanguagePackInstallState.Installing) {
         val progress by languagePackInstallState.progress.collectAsState()
         CoreLinearProgressIndicator(
@@ -2036,7 +2045,10 @@ fun WatchDetails(
                 confirmButton = {
                     TextButton(onClick = {
                         showFirmwareUpdateConfirmDialog = false
-                        firmwareUpdater.updateFirmware(firmwareUpdateAvailable)
+                        // Fork: verified install path (sha256 + manifest checks).
+                        (watch as? CommonConnectedDevice)?.let {
+                            forkInstaller.install(it, firmwareUpdateAvailable)
+                        }
                     }) { Text("Install") }
                 },
                 dismissButton = { TextButton(onClick = { showFirmwareUpdateConfirmDialog = false }) { Text("Cancel") } }

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchesScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchesScreen.kt
@@ -2046,8 +2046,11 @@ fun WatchDetails(
                     TextButton(onClick = {
                         showFirmwareUpdateConfirmDialog = false
                         // Fork: verified install path (sha256 + manifest checks).
-                        (watch as? CommonConnectedDevice)?.let {
-                            forkInstaller.install(it, firmwareUpdateAvailable)
+                        val device = watch as? CommonConnectedDevice
+                        if (device == null) {
+                            logger.w { "Can't update firmware for $watch" }
+                        } else {
+                            forkInstaller.install(device, firmwareUpdateAvailable)
                         }
                     }) { Text("Install") }
                 },

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/watchModule.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/watchModule.kt
@@ -200,10 +200,7 @@ val watchModule = module {
     // Fork: Core-watch updates come from the public PebbleOS GitHub releases
     // (fork builds ship no Memfault token, and cohorts rejects Core hardware).
     singleOf(::FirmwareArtifactExpectations)
-    single {
-        val coreConfig = get<CoreConfigFlow>()
-        GithubReleases(get(), get(), { coreConfig.value.firmwareUpdateChannel() }, get())
-    }
+    singleOf(::GithubReleases)
     single {
         // Fork: download+verify+sideload pipeline for firmware installs. Reuses
         // upstream's firmware cache directory (unique per-install filenames);
@@ -222,7 +219,19 @@ val watchModule = module {
             },
         )
     }
-    singleOf(::FirmwareUpdateCheck)
+    single {
+        // Fork: the channel provider is a live CoreConfig read; the check
+        // reads it exactly once per check so its cache key and the GitHub
+        // release selection always agree.
+        val coreConfig = get<CoreConfigFlow>()
+        FirmwareUpdateCheck(
+            memfault = get(),
+            cohorts = get(),
+            githubReleases = get(),
+            channel = { coreConfig.value.firmwareUpdateChannel() },
+            clock = get(),
+        )
+    }
     factoryOf(::PebbleFeatures)
     factoryOf(::WeatherFetcher)
     factoryOf(::LanguagePackRepository)

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/watchModule.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/watchModule.kt
@@ -22,6 +22,7 @@ import coredevices.pebble.firmware.FirmwareUpdateCheck
 import coredevices.pebble.firmware.FirmwareUpdateUiTracker
 import coredevices.pebble.firmware.GithubReleases
 import coredevices.pebble.firmware.RealFirmwareUpdateUiTracker
+import coredevices.pebble.firmware.VerifiedFirmwareInstaller
 import coredevices.pebble.services.AppstoreCache
 import coredevices.pebble.services.AppstoreService
 import coredevices.pebble.services.AppstoreSourceInitializer
@@ -72,6 +73,8 @@ import io.rebble.libpebblecommon.BleConfig
 import io.rebble.libpebblecommon.LibPebbleConfig
 import io.rebble.libpebblecommon.NotificationConfig
 import io.rebble.libpebblecommon.WatchConfig
+import io.rebble.libpebblecommon.connection.AppContext
+import io.rebble.libpebblecommon.connection.ConnectedPebble
 import io.rebble.libpebblecommon.connection.ConnectedPebbleDevice
 import io.rebble.libpebblecommon.connection.HealthDataApi
 import io.rebble.libpebblecommon.connection.LibPebble
@@ -80,6 +83,7 @@ import io.rebble.libpebblecommon.connection.NotificationApps
 import io.rebble.libpebblecommon.connection.TokenProvider
 import io.rebble.libpebblecommon.connection.WebServices
 import io.rebble.libpebblecommon.js.InjectedPKJSHttpInterceptors
+import io.rebble.libpebblecommon.locker.getLockerPBWCacheDirectory
 import io.rebble.libpebblecommon.util.SystemGeolocation
 import io.rebble.libpebblecommon.voice.TranscriptionProvider
 import io.rebble.libpebblecommon.web.LockerEntry
@@ -197,6 +201,24 @@ val watchModule = module {
     // The channel provider is pinned to Soaked until the settings toggle lands.
     singleOf(::FirmwareArtifactExpectations)
     single { GithubReleases(get(), get(), { FirmwareUpdateChannel.Soaked }, get()) }
+    single {
+        // Fork: download+verify+sideload pipeline for firmware installs. Reuses
+        // upstream's firmware cache directory (unique per-install filenames);
+        // LibPebble resolves lazily because it is itself created in this module.
+        val appContext = get<AppContext>()
+        val libPebble = lazy { get<LibPebble>() }
+        VerifiedFirmwareInstaller(
+            httpClient = get(),
+            expectations = get(),
+            downloadDirectory = { getLockerPBWCacheDirectory(appContext) },
+            watchUpdateStates = { identifierKey ->
+                libPebble.value.watches.map { watches ->
+                    val device = watches.firstOrNull { it.identifier.asString == identifierKey }
+                    (device as? ConnectedPebble.Firmware)?.firmwareUpdateState
+                }
+            },
+        )
+    }
     singleOf(::FirmwareUpdateCheck)
     factoryOf(::PebbleFeatures)
     factoryOf(::WeatherFetcher)

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/watchModule.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/watchModule.kt
@@ -16,8 +16,11 @@ import coredevices.pebble.account.RealFirestoreKnownWatchesSync
 import coredevices.pebble.account.RealFirestoreLocker
 import coredevices.pebble.account.RealPebbleAccount
 import coredevices.pebble.firmware.Cohorts
+import coredevices.pebble.firmware.FirmwareArtifactExpectations
+import coredevices.pebble.firmware.FirmwareUpdateChannel
 import coredevices.pebble.firmware.FirmwareUpdateCheck
 import coredevices.pebble.firmware.FirmwareUpdateUiTracker
+import coredevices.pebble.firmware.GithubReleases
 import coredevices.pebble.firmware.RealFirmwareUpdateUiTracker
 import coredevices.pebble.services.AppstoreCache
 import coredevices.pebble.services.AppstoreService
@@ -189,6 +192,11 @@ val watchModule = module {
     singleOf(::AnalyticsHeartbeatQueue)
     singleOf(::ContactDeveloperApi)
     factoryOf(::Cohorts)
+    // Fork: Core-watch updates come from the public PebbleOS GitHub releases
+    // (fork builds ship no Memfault token, and cohorts rejects Core hardware).
+    // The channel provider is pinned to Soaked until the settings toggle lands.
+    singleOf(::FirmwareArtifactExpectations)
+    single { GithubReleases(get(), get(), { FirmwareUpdateChannel.Soaked }, get()) }
     singleOf(::FirmwareUpdateCheck)
     factoryOf(::PebbleFeatures)
     factoryOf(::WeatherFetcher)

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/watchModule.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/watchModule.kt
@@ -17,10 +17,10 @@ import coredevices.pebble.account.RealFirestoreLocker
 import coredevices.pebble.account.RealPebbleAccount
 import coredevices.pebble.firmware.Cohorts
 import coredevices.pebble.firmware.FirmwareArtifactExpectations
-import coredevices.pebble.firmware.FirmwareUpdateChannel
 import coredevices.pebble.firmware.FirmwareUpdateCheck
 import coredevices.pebble.firmware.FirmwareUpdateUiTracker
 import coredevices.pebble.firmware.GithubReleases
+import coredevices.pebble.firmware.firmwareUpdateChannel
 import coredevices.pebble.firmware.RealFirmwareUpdateUiTracker
 import coredevices.pebble.firmware.VerifiedFirmwareInstaller
 import coredevices.pebble.services.AppstoreCache
@@ -62,6 +62,7 @@ import coredevices.pebble.weather.OpenWeather25Interceptor
 import coredevices.pebble.weather.WeatherFetcher
 import coredevices.pebble.weather.YahooWeatherInterceptor
 import coredevices.util.CommonBuildKonfig
+import coredevices.util.CoreConfigFlow
 import dev.gitlive.firebase.Firebase
 import dev.gitlive.firebase.auth.auth
 import dev.jordond.compass.geocoder.Geocoder
@@ -198,9 +199,11 @@ val watchModule = module {
     factoryOf(::Cohorts)
     // Fork: Core-watch updates come from the public PebbleOS GitHub releases
     // (fork builds ship no Memfault token, and cohorts rejects Core hardware).
-    // The channel provider is pinned to Soaked until the settings toggle lands.
     singleOf(::FirmwareArtifactExpectations)
-    single { GithubReleases(get(), get(), { FirmwareUpdateChannel.Soaked }, get()) }
+    single {
+        val coreConfig = get<CoreConfigFlow>()
+        GithubReleases(get(), get(), { coreConfig.value.firmwareUpdateChannel() }, get())
+    }
     single {
         // Fork: download+verify+sideload pipeline for firmware installs. Reuses
         // upstream's firmware cache directory (unique per-install filenames);

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/CohortsTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/CohortsTest.kt
@@ -1,23 +1,8 @@
 package coredevices.pebble.firmware
 
-import CoreAppVersion
-import coredevices.pebble.account.PebbleAccount
-import coredevices.pebble.services.PebbleAccountProvider
-import coredevices.pebble.services.PebbleHttpClient
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.mock.MockEngine
-import io.ktor.client.engine.mock.respond
-import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.http.HttpHeaders
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.headersOf
-import io.ktor.serialization.kotlinx.json.json
-import io.rebble.libpebblecommon.connection.FakeLibPebble
 import io.rebble.libpebblecommon.connection.FirmwareUpdateCheckResult
 import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -31,37 +16,10 @@ import kotlin.test.assertNull
  */
 class CohortsTest {
 
-    private class SignedOutAccounts : PebbleAccountProvider {
-        override fun get(): PebbleAccount = object : PebbleAccount {
-            override val loggedIn = MutableStateFlow<String?>(null)
-            override val devToken = MutableStateFlow<String?>(null)
-            override suspend fun setToken(token: String?, bootUrl: String?) {}
-            override suspend fun setDevPortalId() {}
-        }
-    }
-
-    private fun cohortsBody(sha256: String) =
-        """{"fw":{"normal":{"friendlyVersion":"v4.4.3-rbl","notes":"legacy notes",""" +
-            """"sha-256":"$sha256","timestamp":1762930476,""" +
-            """"url":"https://binaries.rebble.io/fw/silk/Pebble-4.4.3-rbl-silk.pbz"}}}"""
-
-    private fun cohorts(body: String, expectations: FirmwareArtifactExpectations): Cohorts {
-        val client = HttpClient(MockEngine { _ ->
-            respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
-        }) {
-            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
-        }
-        return Cohorts(
-            httpClient = PebbleHttpClient(SignedOutAccounts(), client, lazy { FakeLibPebble() }),
-            appVersion = CoreAppVersion("0.0.0"),
-            expectations = expectations,
-        )
-    }
-
     @Test
     fun recordsServerSha256WhenOfferingAnUpdate() = runTest {
         val expectations = FirmwareArtifactExpectations()
-        val result = cohorts(cohortsBody("B".repeat(64)), expectations)
+        val result = testCohorts(jsonRespondingClient(cohortsBody("B".repeat(64))), expectations)
             .getLatestFirmware(testWatchInfo(WatchHardwarePlatform.PEBBLE_SILK, "v4.0.0"))
         val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
         assertEquals(
@@ -77,7 +35,7 @@ class CohortsTest {
     @Test
     fun malformedSha256RecordsNothingButStillOffers() = runTest {
         val expectations = FirmwareArtifactExpectations()
-        val result = cohorts(cohortsBody("not-a-hash"), expectations)
+        val result = testCohorts(jsonRespondingClient(cohortsBody("not-a-hash")), expectations)
             .getLatestFirmware(testWatchInfo(WatchHardwarePlatform.PEBBLE_SILK, "v4.0.0"))
         val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
         assertNull(expectations.lookup(update.url))

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/CohortsTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/CohortsTest.kt
@@ -1,0 +1,85 @@
+package coredevices.pebble.firmware
+
+import CoreAppVersion
+import coredevices.pebble.account.PebbleAccount
+import coredevices.pebble.services.PebbleAccountProvider
+import coredevices.pebble.services.PebbleHttpClient
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.rebble.libpebblecommon.connection.FakeLibPebble
+import io.rebble.libpebblecommon.connection.FirmwareUpdateCheckResult
+import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+/**
+ * Pins the fork's addition to the cohorts checker: the server's sha-256,
+ * which upstream parses and discards, is recorded for the verified installer.
+ * A malformed hash records nothing (the installer then refuses that download)
+ * but must not break the offer itself.
+ */
+class CohortsTest {
+
+    private class SignedOutAccounts : PebbleAccountProvider {
+        override fun get(): PebbleAccount = object : PebbleAccount {
+            override val loggedIn = MutableStateFlow<String?>(null)
+            override val devToken = MutableStateFlow<String?>(null)
+            override suspend fun setToken(token: String?, bootUrl: String?) {}
+            override suspend fun setDevPortalId() {}
+        }
+    }
+
+    private fun cohortsBody(sha256: String) =
+        """{"fw":{"normal":{"friendlyVersion":"v4.4.3-rbl","notes":"legacy notes",""" +
+            """"sha-256":"$sha256","timestamp":1762930476,""" +
+            """"url":"https://binaries.rebble.io/fw/silk/Pebble-4.4.3-rbl-silk.pbz"}}}"""
+
+    private fun cohorts(body: String, expectations: FirmwareArtifactExpectations): Cohorts {
+        val client = HttpClient(MockEngine { _ ->
+            respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }) {
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+        return Cohorts(
+            httpClient = PebbleHttpClient(SignedOutAccounts(), client, lazy { FakeLibPebble() }),
+            appVersion = CoreAppVersion("0.0.0"),
+            expectations = expectations,
+        )
+    }
+
+    @Test
+    fun recordsServerSha256WhenOfferingAnUpdate() = runTest {
+        val expectations = FirmwareArtifactExpectations()
+        val result = cohorts(cohortsBody("B".repeat(64)), expectations)
+            .getLatestFirmware(testWatchInfo(WatchHardwarePlatform.PEBBLE_SILK, "v4.0.0"))
+        val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
+        assertEquals(
+            ExpectedFirmwareArtifact(
+                sha256Hex = "b".repeat(64),
+                sizeBytes = null,
+                versionTag = "v4.4.3-rbl",
+            ),
+            expectations.lookup(update.url),
+        )
+    }
+
+    @Test
+    fun malformedSha256RecordsNothingButStillOffers() = runTest {
+        val expectations = FirmwareArtifactExpectations()
+        val result = cohorts(cohortsBody("not-a-hash"), expectations)
+            .getLatestFirmware(testWatchInfo(WatchHardwarePlatform.PEBBLE_SILK, "v4.0.0"))
+        val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
+        assertNull(expectations.lookup(update.url))
+    }
+}

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/FirmwareArtifactExpectationsTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/FirmwareArtifactExpectationsTest.kt
@@ -1,0 +1,68 @@
+package coredevices.pebble.firmware
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Pins the registry contract the verified installer fails closed against:
+ * exact-URL lookup, recording-order eviction, and the hash normalization
+ * that decides whether a source's hash is usable at all.
+ */
+class FirmwareArtifactExpectationsTest {
+
+    private fun expected(tag: String) = ExpectedFirmwareArtifact(
+        sha256Hex = "ab".repeat(32),
+        sizeBytes = 123L,
+        versionTag = tag,
+    )
+
+    @Test
+    fun recordThenLookupReturnsEntry() = runTest {
+        val registry = FirmwareArtifactExpectations()
+        registry.record("https://example.com/a.pbz", expected("v4.31.1"))
+        assertEquals(expected("v4.31.1"), registry.lookup("https://example.com/a.pbz"))
+        assertNull(registry.lookup("https://example.com/other.pbz"))
+    }
+
+    @Test
+    fun oldestEntryIsEvictedPastTheCap() = runTest {
+        val registry = FirmwareArtifactExpectations()
+        repeat(17) { i -> registry.record("https://example.com/$i.pbz", expected("v$i")) }
+        assertNull(registry.lookup("https://example.com/0.pbz"))
+        assertEquals(expected("v1"), registry.lookup("https://example.com/1.pbz"))
+        assertEquals(expected("v16"), registry.lookup("https://example.com/16.pbz"))
+    }
+
+    @Test
+    fun reRecordingRefreshesEvictionOrder() = runTest {
+        val registry = FirmwareArtifactExpectations()
+        repeat(16) { i -> registry.record("https://example.com/$i.pbz", expected("v$i")) }
+        // Re-record the oldest, then push one more: entry 1 (now oldest) goes,
+        // entry 0 stays.
+        registry.record("https://example.com/0.pbz", expected("v0new"))
+        registry.record("https://example.com/16.pbz", expected("v16"))
+        assertEquals(expected("v0new"), registry.lookup("https://example.com/0.pbz"))
+        assertNull(registry.lookup("https://example.com/1.pbz"))
+    }
+
+    @Test
+    fun normalizeAcceptsPrefixedAndBareHexAndLowercases() {
+        val hex = "AB".repeat(32)
+        assertEquals("ab".repeat(32), normalizeSha256Hex("sha256:$hex"))
+        assertEquals("ab".repeat(32), normalizeSha256Hex(hex))
+        assertEquals("12".repeat(32), normalizeSha256Hex(" ${"12".repeat(32)} "))
+    }
+
+    @Test
+    fun normalizeRejectsAnythingElse() {
+        assertNull(normalizeSha256Hex(null))
+        assertNull(normalizeSha256Hex(""))
+        assertNull(normalizeSha256Hex("sha256:"))
+        assertNull(normalizeSha256Hex("ab".repeat(31)))
+        assertNull(normalizeSha256Hex("ab".repeat(33)))
+        assertNull(normalizeSha256Hex("zz".repeat(32)))
+        assertNull(normalizeSha256Hex("sha512:" + "ab".repeat(32)))
+    }
+}

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/FirmwareReleaseSelectionTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/FirmwareReleaseSelectionTest.kt
@@ -1,0 +1,200 @@
+package coredevices.pebble.firmware
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
+
+/**
+ * Locks the two behaviors the GitHub update path depends on and which
+ * upstream's FirmwareVersion cannot provide:
+ *
+ * 1. Anchored four-component tag parsing. Upstream's regex find() would
+ *    truncate "v4.9.142.3" to 4.9.142, making factory tags structurally
+ *    invisible and factory hotfixes mutually equal.
+ * 2. Structural release selection. GitHub's "latest" badge and publish dates
+ *    must never influence which release is offered; a factory tag published
+ *    five minutes ago must lose to an older main-line tag.
+ */
+class FirmwareReleaseSelectionTest {
+
+    // --- ReleaseTagVersion parsing ---
+
+    @Test
+    fun parsesThreeComponentMainLineTag() {
+        val v = ReleaseTagVersion.from("v4.32.0")!!
+        assertEquals(4, v.major)
+        assertEquals(32, v.minor)
+        assertEquals(0, v.patch)
+        assertEquals(0, v.fourth)
+        assertEquals(3, v.componentCount)
+        assertEquals(false, v.isFactoryLine)
+    }
+
+    @Test
+    fun parsesFourComponentFactoryTagWithoutTruncation() {
+        val v = ReleaseTagVersion.from("v4.9.142.3")!!
+        assertEquals(listOf(4, 9, 142, 3), listOf(v.major, v.minor, v.patch, v.fourth))
+        assertEquals(4, v.componentCount)
+        assertTrue(v.isFactoryLine)
+    }
+
+    @Test
+    fun parsesTwoComponentAndSuffixForms() {
+        val prf = ReleaseTagVersion.from("v4.0-prf4")!!
+        assertEquals(2, prf.componentCount)
+        assertEquals(0, prf.patch)
+        val suffixed = ReleaseTagVersion.from("4.0.1-beta2")!!
+        assertEquals(1, suffixed.patch)
+        assertEquals(3, suffixed.componentCount)
+    }
+
+    @Test
+    fun rejectsUnparseableTags() {
+        assertNull(ReleaseTagVersion.from("unknown"))
+        assertNull(ReleaseTagVersion.from(""))
+        assertNull(ReleaseTagVersion.from("v4"))
+        assertNull(ReleaseTagVersion.from("v4."))
+        // Five components must fail whole-string matching, not silently drop one.
+        assertNull(ReleaseTagVersion.from("v4.9.142.3.1"))
+    }
+
+    // --- Comparison ---
+
+    @Test
+    fun mainLineOutranksFactoryLineNumerically() {
+        // 32 > 9 on the minor component; the factory line is older content
+        // despite its larger patch/fourth components.
+        assertTrue(ReleaseTagVersion.from("v4.32.0")!! > ReleaseTagVersion.from("v4.9.142.3")!!)
+    }
+
+    @Test
+    fun fourthComponentOrdersFactoryHotfixes() {
+        // Upstream's truncating parser would compare these equal.
+        assertTrue(ReleaseTagVersion.from("v4.9.142.3")!! > ReleaseTagVersion.from("v4.9.142.2")!!)
+    }
+
+    @Test
+    fun equalVersionsCompareEqualAcrossFormsAndSuffixes() {
+        val plain = ReleaseTagVersion.from("v4.31.1")!!
+        assertEquals(0, plain.compareTo(ReleaseTagVersion.from("4.31.1")!!))
+        assertEquals(0, plain.compareTo(ReleaseTagVersion.from("v4.31.1-anything")!!))
+        assertEquals(0, ReleaseTagVersion.from("v4.31")!!.compareTo(ReleaseTagVersion.from("v4.31.0")!!))
+    }
+
+    @Test
+    fun patchOrdersWithinMinor() {
+        assertTrue(ReleaseTagVersion.from("v4.31.1")!! > ReleaseTagVersion.from("v4.31.0")!!)
+        assertTrue(ReleaseTagVersion.from("v4.32.0")!! > ReleaseTagVersion.from("v4.31.1")!!)
+    }
+
+    // --- Release selection ---
+
+    private val now = Instant.parse("2026-07-31T00:00:00Z")
+
+    private fun release(tag: String, ageDays: Int, hasAsset: Boolean = true) = SelectableRelease(
+        version = ReleaseTagVersion.from(tag)!!,
+        publishedAt = now - ageDays.days,
+        hasAsset = hasAsset,
+    )
+
+    @Test
+    fun factoryTagNewestByDateIsNeverPicked() {
+        // The "latest badge trap": a factory hotfix published most recently
+        // would hold GitHub's Latest badge, and it also has the numerically
+        // largest patch component. Both channels must ignore it.
+        val releases = listOf(
+            release("v4.9.142.4", ageDays = 0),
+            release("v4.32.0", ageDays = 2),
+            release("v4.31.1", ageDays = 8),
+            release("v4.31.0", ageDays = 10),
+        )
+        assertEquals("v4.32.0", selectRelease(releases, FirmwareUpdateChannel.Early, now)!!.version.raw)
+        assertEquals("v4.31.1", selectRelease(releases, FirmwareUpdateChannel.Soaked, now)!!.version.raw)
+    }
+
+    @Test
+    fun soakedSkipsFreshMinorButTakesFreshHotfixWithinSoakedMinor() {
+        val releases = listOf(
+            release("v4.32.0", ageDays = 2),
+            // Minor 4.31 first published 10 days ago; its hotfix is 1 day old
+            // and must be taken immediately: it stabilizes the promoted build.
+            release("v4.31.1", ageDays = 1),
+            release("v4.31.0", ageDays = 10),
+            release("v4.30.0", ageDays = 20),
+        )
+        assertEquals("v4.31.1", selectRelease(releases, FirmwareUpdateChannel.Soaked, now)!!.version.raw)
+    }
+
+    @Test
+    fun soakedReturnsNullWhenNoMinorHasSoaked() {
+        val releases = listOf(
+            release("v4.32.0", ageDays = 2),
+            release("v4.31.0", ageDays = 5),
+        )
+        assertNull(selectRelease(releases, FirmwareUpdateChannel.Soaked, now))
+    }
+
+    @Test
+    fun soakedWalksForwardWhenTargetLacksAssetForNewHardware() {
+        // Hardware ramp: the soaked pick predates the board revision, so the
+        // nearest newer release that has the asset is offered instead.
+        val releases = listOf(
+            release("v4.32.0", ageDays = 1, hasAsset = true),
+            release("v4.31.1", ageDays = 3, hasAsset = true),
+            release("v4.31.0", ageDays = 10, hasAsset = false),
+            release("v4.30.0", ageDays = 20, hasAsset = false),
+        )
+        // Soaked target is 4.31.1 (minor 4.31 soaked, highest patch) but the
+        // walk starts from the target: 4.31.1 has the asset, so it wins.
+        assertEquals("v4.31.1", selectRelease(releases, FirmwareUpdateChannel.Soaked, now)!!.version.raw)
+
+        val noAssetUntil432 = listOf(
+            release("v4.32.0", ageDays = 1, hasAsset = true),
+            release("v4.31.1", ageDays = 3, hasAsset = false),
+            release("v4.31.0", ageDays = 10, hasAsset = false),
+        )
+        assertEquals("v4.32.0", selectRelease(noAssetUntil432, FirmwareUpdateChannel.Soaked, now)!!.version.raw)
+    }
+
+    @Test
+    fun selectionReturnsNullWhenNoReleaseHasAsset() {
+        val releases = listOf(
+            release("v4.31.0", ageDays = 10, hasAsset = false),
+            release("v4.30.0", ageDays = 20, hasAsset = false),
+        )
+        assertNull(selectRelease(releases, FirmwareUpdateChannel.Soaked, now))
+        assertNull(selectRelease(releases, FirmwareUpdateChannel.Early, now))
+    }
+
+    @Test
+    fun earlyPicksNewestMainLineWithAsset() {
+        val releases = listOf(
+            release("v4.32.0", ageDays = 0, hasAsset = false),
+            release("v4.31.1", ageDays = 2, hasAsset = true),
+        )
+        assertEquals("v4.31.1", selectRelease(releases, FirmwareUpdateChannel.Early, now)!!.version.raw)
+    }
+
+    @Test
+    fun emptyAndFactoryOnlyListsSelectNothing() {
+        assertNull(selectRelease(emptyList(), FirmwareUpdateChannel.Early, now))
+        val factoryOnly = listOf(release("v4.9.142.3", ageDays = 30))
+        assertNull(selectRelease(factoryOnly, FirmwareUpdateChannel.Early, now))
+        assertNull(selectRelease(factoryOnly, FirmwareUpdateChannel.Soaked, now))
+    }
+
+    @Test
+    fun selectionOrdersByVersionNotPublishDate() {
+        // A re-published or out-of-order-tagged older release must not win on
+        // recency: 4.30.1 is newer by date but 4.31.0 is the newer version.
+        val releases = listOf(
+            release("v4.30.1", ageDays = 8),
+            release("v4.31.0", ageDays = 9),
+        )
+        assertEquals("v4.31.0", selectRelease(releases, FirmwareUpdateChannel.Early, now)!!.version.raw)
+        assertEquals("v4.31.0", selectRelease(releases, FirmwareUpdateChannel.Soaked, now)!!.version.raw)
+    }
+}

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/FirmwareReleaseSelectionTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/FirmwareReleaseSelectionTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.days
-import kotlin.time.Instant
+import kotlin.time.Duration.Companion.hours
 
 /**
  * Locks the two behaviors the GitHub update path depends on and which
@@ -92,7 +92,7 @@ class FirmwareReleaseSelectionTest {
 
     // --- Release selection ---
 
-    private val now = Instant.parse("2026-07-31T00:00:00Z")
+    private val now = TEST_NOW
 
     private fun release(tag: String, ageDays: Int, hasAsset: Boolean = true) = SelectableRelease(
         version = ReleaseTagVersion.from(tag)!!,
@@ -126,6 +126,27 @@ class FirmwareReleaseSelectionTest {
             release("v4.30.0", ageDays = 20),
         )
         assertEquals("v4.31.1", selectRelease(releases, FirmwareUpdateChannel.Soaked, now)!!.version.raw)
+    }
+
+    @Test
+    fun soakBoundaryIsInclusiveAtExactlySevenDays() {
+        // A minor exactly SOAK_WINDOW old counts as soaked: pins the
+        // inclusive comparison so an operator flip cannot pass the suite.
+        val releases = listOf(release("v4.31.0", ageDays = 7))
+        assertEquals("v4.31.0", selectRelease(releases, FirmwareUpdateChannel.Soaked, now)!!.version.raw)
+    }
+
+    @Test
+    fun soakWindowRequiresTheFullSevenDays() {
+        // Pins the window length from below as well: an hour short of seven
+        // days is not soaked, so tuning SOAK_WINDOW fails a test on purpose
+        // instead of drifting silently.
+        val justUnder = SelectableRelease(
+            version = ReleaseTagVersion.from("v4.31.0")!!,
+            publishedAt = now - 7.days + 1.hours,
+            hasAsset = true,
+        )
+        assertNull(selectRelease(listOf(justUnder), FirmwareUpdateChannel.Soaked, now))
     }
 
     @Test

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheckRoutingTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheckRoutingTest.kt
@@ -1,12 +1,8 @@
 package coredevices.pebble.firmware
 
-import CoreAppVersion
 import com.russhwolf.settings.MapSettings
 import coredevices.pebble.Platform
-import coredevices.pebble.account.PebbleAccount
 import coredevices.pebble.services.Memfault
-import coredevices.pebble.services.PebbleAccountProvider
-import coredevices.pebble.services.PebbleHttpClient
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -15,12 +11,10 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
-import io.rebble.libpebblecommon.connection.FakeLibPebble
 import io.rebble.libpebblecommon.connection.FirmwareUpdateCheckResult
 import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
@@ -28,8 +22,6 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.fail
-import kotlin.time.Clock
-import kotlin.time.Instant
 
 /**
  * Pins the fork's doCheck routing: Core watches must use the GitHub checker
@@ -39,11 +31,6 @@ import kotlin.time.Instant
  */
 class FirmwareUpdateCheckRoutingTest {
 
-    private val now = Instant.parse("2026-07-31T00:00:00Z")
-    private val fixedClock = object : Clock {
-        override fun now(): Instant = this@FirmwareUpdateCheckRoutingTest.now
-    }
-
     private val testJson = Json { ignoreUnknownKeys = true }
 
     private fun failingClient(label: String) = HttpClient(MockEngine { request ->
@@ -52,48 +39,22 @@ class FirmwareUpdateCheckRoutingTest {
         install(ContentNegotiation) { json(testJson) }
     }
 
-    private fun respondingClient(body: String) = HttpClient(MockEngine { _ ->
-        respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
-    }) {
-        install(ContentNegotiation) { json(testJson) }
-    }
-
-    private class SignedOutAccounts : PebbleAccountProvider {
-        override fun get(): PebbleAccount = object : PebbleAccount {
-            override val loggedIn = MutableStateFlow<String?>(null)
-            override val devToken = MutableStateFlow<String?>(null)
-            override suspend fun setToken(token: String?, bootUrl: String?) {}
-            override suspend fun setDevPortalId() {}
-        }
-    }
-
-    private fun cohorts(client: HttpClient, expectations: FirmwareArtifactExpectations) = Cohorts(
-        httpClient = PebbleHttpClient(SignedOutAccounts(), client, lazy { FakeLibPebble() }),
-        appVersion = CoreAppVersion("0.0.0"),
-        expectations = expectations,
-    )
-
     private fun memfaultNeverContacted() =
         Memfault(failingClient("Memfault"), MapSettings(), Platform.Android, memfaultToken = null)
 
-    private val githubBody = """[{"tag_name":"v4.31.0","prerelease":false,"draft":false,
-        "published_at":"2026-07-21T00:00:00Z","assets":[{"name":"normal_asterix_v4.31.0.pbz",
-        "browser_download_url":"https://github.com/coredevices/PebbleOS/releases/download/v4.31.0/normal_asterix_v4.31.0.pbz",
-        "digest":"sha256:${"a".repeat(64)}","size":100}]}]""".replace("\n", "")
-
-    private val cohortsBody = """{"fw":{"normal":{"friendlyVersion":"v4.4.3-rbl","notes":"legacy notes",
-        "sha-256":"${"b".repeat(64)}","timestamp":1762930476,
-        "url":"https://binaries.rebble.io/fw/silk/Pebble-4.4.3-rbl-silk.pbz"}}}""".replace("\n", "")
+    private val githubBody = releaseList(
+        releaseJson("v4.31.0", 10, listOf(normalAsset("asterix", "v4.31.0", "sha256:" + "a".repeat(64), 100))),
+    )
 
     @Test
     fun coreWatchRoutesToGithubReleasesOnly() = runTest {
         val expectations = FirmwareArtifactExpectations()
         val check = FirmwareUpdateCheck(
             memfault = memfaultNeverContacted(),
-            cohorts = cohorts(failingClient("Cohorts"), expectations),
-            githubReleases = GithubReleases(respondingClient(githubBody), expectations, fixedClock),
+            cohorts = testCohorts(failingClient("Cohorts"), expectations),
+            githubReleases = GithubReleases(jsonRespondingClient(githubBody), expectations, fixedTestClock),
             channel = { FirmwareUpdateChannel.Soaked },
-            clock = fixedClock,
+            clock = fixedTestClock,
         )
         val result = check.checkForUpdates(
             testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"),
@@ -108,10 +69,10 @@ class FirmwareUpdateCheckRoutingTest {
         val expectations = FirmwareArtifactExpectations()
         val check = FirmwareUpdateCheck(
             memfault = memfaultNeverContacted(),
-            cohorts = cohorts(respondingClient(cohortsBody), expectations),
-            githubReleases = GithubReleases(failingClient("GitHub"), expectations, fixedClock),
+            cohorts = testCohorts(jsonRespondingClient(cohortsBody()), expectations),
+            githubReleases = GithubReleases(failingClient("GitHub"), expectations, fixedTestClock),
             channel = { FirmwareUpdateChannel.Soaked },
-            clock = fixedClock,
+            clock = fixedTestClock,
         )
         val result = check.checkForUpdates(
             testWatchInfo(WatchHardwarePlatform.PEBBLE_SILK, "v4.0.0"),
@@ -122,14 +83,10 @@ class FirmwareUpdateCheckRoutingTest {
     }
 
     /** Two main-line releases: v4.31.0 is soaked, v4.32.0 is 2 days old. */
-    private val twoChannelGithubBody = """[{"tag_name":"v4.32.0","prerelease":false,"draft":false,
-        "published_at":"2026-07-29T00:00:00Z","assets":[{"name":"normal_asterix_v4.32.0.pbz",
-        "browser_download_url":"https://github.com/coredevices/PebbleOS/releases/download/v4.32.0/normal_asterix_v4.32.0.pbz",
-        "digest":"sha256:${"c".repeat(64)}","size":100}]},
-        {"tag_name":"v4.31.0","prerelease":false,"draft":false,
-        "published_at":"2026-07-21T00:00:00Z","assets":[{"name":"normal_asterix_v4.31.0.pbz",
-        "browser_download_url":"https://github.com/coredevices/PebbleOS/releases/download/v4.31.0/normal_asterix_v4.31.0.pbz",
-        "digest":"sha256:${"a".repeat(64)}","size":100}]}]""".replace("\n", "")
+    private val twoChannelGithubBody = releaseList(
+        releaseJson("v4.32.0", 2, listOf(normalAsset("asterix", "v4.32.0", "sha256:" + "c".repeat(64), 100))),
+        releaseJson("v4.31.0", 10, listOf(normalAsset("asterix", "v4.31.0", "sha256:" + "a".repeat(64), 100))),
+    )
 
     @Test
     fun channelFlipInvalidatesTheCacheWithoutForce() = runTest {
@@ -147,10 +104,10 @@ class FirmwareUpdateCheckRoutingTest {
         }
         val check = FirmwareUpdateCheck(
             memfault = memfaultNeverContacted(),
-            cohorts = cohorts(failingClient("Cohorts"), expectations),
-            githubReleases = GithubReleases(client, expectations, fixedClock),
+            cohorts = testCohorts(failingClient("Cohorts"), expectations),
+            githubReleases = GithubReleases(client, expectations, fixedTestClock),
             channel = { channel },
-            clock = fixedClock,
+            clock = fixedTestClock,
         )
         val watch = testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0")
 
@@ -193,10 +150,10 @@ class FirmwareUpdateCheckRoutingTest {
         }
         val check = FirmwareUpdateCheck(
             memfault = memfaultNeverContacted(),
-            cohorts = cohorts(failingClient("Cohorts"), expectations),
-            githubReleases = GithubReleases(client, expectations, fixedClock),
+            cohorts = testCohorts(failingClient("Cohorts"), expectations),
+            githubReleases = GithubReleases(client, expectations, fixedTestClock),
             channel = { channel },
-            clock = fixedClock,
+            clock = fixedTestClock,
         )
         val watch = testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0")
 
@@ -222,16 +179,16 @@ class FirmwareUpdateCheckRoutingTest {
         val expectations = FirmwareArtifactExpectations()
         val client = HttpClient(MockEngine { _ ->
             cohortsRequests++
-            respond(cohortsBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+            respond(cohortsBody(), HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
         }) {
             install(ContentNegotiation) { json(testJson) }
         }
         val check = FirmwareUpdateCheck(
             memfault = memfaultNeverContacted(),
-            cohorts = cohorts(client, expectations),
-            githubReleases = GithubReleases(failingClient("GitHub"), expectations, fixedClock),
+            cohorts = testCohorts(client, expectations),
+            githubReleases = GithubReleases(failingClient("GitHub"), expectations, fixedTestClock),
             channel = { channel },
-            clock = fixedClock,
+            clock = fixedTestClock,
         )
         val watch = testWatchInfo(WatchHardwarePlatform.PEBBLE_SILK, "v4.0.0")
 

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheckRoutingTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheckRoutingTest.kt
@@ -1,0 +1,122 @@
+package coredevices.pebble.firmware
+
+import CoreAppVersion
+import com.russhwolf.settings.MapSettings
+import coredevices.pebble.Platform
+import coredevices.pebble.account.PebbleAccount
+import coredevices.pebble.services.Memfault
+import coredevices.pebble.services.PebbleAccountProvider
+import coredevices.pebble.services.PebbleHttpClient
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.rebble.libpebblecommon.connection.FakeLibPebble
+import io.rebble.libpebblecommon.connection.FirmwareUpdateCheckResult
+import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertIs
+import kotlin.test.fail
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+/**
+ * Pins the fork's doCheck routing: Core watches must use the GitHub checker
+ * and never touch cohorts (which rejects Core hardware) or Memfault (no token
+ * in fork builds; MemfaultTest pins that separately). Legacy watches must
+ * keep using cohorts and never touch GitHub.
+ */
+class FirmwareUpdateCheckRoutingTest {
+
+    private val now = Instant.parse("2026-07-31T00:00:00Z")
+    private val fixedClock = object : Clock {
+        override fun now(): Instant = this@FirmwareUpdateCheckRoutingTest.now
+    }
+
+    private val testJson = Json { ignoreUnknownKeys = true }
+
+    private fun failingClient(label: String) = HttpClient(MockEngine { request ->
+        fail("$label must not be contacted for this watch, but got a request to ${request.url}")
+    }) {
+        install(ContentNegotiation) { json(testJson) }
+    }
+
+    private fun respondingClient(body: String) = HttpClient(MockEngine { _ ->
+        respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+    }) {
+        install(ContentNegotiation) { json(testJson) }
+    }
+
+    private class SignedOutAccounts : PebbleAccountProvider {
+        override fun get(): PebbleAccount = object : PebbleAccount {
+            override val loggedIn = MutableStateFlow<String?>(null)
+            override val devToken = MutableStateFlow<String?>(null)
+            override suspend fun setToken(token: String?, bootUrl: String?) {}
+            override suspend fun setDevPortalId() {}
+        }
+    }
+
+    private fun cohorts(client: HttpClient, expectations: FirmwareArtifactExpectations) = Cohorts(
+        httpClient = PebbleHttpClient(SignedOutAccounts(), client, lazy { FakeLibPebble() }),
+        appVersion = CoreAppVersion("0.0.0"),
+        expectations = expectations,
+    )
+
+    private fun memfaultNeverContacted() =
+        Memfault(failingClient("Memfault"), MapSettings(), Platform.Android, memfaultToken = null)
+
+    private val githubBody = """[{"tag_name":"v4.31.0","prerelease":false,"draft":false,
+        "published_at":"2026-07-21T00:00:00Z","assets":[{"name":"normal_asterix_v4.31.0.pbz",
+        "browser_download_url":"https://github.com/coredevices/PebbleOS/releases/download/v4.31.0/normal_asterix_v4.31.0.pbz",
+        "digest":"sha256:${"a".repeat(64)}","size":100}]}]""".replace("\n", "")
+
+    private val cohortsBody = """{"fw":{"normal":{"friendlyVersion":"v4.4.3-rbl","notes":"legacy notes",
+        "sha-256":"${"b".repeat(64)}","timestamp":1762930476,
+        "url":"https://binaries.rebble.io/fw/silk/Pebble-4.4.3-rbl-silk.pbz"}}}""".replace("\n", "")
+
+    @Test
+    fun coreWatchRoutesToGithubReleasesOnly() = runTest {
+        val expectations = FirmwareArtifactExpectations()
+        val check = FirmwareUpdateCheck(
+            memfault = memfaultNeverContacted(),
+            cohorts = cohorts(failingClient("Cohorts"), expectations),
+            githubReleases = GithubReleases(
+                respondingClient(githubBody), expectations, { FirmwareUpdateChannel.Soaked }, fixedClock,
+            ),
+            clock = fixedClock,
+        )
+        val result = check.checkForUpdates(
+            testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"),
+            force = false,
+        )
+        val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
+        assertContains(update.url, "normal_asterix_v4.31.0.pbz")
+    }
+
+    @Test
+    fun legacyWatchRoutesToCohortsOnly() = runTest {
+        val expectations = FirmwareArtifactExpectations()
+        val check = FirmwareUpdateCheck(
+            memfault = memfaultNeverContacted(),
+            cohorts = cohorts(respondingClient(cohortsBody), expectations),
+            githubReleases = GithubReleases(
+                failingClient("GitHub"), expectations, { FirmwareUpdateChannel.Soaked }, fixedClock,
+            ),
+            clock = fixedClock,
+        )
+        val result = check.checkForUpdates(
+            testWatchInfo(WatchHardwarePlatform.PEBBLE_SILK, "v4.0.0"),
+            force = false,
+        )
+        val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
+        assertContains(update.url, "binaries.rebble.io")
+    }
+}

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheckRoutingTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheckRoutingTest.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.fail
 import kotlin.time.Clock
@@ -118,5 +119,79 @@ class FirmwareUpdateCheckRoutingTest {
         )
         val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
         assertContains(update.url, "binaries.rebble.io")
+    }
+
+    /** Two main-line releases: v4.31.0 is soaked, v4.32.0 is 2 days old. */
+    private val twoChannelGithubBody = """[{"tag_name":"v4.32.0","prerelease":false,"draft":false,
+        "published_at":"2026-07-29T00:00:00Z","assets":[{"name":"normal_asterix_v4.32.0.pbz",
+        "browser_download_url":"https://github.com/coredevices/PebbleOS/releases/download/v4.32.0/normal_asterix_v4.32.0.pbz",
+        "digest":"sha256:${"c".repeat(64)}","size":100}]},
+        {"tag_name":"v4.31.0","prerelease":false,"draft":false,
+        "published_at":"2026-07-21T00:00:00Z","assets":[{"name":"normal_asterix_v4.31.0.pbz",
+        "browser_download_url":"https://github.com/coredevices/PebbleOS/releases/download/v4.31.0/normal_asterix_v4.31.0.pbz",
+        "digest":"sha256:${"a".repeat(64)}","size":100}]}]""".replace("\n", "")
+
+    @Test
+    fun channelFlipInvalidatesTheCacheWithoutForce() = runTest {
+        // Regression: the cache key must include the channel, or flipping the
+        // Early setting keeps serving the other channel's cached result until
+        // the TTL expires (no UI path forces a check).
+        var channel = FirmwareUpdateChannel.Soaked
+        var githubRequests = 0
+        val expectations = FirmwareArtifactExpectations()
+        val client = HttpClient(MockEngine { _ ->
+            githubRequests++
+            respond(twoChannelGithubBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }) {
+            install(ContentNegotiation) { json(testJson) }
+        }
+        val check = FirmwareUpdateCheck(
+            memfault = memfaultNeverContacted(),
+            cohorts = cohorts(failingClient("Cohorts"), expectations),
+            githubReleases = GithubReleases(client, expectations, { channel }, fixedClock),
+            clock = fixedClock,
+        )
+        val watch = testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0")
+
+        val soaked = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(check.checkForUpdates(watch, force = false))
+        assertContains(soaked.url, "v4.31.0")
+        check.checkForUpdates(watch, force = false)
+        assertEquals(1, githubRequests)
+
+        channel = FirmwareUpdateChannel.Early
+        val early = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(check.checkForUpdates(watch, force = false))
+        assertContains(early.url, "v4.32.0")
+        assertEquals(2, githubRequests)
+
+        // Flipping back reuses the still-valid Soaked entry.
+        channel = FirmwareUpdateChannel.Soaked
+        val soakedAgain = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(check.checkForUpdates(watch, force = false))
+        assertContains(soakedAgain.url, "v4.31.0")
+        assertEquals(2, githubRequests)
+    }
+
+    @Test
+    fun channelFlipDoesNotEvictLegacyWatchCache() = runTest {
+        var channel = FirmwareUpdateChannel.Soaked
+        var cohortsRequests = 0
+        val expectations = FirmwareArtifactExpectations()
+        val client = HttpClient(MockEngine { _ ->
+            cohortsRequests++
+            respond(cohortsBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }) {
+            install(ContentNegotiation) { json(testJson) }
+        }
+        val check = FirmwareUpdateCheck(
+            memfault = memfaultNeverContacted(),
+            cohorts = cohorts(client, expectations),
+            githubReleases = GithubReleases(failingClient("GitHub"), expectations, { channel }, fixedClock),
+            clock = fixedClock,
+        )
+        val watch = testWatchInfo(WatchHardwarePlatform.PEBBLE_SILK, "v4.0.0")
+
+        assertIs<FirmwareUpdateCheckResult.FoundUpdate>(check.checkForUpdates(watch, force = false))
+        channel = FirmwareUpdateChannel.Early
+        assertIs<FirmwareUpdateCheckResult.FoundUpdate>(check.checkForUpdates(watch, force = false))
+        assertEquals(1, cohortsRequests)
     }
 }

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheckRoutingTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/FirmwareUpdateCheckRoutingTest.kt
@@ -18,6 +18,8 @@ import io.ktor.serialization.kotlinx.json.json
 import io.rebble.libpebblecommon.connection.FakeLibPebble
 import io.rebble.libpebblecommon.connection.FirmwareUpdateCheckResult
 import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -89,9 +91,8 @@ class FirmwareUpdateCheckRoutingTest {
         val check = FirmwareUpdateCheck(
             memfault = memfaultNeverContacted(),
             cohorts = cohorts(failingClient("Cohorts"), expectations),
-            githubReleases = GithubReleases(
-                respondingClient(githubBody), expectations, { FirmwareUpdateChannel.Soaked }, fixedClock,
-            ),
+            githubReleases = GithubReleases(respondingClient(githubBody), expectations, fixedClock),
+            channel = { FirmwareUpdateChannel.Soaked },
             clock = fixedClock,
         )
         val result = check.checkForUpdates(
@@ -108,9 +109,8 @@ class FirmwareUpdateCheckRoutingTest {
         val check = FirmwareUpdateCheck(
             memfault = memfaultNeverContacted(),
             cohorts = cohorts(respondingClient(cohortsBody), expectations),
-            githubReleases = GithubReleases(
-                failingClient("GitHub"), expectations, { FirmwareUpdateChannel.Soaked }, fixedClock,
-            ),
+            githubReleases = GithubReleases(failingClient("GitHub"), expectations, fixedClock),
+            channel = { FirmwareUpdateChannel.Soaked },
             clock = fixedClock,
         )
         val result = check.checkForUpdates(
@@ -148,7 +148,8 @@ class FirmwareUpdateCheckRoutingTest {
         val check = FirmwareUpdateCheck(
             memfault = memfaultNeverContacted(),
             cohorts = cohorts(failingClient("Cohorts"), expectations),
-            githubReleases = GithubReleases(client, expectations, { channel }, fixedClock),
+            githubReleases = GithubReleases(client, expectations, fixedClock),
+            channel = { channel },
             clock = fixedClock,
         )
         val watch = testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0")
@@ -171,6 +172,50 @@ class FirmwareUpdateCheckRoutingTest {
     }
 
     @Test
+    fun midFlightChannelFlipDoesNotPoisonTheOtherChannelsCache() = runTest {
+        // Regression: the channel is read exactly once per check and serves
+        // both the cache key and the release selection. A toggle flip while
+        // the fetch is in flight must not cache the new channel's selection
+        // under the old channel's key (background checks overlap freely with
+        // settings visits).
+        var channel = FirmwareUpdateChannel.Soaked
+        var githubRequests = 0
+        val fetchStarted = CompletableDeferred<Unit>()
+        val releaseFetch = CompletableDeferred<Unit>()
+        val expectations = FirmwareArtifactExpectations()
+        val client = HttpClient(MockEngine { _ ->
+            githubRequests++
+            fetchStarted.complete(Unit)
+            releaseFetch.await()
+            respond(twoChannelGithubBody, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }) {
+            install(ContentNegotiation) { json(testJson) }
+        }
+        val check = FirmwareUpdateCheck(
+            memfault = memfaultNeverContacted(),
+            cohorts = cohorts(failingClient("Cohorts"), expectations),
+            githubReleases = GithubReleases(client, expectations, fixedClock),
+            channel = { channel },
+            clock = fixedClock,
+        )
+        val watch = testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0")
+
+        val inFlight = async { check.checkForUpdates(watch, force = false) }
+        fetchStarted.await()
+        channel = FirmwareUpdateChannel.Early // flips while the fetch is in flight
+        releaseFetch.complete(Unit)
+        val first = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(inFlight.await())
+        // The selection must match the channel the check started with.
+        assertContains(first.url, "v4.31.0")
+
+        // And the entry cached for Soaked must be the Soaked result.
+        channel = FirmwareUpdateChannel.Soaked
+        val cached = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(check.checkForUpdates(watch, force = false))
+        assertContains(cached.url, "v4.31.0")
+        assertEquals(1, githubRequests)
+    }
+
+    @Test
     fun channelFlipDoesNotEvictLegacyWatchCache() = runTest {
         var channel = FirmwareUpdateChannel.Soaked
         var cohortsRequests = 0
@@ -184,7 +229,8 @@ class FirmwareUpdateCheckRoutingTest {
         val check = FirmwareUpdateCheck(
             memfault = memfaultNeverContacted(),
             cohorts = cohorts(client, expectations),
-            githubReleases = GithubReleases(failingClient("GitHub"), expectations, { channel }, fixedClock),
+            githubReleases = GithubReleases(failingClient("GitHub"), expectations, fixedClock),
+            channel = { channel },
             clock = fixedClock,
         )
         val watch = testWatchInfo(WatchHardwarePlatform.PEBBLE_SILK, "v4.0.0")

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/GithubReleasesTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/GithubReleasesTest.kt
@@ -77,8 +77,6 @@ class GithubReleasesTest {
     private fun checker(
         body: String,
         status: HttpStatusCode = HttpStatusCode.OK,
-        channel: FirmwareUpdateChannel = FirmwareUpdateChannel.Soaked,
-        channelProvider: () -> FirmwareUpdateChannel = { channel },
         expectations: FirmwareArtifactExpectations = FirmwareArtifactExpectations(),
         requests: MutableList<HttpRequestData> = mutableListOf(),
     ): GithubReleases {
@@ -90,14 +88,14 @@ class GithubReleasesTest {
                 json(Json { ignoreUnknownKeys = true })
             }
         }
-        return GithubReleases(client, expectations, channelProvider, fixedClock)
+        return GithubReleases(client, expectations, fixedClock)
     }
 
     @Test
     fun soakedOffersSoakedMinorHotfixAndRecordsExpectation() = runTest {
         val expectations = FirmwareArtifactExpectations()
         val checker = checker(standardBody(), expectations = expectations)
-        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"), FirmwareUpdateChannel.Soaked)
         val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
         // Minor 4.31 soaked (first release 10 days old), hotfix taken despite
         // being 1 day old; 4.32 (2 days) not soaked; factory tag ignored.
@@ -112,8 +110,8 @@ class GithubReleasesTest {
 
     @Test
     fun earlyOffersNewestMainLineTagNeverTheFactoryTag() = runTest {
-        val checker = checker(standardBody(), channel = FirmwareUpdateChannel.Early)
-        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        val checker = checker(standardBody())
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"), FirmwareUpdateChannel.Early)
         val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
         // The factory hotfix v4.9.142.4 is the most recent publish (it would
         // hold GitHub's Latest badge) and has the biggest patch number.
@@ -122,22 +120,29 @@ class GithubReleasesTest {
 
     @Test
     fun earlyChannelSettingSwitchesTheOfferBetweenChecks() = runTest {
-        // The real wiring hands GithubReleases a provider that re-reads
-        // CoreConfig on every check; flipping the setting must change the
-        // offer without recreating the checker.
+        // The channel is read from CoreConfig per check (by
+        // FirmwareUpdateCheck in production) and passed in; flipping the
+        // setting between checks must change the offer without recreating
+        // the checker.
         var config = CoreConfig()
-        val checker = checker(standardBody(), channelProvider = { config.firmwareUpdateChannel() })
+        val checker = checker(standardBody())
         val watch = testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0")
 
-        val soaked = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(checker.getLatestFirmware(watch))
+        val soaked = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(
+            checker.getLatestFirmware(watch, config.firmwareUpdateChannel()),
+        )
         assertEquals("v4.31.1", soaked.version.stringVersion)
 
         config = config.copy(firmwareUpdatesEarlyChannel = true)
-        val early = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(checker.getLatestFirmware(watch))
+        val early = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(
+            checker.getLatestFirmware(watch, config.firmwareUpdateChannel()),
+        )
         assertEquals("v4.32.0", early.version.stringVersion)
 
         config = config.copy(firmwareUpdatesEarlyChannel = false)
-        val backToSoaked = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(checker.getLatestFirmware(watch))
+        val backToSoaked = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(
+            checker.getLatestFirmware(watch, config.firmwareUpdateChannel()),
+        )
         assertEquals("v4.31.1", backToSoaked.version.stringVersion)
     }
 
@@ -148,7 +153,7 @@ class GithubReleasesTest {
         // same version "newer" on its timestamp tiebreak. The checker must
         // compare tags and say no.
         val checker = checker(standardBody())
-        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.31.1"))
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.31.1"), FirmwareUpdateChannel.Soaked)
         assertIs<FirmwareUpdateCheckResult.FoundNoUpdate>(result)
     }
 
@@ -157,7 +162,7 @@ class GithubReleasesTest {
         // Running the Early tier, then switching back to Soaked: the soaked
         // candidate is older than the running firmware.
         val checker = checker(standardBody())
-        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.32.0"))
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.32.0"), FirmwareUpdateChannel.Soaked)
         assertIs<FirmwareUpdateCheckResult.FoundNoUpdate>(result)
     }
 
@@ -166,10 +171,12 @@ class GithubReleasesTest {
         val checker = checker(standardBody())
         val equalVersion = checker.getLatestFirmware(
             testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.31.1", isRecovery = true),
+            FirmwareUpdateChannel.Soaked,
         )
         assertIs<FirmwareUpdateCheckResult.FoundUpdate>(equalVersion)
         val unparseable = checker.getLatestFirmware(
             testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "unknown", isRecovery = true),
+            FirmwareUpdateChannel.Soaked,
         )
         assertIs<FirmwareUpdateCheckResult.FoundUpdate>(unparseable)
     }
@@ -177,7 +184,7 @@ class GithubReleasesTest {
     @Test
     fun unparseableRunningVersionFailsClosed() = runTest {
         val checker = checker(standardBody())
-        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "unknown"))
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "unknown"), FirmwareUpdateChannel.Soaked)
         assertIs<FirmwareUpdateCheckResult.UpdateCheckFailed>(result)
     }
 
@@ -190,7 +197,7 @@ class GithubReleasesTest {
         ).joinToString(",") + "]"
         val expectations = FirmwareArtifactExpectations()
         val checker = checker(body, expectations = expectations)
-        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"), FirmwareUpdateChannel.Soaked)
         val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
         // Soaked target is 4.31.1 (digest null) and 4.31.0's digest is
         // malformed; the nearest newer verifiable release wins.
@@ -205,7 +212,7 @@ class GithubReleasesTest {
             listOf(normalAsset("obelix_pvt", "v4.31.0", digest('a'), 111)),
         ) + "]"
         val checker = checker(body)
-        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"), FirmwareUpdateChannel.Soaked)
         assertIs<FirmwareUpdateCheckResult.UpdateCheckFailed>(result)
     }
 
@@ -217,7 +224,7 @@ class GithubReleasesTest {
             releaseJson("v4.31.0", 10, listOf(normalAsset("asterix", "v4.31.0", digest('c'), 333))),
         ).joinToString(",") + "]"
         val checker = checker(body)
-        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"), FirmwareUpdateChannel.Soaked)
         val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
         assertEquals("v4.31.0", update.version.stringVersion)
     }
@@ -225,7 +232,7 @@ class GithubReleasesTest {
     @Test
     fun rateLimitFailsWithARetryableMessage() = runTest {
         val checker = checker("""{"message":"API rate limit exceeded"}""", status = HttpStatusCode.Forbidden)
-        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"), FirmwareUpdateChannel.Soaked)
         val failure = assertIs<FirmwareUpdateCheckResult.UpdateCheckFailed>(result)
         assertContains(failure.error, "rate limited")
     }
@@ -233,11 +240,11 @@ class GithubReleasesTest {
     @Test
     fun serverErrorsAndMalformedBodiesFailClosed() = runTest {
         val serverError = checker("oops", status = HttpStatusCode.InternalServerError)
-            .getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+            .getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"), FirmwareUpdateChannel.Soaked)
         assertIs<FirmwareUpdateCheckResult.UpdateCheckFailed>(serverError)
 
         val notJson = checker("this is not json")
-            .getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+            .getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"), FirmwareUpdateChannel.Soaked)
         assertIs<FirmwareUpdateCheckResult.UpdateCheckFailed>(notJson)
     }
 
@@ -246,10 +253,8 @@ class GithubReleasesTest {
         val client = HttpClient(MockEngine { throw IOException("network down") }) {
             install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
         }
-        val checker = GithubReleases(
-            client, FirmwareArtifactExpectations(), { FirmwareUpdateChannel.Soaked }, fixedClock,
-        )
-        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        val checker = GithubReleases(client, FirmwareArtifactExpectations(), fixedClock)
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"), FirmwareUpdateChannel.Soaked)
         assertIs<FirmwareUpdateCheckResult.UpdateCheckFailed>(result)
     }
 
@@ -257,7 +262,7 @@ class GithubReleasesTest {
     fun requestIsAnonymousAndTargetsTheReleaseList() = runTest {
         val requests = mutableListOf<HttpRequestData>()
         val checker = checker(standardBody(), requests = requests)
-        checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"), FirmwareUpdateChannel.Soaked)
         assertEquals(1, requests.size)
         val request = requests.single()
         assertEquals("api.github.com", request.url.host)
@@ -278,7 +283,7 @@ class GithubReleasesTest {
     fun nothingIsRecordedWhenNoUpdateIsOffered() = runTest {
         val expectations = FirmwareArtifactExpectations()
         val checker = checker(standardBody(), expectations = expectations)
-        checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.31.1"))
+        checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.31.1"), FirmwareUpdateChannel.Soaked)
         assertNull(expectations.lookup("https://github.com/coredevices/PebbleOS/releases/download/x/normal_asterix_v4.31.1.pbz"))
     }
 }

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/GithubReleasesTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/GithubReleasesTest.kt
@@ -1,0 +1,261 @@
+package coredevices.pebble.firmware
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.rebble.libpebblecommon.connection.FirmwareUpdateCheckResult
+import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
+import kotlinx.io.IOException
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
+
+/**
+ * Pins the GitHub-releases checker against the traps found during research:
+ * GitHub's Latest badge and publish dates must never drive selection, factory
+ * tags are never offered, an equal version is never re-offered (upstream's
+ * timestamp tiebreak would re-offer forever), unverifiable assets are treated
+ * as absent, and the request must carry zero device data.
+ */
+class GithubReleasesTest {
+
+    private val now = Instant.parse("2026-07-31T00:00:00Z")
+    private val fixedClock = object : Clock {
+        override fun now(): Instant = this@GithubReleasesTest.now
+    }
+
+    private fun digest(char: Char) = "sha256:" + char.toString().repeat(64)
+    private fun hex(char: Char) = char.toString().repeat(64)
+
+    private fun assetJson(name: String, digestValue: String?, size: Long) = buildString {
+        append("""{"name":"$name",""")
+        append(""""browser_download_url":"https://github.com/coredevices/PebbleOS/releases/download/x/$name",""")
+        append(""""digest":${if (digestValue != null) "\"$digestValue\"" else "null"},""")
+        append(""""size":$size,"content_type":"application/octet-stream"}""")
+    }
+
+    private fun releaseJson(
+        tag: String,
+        ageDays: Int,
+        assets: List<String>,
+        prerelease: Boolean = false,
+        draft: Boolean = false,
+    ) = buildString {
+        append("""{"tag_name":"$tag","html_url":"https://github.com/x","prerelease":$prerelease,"draft":$draft,""")
+        append(""""published_at":"${now - ageDays.days}","body":"",""")
+        append(""""assets":[${assets.joinToString(",")}]}""")
+    }
+
+    private fun normalAsset(revision: String, tag: String, digestValue: String? , size: Long) =
+        assetJson("normal_${revision}_$tag.pbz", digestValue, size)
+
+    /** Two main-line minors, one soaked; a factory hotfix is the newest publish. */
+    private fun standardBody() = "[" + listOf(
+        releaseJson("v4.9.142.4", 0, listOf(normalAsset("asterix", "v4.9.142.4", digest('d'), 400))),
+        releaseJson("v4.31.1", 1, listOf(normalAsset("asterix", "v4.31.1", digest('b'), 222))),
+        releaseJson("v4.32.0", 2, listOf(normalAsset("asterix", "v4.32.0", digest('a'), 111))),
+        releaseJson("v4.31.0", 10, listOf(normalAsset("asterix", "v4.31.0", digest('c'), 333))),
+        releaseJson("v4.30.0", 20, listOf(normalAsset("asterix", "v4.30.0", digest('e'), 555))),
+    ).joinToString(",") + "]"
+
+    private fun checker(
+        body: String,
+        status: HttpStatusCode = HttpStatusCode.OK,
+        channel: FirmwareUpdateChannel = FirmwareUpdateChannel.Soaked,
+        expectations: FirmwareArtifactExpectations = FirmwareArtifactExpectations(),
+        requests: MutableList<HttpRequestData> = mutableListOf(),
+    ): GithubReleases {
+        val client = HttpClient(MockEngine { request ->
+            requests += request
+            respond(body, status, headersOf(HttpHeaders.ContentType, "application/json"))
+        }) {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+        return GithubReleases(client, expectations, { channel }, fixedClock)
+    }
+
+    @Test
+    fun soakedOffersSoakedMinorHotfixAndRecordsExpectation() = runTest {
+        val expectations = FirmwareArtifactExpectations()
+        val checker = checker(standardBody(), expectations = expectations)
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
+        // Minor 4.31 soaked (first release 10 days old), hotfix taken despite
+        // being 1 day old; 4.32 (2 days) not soaked; factory tag ignored.
+        assertEquals("v4.31.1", update.version.stringVersion)
+        assertContains(update.url, "normal_asterix_v4.31.1.pbz")
+        assertEquals("", update.notes)
+        assertEquals(
+            ExpectedFirmwareArtifact(hex('b'), 222, "v4.31.1"),
+            expectations.lookup(update.url),
+        )
+    }
+
+    @Test
+    fun earlyOffersNewestMainLineTagNeverTheFactoryTag() = runTest {
+        val checker = checker(standardBody(), channel = FirmwareUpdateChannel.Early)
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
+        // The factory hotfix v4.9.142.4 is the most recent publish (it would
+        // hold GitHub's Latest badge) and has the biggest patch number.
+        assertEquals("v4.32.0", update.version.stringVersion)
+    }
+
+    @Test
+    fun equalVersionIsNeverReOffered() = runTest {
+        // The release's published_at is later than any firmware build
+        // timestamp, so upstream FirmwareVersion comparison would call the
+        // same version "newer" on its timestamp tiebreak. The checker must
+        // compare tags and say no.
+        val checker = checker(standardBody())
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.31.1"))
+        assertIs<FirmwareUpdateCheckResult.FoundNoUpdate>(result)
+    }
+
+    @Test
+    fun downgradeIsNeverOffered() = runTest {
+        // Running the Early tier, then switching back to Soaked: the soaked
+        // candidate is older than the running firmware.
+        val checker = checker(standardBody())
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.32.0"))
+        assertIs<FirmwareUpdateCheckResult.FoundNoUpdate>(result)
+    }
+
+    @Test
+    fun recoveryIsAlwaysOffered() = runTest {
+        val checker = checker(standardBody())
+        val equalVersion = checker.getLatestFirmware(
+            testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.31.1", isRecovery = true),
+        )
+        assertIs<FirmwareUpdateCheckResult.FoundUpdate>(equalVersion)
+        val unparseable = checker.getLatestFirmware(
+            testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "unknown", isRecovery = true),
+        )
+        assertIs<FirmwareUpdateCheckResult.FoundUpdate>(unparseable)
+    }
+
+    @Test
+    fun unparseableRunningVersionFailsClosed() = runTest {
+        val checker = checker(standardBody())
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "unknown"))
+        assertIs<FirmwareUpdateCheckResult.UpdateCheckFailed>(result)
+    }
+
+    @Test
+    fun unverifiableAssetIsTreatedAsAbsentAndSelectionWalksForward() = runTest {
+        val body = "[" + listOf(
+            releaseJson("v4.32.0", 2, listOf(normalAsset("asterix", "v4.32.0", digest('a'), 111))),
+            releaseJson("v4.31.1", 1, listOf(normalAsset("asterix", "v4.31.1", null, 222))),
+            releaseJson("v4.31.0", 10, listOf(normalAsset("asterix", "v4.31.0", "not-a-digest", 333))),
+        ).joinToString(",") + "]"
+        val expectations = FirmwareArtifactExpectations()
+        val checker = checker(body, expectations = expectations)
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
+        // Soaked target is 4.31.1 (digest null) and 4.31.0's digest is
+        // malformed; the nearest newer verifiable release wins.
+        assertEquals("v4.32.0", update.version.stringVersion)
+        assertEquals(ExpectedFirmwareArtifact(hex('a'), 111, "v4.32.0"), expectations.lookup(update.url))
+    }
+
+    @Test
+    fun noAssetForThisHardwareFailsClosed() = runTest {
+        val body = "[" + releaseJson(
+            "v4.31.0", 10,
+            listOf(normalAsset("obelix_pvt", "v4.31.0", digest('a'), 111)),
+        ) + "]"
+        val checker = checker(body)
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        assertIs<FirmwareUpdateCheckResult.UpdateCheckFailed>(result)
+    }
+
+    @Test
+    fun prereleaseAndDraftAreSkipped() = runTest {
+        val body = "[" + listOf(
+            releaseJson("v4.33.0", 10, listOf(normalAsset("asterix", "v4.33.0", digest('a'), 111)), prerelease = true),
+            releaseJson("v4.34.0", 10, listOf(normalAsset("asterix", "v4.34.0", digest('b'), 222)), draft = true),
+            releaseJson("v4.31.0", 10, listOf(normalAsset("asterix", "v4.31.0", digest('c'), 333))),
+        ).joinToString(",") + "]"
+        val checker = checker(body)
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
+        assertEquals("v4.31.0", update.version.stringVersion)
+    }
+
+    @Test
+    fun rateLimitFailsWithARetryableMessage() = runTest {
+        val checker = checker("""{"message":"API rate limit exceeded"}""", status = HttpStatusCode.Forbidden)
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        val failure = assertIs<FirmwareUpdateCheckResult.UpdateCheckFailed>(result)
+        assertContains(failure.error, "rate limited")
+    }
+
+    @Test
+    fun serverErrorsAndMalformedBodiesFailClosed() = runTest {
+        val serverError = checker("oops", status = HttpStatusCode.InternalServerError)
+            .getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        assertIs<FirmwareUpdateCheckResult.UpdateCheckFailed>(serverError)
+
+        val notJson = checker("this is not json")
+            .getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        assertIs<FirmwareUpdateCheckResult.UpdateCheckFailed>(notJson)
+    }
+
+    @Test
+    fun networkErrorFailsClosed() = runTest {
+        val client = HttpClient(MockEngine { throw IOException("network down") }) {
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+        val checker = GithubReleases(
+            client, FirmwareArtifactExpectations(), { FirmwareUpdateChannel.Soaked }, fixedClock,
+        )
+        val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        assertIs<FirmwareUpdateCheckResult.UpdateCheckFailed>(result)
+    }
+
+    @Test
+    fun requestIsAnonymousAndTargetsTheReleaseList() = runTest {
+        val requests = mutableListOf<HttpRequestData>()
+        val checker = checker(standardBody(), requests = requests)
+        checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"))
+        assertEquals(1, requests.size)
+        val request = requests.single()
+        assertEquals("api.github.com", request.url.host)
+        assertEquals("/repos/coredevices/PebbleOS/releases", request.url.encodedPath)
+        // The only query parameter is the page size: no hardware, serial, or
+        // version leaves the device.
+        assertEquals(setOf("per_page"), request.url.parameters.names())
+        val urlText = request.url.toString()
+        assertFalse(urlText.contains(TEST_WATCH_SERIAL))
+        assertFalse(urlText.contains("asterix"))
+        assertEquals("application/vnd.github+json", request.headers["Accept"])
+        assertTrue(request.headers.names().none { name ->
+            request.headers.getAll(name).orEmpty().any { it.contains(TEST_WATCH_SERIAL) }
+        })
+    }
+
+    @Test
+    fun nothingIsRecordedWhenNoUpdateIsOffered() = runTest {
+        val expectations = FirmwareArtifactExpectations()
+        val checker = checker(standardBody(), expectations = expectations)
+        checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.31.1"))
+        assertNull(expectations.lookup("https://github.com/coredevices/PebbleOS/releases/download/x/normal_asterix_v4.31.1.pbz"))
+    }
+}

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/GithubReleasesTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/GithubReleasesTest.kt
@@ -22,9 +22,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlin.time.Clock
-import kotlin.time.Duration.Companion.days
-import kotlin.time.Instant
 
 /**
  * Pins the GitHub-releases checker against the traps found during research:
@@ -35,35 +32,8 @@ import kotlin.time.Instant
  */
 class GithubReleasesTest {
 
-    private val now = Instant.parse("2026-07-31T00:00:00Z")
-    private val fixedClock = object : Clock {
-        override fun now(): Instant = this@GithubReleasesTest.now
-    }
-
     private fun digest(char: Char) = "sha256:" + char.toString().repeat(64)
     private fun hex(char: Char) = char.toString().repeat(64)
-
-    private fun assetJson(name: String, digestValue: String?, size: Long) = buildString {
-        append("""{"name":"$name",""")
-        append(""""browser_download_url":"https://github.com/coredevices/PebbleOS/releases/download/x/$name",""")
-        append(""""digest":${if (digestValue != null) "\"$digestValue\"" else "null"},""")
-        append(""""size":$size,"content_type":"application/octet-stream"}""")
-    }
-
-    private fun releaseJson(
-        tag: String,
-        ageDays: Int,
-        assets: List<String>,
-        prerelease: Boolean = false,
-        draft: Boolean = false,
-    ) = buildString {
-        append("""{"tag_name":"$tag","html_url":"https://github.com/x","prerelease":$prerelease,"draft":$draft,""")
-        append(""""published_at":"${now - ageDays.days}","body":"",""")
-        append(""""assets":[${assets.joinToString(",")}]}""")
-    }
-
-    private fun normalAsset(revision: String, tag: String, digestValue: String? , size: Long) =
-        assetJson("normal_${revision}_$tag.pbz", digestValue, size)
 
     /** Two main-line minors, one soaked; a factory hotfix is the newest publish. */
     private fun standardBody() = "[" + listOf(
@@ -88,7 +58,7 @@ class GithubReleasesTest {
                 json(Json { ignoreUnknownKeys = true })
             }
         }
-        return GithubReleases(client, expectations, fixedClock)
+        return GithubReleases(client, expectations, fixedTestClock)
     }
 
     @Test
@@ -206,6 +176,42 @@ class GithubReleasesTest {
     }
 
     @Test
+    fun perEntryMalformedReleasesAreSkippedNotFatal() = runTest {
+        // The skip-vs-fail split is deliberate: one odd upstream entry (bad
+        // tag, missing or garbage date) must cost only itself, or a single
+        // unusual tag would break every Core watch's update check.
+        val body = "[" + listOf(
+            """{"tag_name":"totally-unparseable","prerelease":false,"draft":false,""" +
+                """"published_at":"${TEST_NOW}","assets":[]}""",
+            """{"tag_name":"v4.33.0","prerelease":false,"draft":false,""" +
+                """"assets":[${normalAsset("asterix", "v4.33.0", digest('f'), 111)}]}""",
+            """{"tag_name":"v4.34.0","prerelease":false,"draft":false,"published_at":"not-a-date",""" +
+                """"assets":[${normalAsset("asterix", "v4.34.0", digest('f'), 111)}]}""",
+            releaseJson("v4.31.0", 10, listOf(normalAsset("asterix", "v4.31.0", digest('c'), 333))),
+        ).joinToString(",") + "]"
+        val result = checker(body).getLatestFirmware(
+            testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"), FirmwareUpdateChannel.Soaked,
+        )
+        val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
+        assertEquals("v4.31.0", update.version.stringVersion)
+    }
+
+    @Test
+    fun zeroSizeAssetIsTreatedAsUnverifiable() = runTest {
+        // A zero-size asset cannot be size-verified, so it counts as absent
+        // and selection moves on, like the null/garbage digest cases.
+        val body = "[" + listOf(
+            releaseJson("v4.32.0", 2, listOf(normalAsset("asterix", "v4.32.0", digest('a'), 0))),
+            releaseJson("v4.31.1", 3, listOf(normalAsset("asterix", "v4.31.1", digest('b'), 222))),
+        ).joinToString(",") + "]"
+        val result = checker(body).getLatestFirmware(
+            testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"), FirmwareUpdateChannel.Early,
+        )
+        val update = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(result)
+        assertEquals("v4.31.1", update.version.stringVersion)
+    }
+
+    @Test
     fun noAssetForThisHardwareFailsClosed() = runTest {
         val body = "[" + releaseJson(
             "v4.31.0", 10,
@@ -253,7 +259,7 @@ class GithubReleasesTest {
         val client = HttpClient(MockEngine { throw IOException("network down") }) {
             install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
         }
-        val checker = GithubReleases(client, FirmwareArtifactExpectations(), fixedClock)
+        val checker = GithubReleases(client, FirmwareArtifactExpectations(), fixedTestClock)
         val result = checker.getLatestFirmware(testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0"), FirmwareUpdateChannel.Soaked)
         assertIs<FirmwareUpdateCheckResult.UpdateCheckFailed>(result)
     }

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/GithubReleasesTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/GithubReleasesTest.kt
@@ -1,5 +1,6 @@
 package coredevices.pebble.firmware
 
+import coredevices.util.CoreConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -77,6 +78,7 @@ class GithubReleasesTest {
         body: String,
         status: HttpStatusCode = HttpStatusCode.OK,
         channel: FirmwareUpdateChannel = FirmwareUpdateChannel.Soaked,
+        channelProvider: () -> FirmwareUpdateChannel = { channel },
         expectations: FirmwareArtifactExpectations = FirmwareArtifactExpectations(),
         requests: MutableList<HttpRequestData> = mutableListOf(),
     ): GithubReleases {
@@ -88,7 +90,7 @@ class GithubReleasesTest {
                 json(Json { ignoreUnknownKeys = true })
             }
         }
-        return GithubReleases(client, expectations, { channel }, fixedClock)
+        return GithubReleases(client, expectations, channelProvider, fixedClock)
     }
 
     @Test
@@ -116,6 +118,27 @@ class GithubReleasesTest {
         // The factory hotfix v4.9.142.4 is the most recent publish (it would
         // hold GitHub's Latest badge) and has the biggest patch number.
         assertEquals("v4.32.0", update.version.stringVersion)
+    }
+
+    @Test
+    fun earlyChannelSettingSwitchesTheOfferBetweenChecks() = runTest {
+        // The real wiring hands GithubReleases a provider that re-reads
+        // CoreConfig on every check; flipping the setting must change the
+        // offer without recreating the checker.
+        var config = CoreConfig()
+        val checker = checker(standardBody(), channelProvider = { config.firmwareUpdateChannel() })
+        val watch = testWatchInfo(WatchHardwarePlatform.CORE_ASTERIX, "v4.30.0")
+
+        val soaked = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(checker.getLatestFirmware(watch))
+        assertEquals("v4.31.1", soaked.version.stringVersion)
+
+        config = config.copy(firmwareUpdatesEarlyChannel = true)
+        val early = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(checker.getLatestFirmware(watch))
+        assertEquals("v4.32.0", early.version.stringVersion)
+
+        config = config.copy(firmwareUpdatesEarlyChannel = false)
+        val backToSoaked = assertIs<FirmwareUpdateCheckResult.FoundUpdate>(checker.getLatestFirmware(watch))
+        assertEquals("v4.31.1", backToSoaked.version.stringVersion)
     }
 
     @Test

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/TestFirmwareFixtures.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/TestFirmwareFixtures.kt
@@ -1,0 +1,88 @@
+package coredevices.pebble.firmware
+
+import CoreAppVersion
+import coredevices.pebble.account.PebbleAccount
+import coredevices.pebble.services.PebbleAccountProvider
+import coredevices.pebble.services.PebbleHttpClient
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.rebble.libpebblecommon.connection.FakeLibPebble
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.serialization.json.Json
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
+
+/**
+ * Shared scaffolding for the firmware-update test suite (the WatchInfo
+ * fixtures live in TestWatches.kt). Each of these used to be copied per test
+ * file; keeping them here means a DTO field or constructor change touches
+ * one place.
+ */
+
+/** The suite's fixed "now": fixtures state publish ages relative to this. */
+val TEST_NOW: Instant = Instant.parse("2026-07-31T00:00:00Z")
+
+val fixedTestClock: Clock = object : Clock {
+    override fun now(): Instant = TEST_NOW
+}
+
+/** The fork always runs signed out; services still need the provider shape. */
+class SignedOutAccounts : PebbleAccountProvider {
+    override fun get(): PebbleAccount = object : PebbleAccount {
+        override val loggedIn = MutableStateFlow<String?>(null)
+        override val devToken = MutableStateFlow<String?>(null)
+        override suspend fun setToken(token: String?, bootUrl: String?) {}
+        override suspend fun setDevPortalId() {}
+    }
+}
+
+fun jsonRespondingClient(body: String): HttpClient = HttpClient(MockEngine { _ ->
+    respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+}) {
+    install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+}
+
+fun testCohorts(client: HttpClient, expectations: FirmwareArtifactExpectations): Cohorts = Cohorts(
+    httpClient = PebbleHttpClient(SignedOutAccounts(), client, lazy { FakeLibPebble() }),
+    appVersion = CoreAppVersion("0.0.0"),
+    expectations = expectations,
+)
+
+fun cohortsBody(sha256: String = "b".repeat(64)): String =
+    """{"fw":{"normal":{"friendlyVersion":"v4.4.3-rbl","notes":"legacy notes",""" +
+        """"sha-256":"$sha256","timestamp":1762930476,""" +
+        """"url":"https://binaries.rebble.io/fw/silk/Pebble-4.4.3-rbl-silk.pbz"}}}"""
+
+// GitHub release-list JSON, one builder set for every test faking the
+// endpoint: hand-inlined copies drift apart when the DTO changes.
+
+fun assetJson(name: String, digestValue: String?, size: Long): String = buildString {
+    append("""{"name":"$name",""")
+    append(""""browser_download_url":"https://github.com/coredevices/PebbleOS/releases/download/x/$name",""")
+    append(""""digest":${if (digestValue != null) "\"$digestValue\"" else "null"},""")
+    append(""""size":$size,"content_type":"application/octet-stream"}""")
+}
+
+fun normalAsset(revision: String, tag: String, digestValue: String?, size: Long): String =
+    assetJson("normal_${revision}_$tag.pbz", digestValue, size)
+
+fun releaseJson(
+    tag: String,
+    ageDays: Int,
+    assets: List<String>,
+    prerelease: Boolean = false,
+    draft: Boolean = false,
+): String = buildString {
+    append("""{"tag_name":"$tag","html_url":"https://github.com/x","prerelease":$prerelease,"draft":$draft,""")
+    append(""""published_at":"${TEST_NOW - ageDays.days}","body":"",""")
+    append(""""assets":[${assets.joinToString(",")}]}""")
+}
+
+fun releaseList(vararg releases: String): String = "[" + releases.joinToString(",") + "]"

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/TestWatches.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/firmware/TestWatches.kt
@@ -1,0 +1,59 @@
+package coredevices.pebble.firmware
+
+import io.rebble.libpebblecommon.metadata.WatchColor
+import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
+import io.rebble.libpebblecommon.services.FirmwareVersion
+import io.rebble.libpebblecommon.services.WatchInfo
+import kotlin.time.Instant
+
+/**
+ * WatchInfo fixtures for firmware-update tests. The running version is built
+ * from the real parser when possible so upstream comparison code (the cohorts
+ * path) sees consistent numeric fields; deliberately unparseable tags fall
+ * back to a hand-built value so the fail-closed paths can be exercised.
+ */
+fun testFwVersion(tag: String, isRecovery: Boolean = false): FirmwareVersion =
+    FirmwareVersion.from(
+        tag = tag,
+        isRecovery = isRecovery,
+        gitHash = "",
+        timestamp = Instant.parse("2026-07-01T00:00:00Z"),
+        isDualSlot = false,
+        isSlot0 = false,
+    ) ?: FirmwareVersion(
+        stringVersion = tag,
+        timestamp = Instant.parse("2026-07-01T00:00:00Z"),
+        major = 0,
+        minor = 0,
+        patch = 0,
+        suffix = "",
+        gitHash = "",
+        isRecovery = isRecovery,
+        isDualSlot = false,
+        isSlot0 = false,
+    )
+
+const val TEST_WATCH_SERIAL = "TESTSERIAL01"
+
+fun testWatchInfo(
+    platform: WatchHardwarePlatform,
+    runningTag: String,
+    isRecovery: Boolean = false,
+): WatchInfo = WatchInfo(
+    runningFwVersion = testFwVersion(runningTag, isRecovery),
+    recoveryFwVersion = null,
+    platform = platform,
+    bootloaderTimestamp = Instant.DISTANT_PAST,
+    board = "test-board",
+    serial = TEST_WATCH_SERIAL,
+    btAddress = "00:11:22:33:44:55",
+    resourceCrc = 0,
+    resourceTimestamp = Instant.DISTANT_PAST,
+    language = "en_US",
+    languageVersion = 2,
+    capabilities = emptySet(),
+    isUnfaithful = false,
+    healthInsightsVersion = 1,
+    javascriptVersion = 1,
+    color = WatchColor.ClassicFlyBlue,
+)

--- a/util/src/commonMain/kotlin/coredevices/util/CoreConfig.kt
+++ b/util/src/commonMain/kotlin/coredevices/util/CoreConfig.kt
@@ -81,6 +81,10 @@ data class CoreConfig(
     val weatherPinsV2: Boolean = true,
     val fetchWeather: Boolean = true,
     val disableFirmwareUpdateNotifications: Boolean = false,
+    // Fork: opts Core watches into the Early PebbleOS release channel
+    // (newest main-line tag, Core's internal-tester tier) instead of the
+    // soaked default; mapped to FirmwareUpdateChannel in :pebble.
+    val firmwareUpdatesEarlyChannel: Boolean = false,
     val enableIndex: Boolean = false,
     val indexPermissionsConfirmed: Boolean = false,
     val weatherUnits: WeatherUnit = deviceDefaultWeatherUnit(),

--- a/util/src/commonTest/kotlin/coredevices/util/FirmwareChannelDefaultTest.kt
+++ b/util/src/commonTest/kotlin/coredevices/util/FirmwareChannelDefaultTest.kt
@@ -1,0 +1,29 @@
+package coredevices.util
+
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+/**
+ * Pins the firmware update channel default to Soaked (false): a fresh
+ * install must never start on the Early tier, and configs persisted before
+ * the field existed must keep decoding to the safe default instead of
+ * failing (which would silently reset the whole stored config, see
+ * CoreConfigHolder.loadFromStorage).
+ */
+class FirmwareChannelDefaultTest {
+    // Same settings as the Json instance CoreConfigHolder decodes with.
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun freshConfigDefaultsToSoaked() {
+        assertFalse(CoreConfig().firmwareUpdatesEarlyChannel)
+    }
+
+    @Test
+    fun configPersistedBeforeTheFieldExistedDecodesToSoaked() {
+        val decoded = json.decodeFromString<CoreConfig>("""{"fetchWeather":false}""")
+        assertFalse(decoded.firmwareUpdatesEarlyChannel)
+        assertFalse(decoded.fetchWeather)
+    }
+}


### PR DESCRIPTION
Core watches had no working update source in fork builds: without a
Memfault token upstream routes every watch to the Rebble cohorts
endpoint, which rejects every Core hardware revision, so Core-watch OTA
was dead. This branch checks the public PebbleOS GitHub releases
instead. The release list is fetched anonymously with no hardware,
serial, or version in the request (the asset is chosen on the phone),
and selection is structural over parsed tags: GitHub's "latest" badge
and publish dates never drive it, the four-component factory line is
never offered, and an equal version is never re-offered. Two channels
sit behind a debug-settings toggle: the default gates a release line on
a week of public soak and takes later hotfix patches within that line
immediately (a documented time-based approximation of the manual public
rollout), Early offers the newest main-line tag.

Installs no longer go through upstream's unchecked downloader. A
fork-owned installer streams the download (per-read stall timeout, size
cap, unique per-install filenames), verifies sha256 and exact size
against what the update source declared at check time, cross-checks
every manifest in the archive (hardware revision, firmware type,
version tag) plus the inner firmware and resources CRCs, and only then
hands the file to libpebble3's public sideload entry point, keeping
every upstream safety check. All four install triggers route through
it, cohorts-served legacy watches gain the same install-time integrity
check through their previously parsed-but-unused sha-256 field, and
libpebble3 itself is untouched. Review-driven hardening followed: the
handoff watcher no longer misattributes stale upstream state (and never
deletes the archive while a sideload still needs it), the channel is
read once per check so the cache key and the selection cannot disagree,
and the update path's docs, Compose glue, and test gaps were closed.

Verification record:

- Tests: 78 unit tests across selection, checker, routing, cohorts,
  installer, and the notification tracker, including the fail-closed
  refusal branches (missing expectation, non-https, checksum, size,
  stall, manifest hardware/type/tag, inner CRC, unparseable archive),
  the null-size legacy path, per-entry resilience to malformed release
  entries, the soak-window boundary from both sides, and a pin that the
  notification action enters the verified pipeline. Every review bug
  fix and every new coverage test was mutation-checked (fix reverted or
  behavior mutated, the matching tests fail). Full build, all-module
  unit suites, jvmTest, and lint green.
- Built-APK endpoint audit (release, minified): the only new
  contactable endpoint in the dex is the GitHub releases API URL; the
  download redirect target appears nowhere (it is followed at runtime,
  never embedded), and no Memfault hosts survive in the release dex at
  all (the token-less code paths are stripped).
- Device e2e on a Pixel running GrapheneOS, release build, paired Core
  Time 2: a dual-slot double-install pass. The default channel offered
  and installed the predicted soaked hotfix through the fork pipeline
  (verified temp file, slot 0 to slot 1), reconnected on the new
  firmware with no re-offer at the equal version; flipping Early then
  offered the newest tag, installed via the update-notification action
  into the other slot, again with no re-offer and zero fatal exceptions
  across the sessions.
- Tamper test against a local fixture serving a forged release entry
  that points at the real hosted asset with a wrong declared digest:
  the install refused with a checksum mismatch, nothing was sideloaded,
  and the file was deleted.
- Cleartext probe: with the committed network security config, a
  plain-http update check to a LAN host is blocked by policy and the
  check fails closed.
- The pre-merge review's 19 confirmed findings were resolved across the
  four most recent commits. Honesty notes: the soak approximation can
  sit one promoted-line hotfix ahead of what the official app's cohort
  serves (the exact cohort is unknowable without a Memfault key), and
  single-slot Core hardware has not been exercised end to end, recorded
  with rationale in KNOWN_ISSUES.md. The post-review Compose and
  wording polish is build-and-suite verified, with a quick on-device
  sanity pass owed at the next device session.
