### PR TITLE
Verify STT model installs and restore the inference boost

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -21,24 +21,3 @@ handoff, past which transfer and install are upstream's unchanged flow,
 and the watch's own bootloader validation with recovery fallback
 backstops a bad install. This entry leaves the file when a single-slot
 watch runs the end-to-end pass.
-
-## Dictation lost the inference-boost foreground service with the Ring unplug
-
-**Status: deferred to the same STT hardening branch.**
-
-Upstream holds foreground-process priority during local Cactus
-transcription via `InferenceForegroundService`, a `shortService`-type
-foreground service hosted in the unplugged `:experimental` module. With the
-module gone, `utilModule`'s `getOrNull<InferenceBoost>()` fallback always
-yields `NoOpInferenceBoost`, so local transcription runs at the priority of
-the app process. This is masked while the watch-connection foreground
-service is active (the `androidForegroundServiceForWatchConnectionV2`
-setting, default on); a user who disables that setting gets
-background-priority inference, which modern Android CPU restrictions can
-slow enough to hit the transcription timeouts.
-
-Deferred because the degradation only manifests in a non-default
-configuration, is a performance regression rather than a correctness or
-security issue, and the fix (a fork-owned minimal boost service, since
-upstream's is pure Android with no GMS dependency) belongs with the rest of
-the STT work rather than in the Play services strip.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -22,35 +22,6 @@ and the watch's own bootloader validation with recovery fallback
 backstops a bad install. This entry leaves the file when a single-slot
 watch runs the end-to-end pass.
 
-## On-device STT model downloads have no integrity verification
-
-**Status: deferred to a dedicated STT hardening branch.**
-
-The fork-owned `CactusModelProvider`
-(`composeApp/src/androidMain/kotlin/coredevices/coreapp/model/CactusModelProvider.kt`)
-downloads STT/LM model weights from `https://huggingface.co/Cactus-Compute`,
-a third-party Hugging Face org (the Cactus engine vendor, not Core Devices
-and not this fork), pinned only to the mutable git tag in
-`CACTUS_WEIGHTS_VERSION` (currently `v2.0.1`). There is no checksum,
-signature, or immutable-revision pin between download and extraction, and no
-size cap on the extracted output (Zip-Slip is handled). The extracted
-weights are parsed by the bundled native `libcactus_engine.so`.
-
-Threat model: a compromise of the Cactus-Compute account, or a retargeted
-tag, silently swaps the weights on the next download or version bump; a
-native parser consuming attacker-controlled blobs is a memory-corruption
-surface, and swapped weights could also manipulate transcriptions silently.
-The only defensive layer today is TLS with default certificate validation.
-This matches upstream's behavior at the fork point (the Play services strip
-promoted the code into fork-owned surface without widening its exposure),
-which is why it is deferred rather than blocking: the exposure is not new,
-one real layer exists, and exploitation requires compromising the vendor
-org.
-
-Planned resolution, on its own branch: pin an immutable revision (or verify
-a build-time SHA-256 of the downloaded archive), cap extraction size, and
-review the on-device STT verification story end to end.
-
 ## Dictation lost the inference-boost foreground service with the Ring unplug
 
 **Status: deferred to the same STT hardening branch.**

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -21,3 +21,28 @@ handoff, past which transfer and install are upstream's unchanged flow,
 and the watch's own bootloader validation with recovery fallback
 backstops a bad install. This entry leaves the file when a single-slot
 watch runs the end-to-end pass.
+
+## Pre-pinning STT/LM model installs are grandfathered without retroactive verification
+
+**Status: accepted until the first model pin bump.**
+
+On-device model archives are now verified before install (immutable-commit
+download URLs, SHA-256 and exact-size gates, bounded staged extraction),
+but that verification is prospective only. Installs made before the
+pinning scheme wrote the release tag (`v2.0.1`) as their
+`.cactus_version` marker after an unverified download from a mutable tag,
+so the marker proves nothing about the installed bytes. `CactusModelPins`
+grandfathers that legacy marker while a model's current pin still names
+the very archive the tag shipped, which means an install that was already
+tampered with under the old scheme (the retargeted-tag or
+compromised-org threats the old entry here described) keeps feeding its
+weights to the native parser until the first real pin bump forces a
+verified reinstall. Retroactive verification is not feasible cheaply:
+only the archive digest is pinned and nothing per-file survives
+extraction, so re-verifying would force every existing user through a
+full re-download (383 MB for STT) after first downgrading them to
+remote-only STT via the incompatible-model sweep, a user-hostile trade
+against a purely historical exposure window. The grandfather clause and
+its frozen anchor digests live in `CactusModelPins.kt`; the first pin
+bump ends the exception automatically, and this entry leaves the file
+with it.

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -165,6 +165,7 @@ kotlin {
         }
         androidUnitTest.dependencies {
             implementation(libs.ktor.client.okhttp)
+            implementation(libs.ktor.client.mock)
             implementation(libs.coroutines.test)
         }
         iosMain.dependencies {

--- a/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/InferenceBoostLifecycleTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/InferenceBoostLifecycleTest.kt
@@ -1,0 +1,55 @@
+package coredevices.coreapp
+
+import android.app.ActivityManager
+import androidx.test.platform.app.InstrumentationRegistry
+import coredevices.util.transcription.InferenceBoost
+import org.junit.Test
+import org.koin.mp.KoinPlatform
+import kotlin.test.assertTrue
+
+/**
+ * Drives the real boost wiring end to end on device: acquire through the
+ * DI-resolved InferenceBoost must start InferenceBoostService in the
+ * foreground, and the final release must stop it. This is what actually
+ * pins the AndroidInferenceBoost glue (delegation direction, Intent
+ * target, main-handler post): a transposed delegation or wrong target
+ * class passes every JVM test and only fails here.
+ */
+class InferenceBoostLifecycleTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun acquireStartsTheForegroundServiceAndFinalReleaseStopsIt() {
+        val boost = KoinPlatform.getKoin().get<InferenceBoost>()
+        boost.acquire()
+        try {
+            assertTrue(
+                waitForService(expectRunning = true),
+                "acquire must start InferenceBoostService in the foreground",
+            )
+        } finally {
+            boost.release()
+        }
+        assertTrue(
+            waitForService(expectRunning = false),
+            "the final release must stop InferenceBoostService",
+        )
+    }
+
+    private fun waitForService(expectRunning: Boolean): Boolean {
+        val am = context.getSystemService(ActivityManager::class.java)
+        repeat(100) {
+            @Suppress("DEPRECATION") // Still supported for the caller's own
+            // services, which is all this asks about; the alternative is
+            // parsing dumpsys through UiAutomation shell output.
+            val running = am.getRunningServices(Int.MAX_VALUE).any {
+                it.service.className == InferenceBoostService::class.java.name &&
+                    it.foreground
+            }
+            if (running == expectRunning) return true
+            Thread.sleep(100)
+        }
+        return false
+    }
+}

--- a/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/InferenceBoostSeamTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/InferenceBoostSeamTest.kt
@@ -1,0 +1,21 @@
+package coredevices.coreapp
+
+import coredevices.util.transcription.InferenceBoost
+import org.junit.Test
+import org.koin.mp.KoinPlatform
+import kotlin.test.assertIs
+
+/**
+ * Smoke test against the live app graph (MainApplication's Koin): the
+ * InferenceBoost seam must resolve to the fork's Android implementation,
+ * not fall through to utilModule's no-op fallback. A JVM koinApplication
+ * cannot check this binding because androidDefaultModule needs a real
+ * Context to instantiate.
+ */
+class InferenceBoostSeamTest {
+
+    @Test
+    fun liveGraphResolvesTheAndroidBoost() {
+        assertIs<AndroidInferenceBoost>(KoinPlatform.getKoin().get<InferenceBoost>())
+    }
+}

--- a/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/transcription/CactusColdStartRaceTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/transcription/CactusColdStartRaceTest.kt
@@ -10,6 +10,8 @@ import coredevices.util.STTConfig
 import coredevices.util.models.CactusSTTMode
 import coredevices.util.transcription.CactusTranscriptionService
 import coredevices.util.transcription.NoOpInferenceBoost
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -82,7 +84,7 @@ class CactusColdStartRaceTest {
                 val provider = ReadOnlyModelPathProvider(modelsDir, MODEL_NAME)
                 if (!provider.isModelDownloaded(MODEL_NAME)) {
                     println("[cold-start] model missing — downloading $MODEL_NAME (one-time)…")
-                    runBlocking { withTimeout(20.minutes) { CactusModelProvider(context).getSTTModelPath() } }
+                    runBlocking { withTimeout(20.minutes) { CactusModelProvider(context, HttpClient(OkHttp)).getSTTModelPath() } }
                 }
                 modelPresent = provider.isModelDownloaded(MODEL_NAME)
 

--- a/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/transcription/CactusLocalCancellationTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/transcription/CactusLocalCancellationTest.kt
@@ -10,6 +10,8 @@ import coredevices.util.models.CactusSTTMode
 import coredevices.util.transcription.CactusModelPathProvider
 import coredevices.util.transcription.CactusTranscriptionService
 import coredevices.util.transcription.NoOpInferenceBoost
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -89,7 +91,7 @@ class CactusLocalCancellationTest {
                     println("[cactus-cancel] model missing at ${modelDir.absolutePath} — downloading $MODEL_NAME (one-time, hundreds of MB)…")
                     // Only the *production* provider downloads; its delete-then-download is harmless
                     // when there's no valid model to lose.
-                    runBlocking { withTimeout(20.minutes) { CactusModelProvider(context).getSTTModelPath() } }
+                    runBlocking { withTimeout(20.minutes) { CactusModelProvider(context, HttpClient(OkHttp)).getSTTModelPath() } }
                 }
                 modelPresent = provider.isModelDownloaded(MODEL_NAME)
                 println("[cactus-cancel] model dir=${modelDir.absolutePath} present=$modelPresent")

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -95,6 +95,16 @@
             android:name=".PebbleService"
             android:foregroundServiceType="connectedDevice"
             android:exported="false" />
+        <!--
+            Fork: holds foreground priority during local Cactus
+            transcription; upstream's equivalent service lives in the
+            unplugged :experimental module. shortService needs no
+            type-specific permission.
+        -->
+        <service
+            android:name=".InferenceBoostService"
+            android:foregroundServiceType="shortService"
+            android:exported="false" />
         <service android:name="coredevices.util.models.ModelDownloadService"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false">

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/AndroidInferenceBoost.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/AndroidInferenceBoost.kt
@@ -1,0 +1,27 @@
+package coredevices.coreapp
+
+import android.content.Context
+import android.content.Intent
+import android.os.Handler
+import android.os.Looper
+import coredevices.util.transcription.InferenceBoost
+
+/**
+ * Android implementation of the InferenceBoost seam. utilModule resolves
+ * the seam with getOrNull and falls back to a no-op, so binding this in
+ * the DI graph is all it takes to give local transcription its foreground
+ * service back; iOS stays on the no-op. minSdk is 26, so
+ * startForegroundService is unconditionally the right entry point.
+ */
+class AndroidInferenceBoost(private val context: Context) : InferenceBoost {
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val refCounter = BoostRefCounter(
+        start = { context.startForegroundService(Intent(context, InferenceBoostService::class.java)) },
+        stop = { context.stopService(Intent(context, InferenceBoostService::class.java)) },
+        postToMain = { action -> mainHandler.post(action) },
+    )
+
+    override fun acquire() = refCounter.acquire()
+
+    override fun release() = refCounter.release()
+}

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/BoostRefCounter.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/BoostRefCounter.kt
@@ -1,0 +1,51 @@
+package coredevices.coreapp
+
+import co.touchlab.kermit.Logger
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Start/stop policy for the inference boost service, mirroring the ref
+ * count of the upstream experimental service: overlapping transcriptions
+ * share one service, the outermost acquire starts it, the last release
+ * stops it. Collaborators are injected as lambdas so the policy runs
+ * under plain JVM tests; the Android glue lives in
+ * [AndroidInferenceBoost].
+ */
+class BoostRefCounter(
+    private val start: () -> Unit,
+    private val stop: () -> Unit,
+    private val postToMain: (() -> Unit) -> Unit,
+) {
+    private val refCount = AtomicInteger(0)
+
+    fun acquire() {
+        if (refCount.getAndIncrement() == 0) {
+            try {
+                start()
+            } catch (e: Exception) {
+                // Load-bearing degrade: on API 31+ a start from the
+                // background is only allowed via the companion-device
+                // exemption, and setups outside it land here. The failure
+                // must not escape, so transcription proceeds unboosted.
+                logger.w(e) { "Inference boost unavailable; continuing unboosted" }
+            }
+        }
+    }
+
+    fun release() {
+        if (refCount.decrementAndGet() == 0) {
+            // Hop to main so the service's own onStartCommand runs before a
+            // stop can land, then re-check: a transcription that began
+            // while the stop was queued keeps the service alive.
+            postToMain {
+                if (refCount.get() == 0) {
+                    stop()
+                }
+            }
+        }
+    }
+
+    private companion object {
+        private val logger = Logger.withTag("BoostRefCounter")
+    }
+}

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/BoostRefCounter.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/BoostRefCounter.kt
@@ -10,6 +10,16 @@ import java.util.concurrent.atomic.AtomicInteger
  * stops it. Collaborators are injected as lambdas so the policy runs
  * under plain JVM tests; the Android glue lives in
  * [AndroidInferenceBoost].
+ *
+ * Fork deviation from the upstream policy: both start and stop decisions
+ * run through [postToMain], never inline on the caller's thread. Upstream
+ * starts inline, which leaves a race in its posted stop: between the
+ * stop's ref-count re-check and the stopService call, a worker thread can
+ * acquire and issue an inline start, and the stop then tears down a
+ * service a live transcription is holding, with no retry until the next
+ * cold acquire. Serializing both sides on one thread closes that; the
+ * cost is a main-looper hop before the boost engages, noise against an
+ * inference that runs for seconds.
  */
 class BoostRefCounter(
     private val start: () -> Unit,
@@ -20,23 +30,26 @@ class BoostRefCounter(
 
     fun acquire() {
         if (refCount.getAndIncrement() == 0) {
-            try {
-                start()
-            } catch (e: Exception) {
-                // Load-bearing degrade: on API 31+ a start from the
-                // background is only allowed via the companion-device
-                // exemption, and setups outside it land here. The failure
-                // must not escape, so transcription proceeds unboosted.
-                logger.w(e) { "Inference boost unavailable; continuing unboosted" }
+            postToMain {
+                try {
+                    start()
+                } catch (e: Exception) {
+                    // Load-bearing degrade: on API 31+ a start from the
+                    // background is only allowed via the companion-device
+                    // exemption, and setups outside it land here. The failure
+                    // must not escape (least of all on the main thread), so
+                    // transcription proceeds unboosted.
+                    logger.w(e) { "Inference boost unavailable; continuing unboosted" }
+                }
             }
         }
     }
 
     fun release() {
         if (refCount.decrementAndGet() == 0) {
-            // Hop to main so the service's own onStartCommand runs before a
-            // stop can land, then re-check: a transcription that began
-            // while the stop was queued keeps the service alive.
+            // Re-check on the serialized thread: a transcription that began
+            // while the stop was queued keeps the service alive (its start,
+            // if any, is queued behind this and re-starts the service).
             postToMain {
                 if (refCount.get() == 0) {
                     stop()

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/InferenceBoostService.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/InferenceBoostService.kt
@@ -1,0 +1,86 @@
+package coredevices.coreapp
+
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationChannelCompat
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.ServiceCompat
+import co.touchlab.kermit.Logger
+import coredevices.util.R
+
+/**
+ * Fork-owned shortService foreground service that holds process priority
+ * during local Cactus transcription. Upstream's equivalent
+ * (InferenceForegroundService) lives in the unplugged :experimental
+ * module, so without this the app transcribes at background priority
+ * whenever the watch-connection foreground service is toggled off, and
+ * modern Android CPU restrictions can push inference past the dictation
+ * timeouts. It gets its own class name on purpose: no upstream call site
+ * references the experimental service, so the same-FQN stub pattern buys
+ * nothing here. The upstream InferenceActivity trampoline is deliberately
+ * not ported.
+ *
+ * Lifecycle is driven by [AndroidInferenceBoost]'s ref count. On API 31+
+ * the start from the background is only permitted through the
+ * companion-device exemption (merged from libpebble3's manifest); without
+ * it (BT Classic watches, CDM association revoked) the start throws and
+ * transcription simply runs unboosted.
+ */
+class InferenceBoostService : Service() {
+    companion object {
+        private val logger = Logger.withTag("InferenceBoostService")
+
+        // Same ids as the upstream experimental service, so a future
+        // upstream port of this feature collides visibly instead of
+        // running two boost notifications side by side.
+        private const val NOTIFICATION_ID = 7631
+        private const val CHANNEL_ID = "inference_fg"
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val channel = NotificationChannelCompat.Builder(CHANNEL_ID, NotificationManager.IMPORTANCE_LOW)
+            .setName("Speech Processing")
+            .build()
+        NotificationManagerCompat.from(this).createNotificationChannel(channel)
+
+        // With POST_NOTIFICATIONS denied the notification stays hidden but
+        // the service still gains foreground priority, so no permission
+        // handling is needed here.
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Processing speech…")
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setOngoing(true)
+            .build()
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                ServiceCompat.startForeground(
+                    this, NOTIFICATION_ID, notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE,
+                )
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+        } catch (e: Exception) {
+            logger.w(e) { "Could not enter the foreground; transcription continues unboosted" }
+            stopSelf(startId)
+        }
+        return START_NOT_STICKY
+    }
+
+    // Fork addition upstream lacks: the system delivers this when the
+    // shortService time budget (about 3 minutes) expires, and a service
+    // that does not stop promptly ANRs the app. A transcription that
+    // outlives the budget just loses its boost.
+    override fun onTimeout(startId: Int) {
+        logger.w { "shortService budget expired; dropping the boost" }
+        stopSelf()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+}

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/di/androidDefaultModule.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/di/androidDefaultModule.kt
@@ -9,6 +9,7 @@ import coredevices.coreapp.PebbleBackgroundManager
 import coredevices.coreapp.auth.NoOpAppleAuthUtil
 import coredevices.coreapp.auth.NoOpGithubAuthUtil
 import coredevices.coreapp.auth.NoOpGoogleAuthUtil
+import coredevices.coreapp.AndroidInferenceBoost
 import coredevices.coreapp.util.AppUpdate
 import coredevices.coreapp.util.NoOpAppUpdate
 import coredevices.coreapp.model.CactusModelProvider
@@ -29,6 +30,7 @@ import coredevices.util.integrations.AndroidOAuthLauncher
 import coredevices.util.integrations.OAuthLauncher
 import coredevices.util.models.ModelDownloadManager
 import coredevices.util.transcription.CactusModelPathProvider
+import coredevices.util.transcription.InferenceBoost
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
 import org.koin.android.ext.koin.androidContext
@@ -77,5 +79,10 @@ val androidDefaultModule = module {
     // The HttpClient is watchModule's shared app-graph single, the same one
     // the verified firmware installer downloads through.
     single { CactusModelProvider(androidContext(), get()) } bind CactusModelPathProvider::class
+    // Fork binding: upstream's inference boost rides in the unplugged
+    // :experimental module, so utilModule's getOrNull fallback always found
+    // nothing and local transcription ran at background priority whenever
+    // the watch-connection foreground service was off.
+    single { AndroidInferenceBoost(androidContext()) } bind InferenceBoost::class
     singleOf(::PebbleBackgroundManager)
 }

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/di/androidDefaultModule.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/di/androidDefaultModule.kt
@@ -31,6 +31,7 @@ import coredevices.util.models.ModelDownloadManager
 import coredevices.util.transcription.CactusModelPathProvider
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.okhttp.OkHttp
+import org.koin.android.ext.koin.androidContext
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -73,6 +74,8 @@ val androidDefaultModule = module {
     // Fork binding: upstream registers its Cactus model provider inside the
     // unplugged :experimental module; without this, on-device Cactus STT
     // falls back to a provider that throws (utilModule) and dictation dies.
-    singleOf(::CactusModelProvider) bind CactusModelPathProvider::class
+    // The HttpClient is watchModule's shared app-graph single, the same one
+    // the verified firmware installer downloads through.
+    single { CactusModelProvider(androidContext(), get()) } bind CactusModelPathProvider::class
     singleOf(::PebbleBackgroundManager)
 }

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/CactusModelPins.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/CactusModelPins.kt
@@ -1,0 +1,105 @@
+package coredevices.coreapp.model
+
+/**
+ * Everything the installer must know to verify one model archive before it
+ * is allowed anywhere near the native parser.
+ *
+ * @param hfRepo repository name under the Cactus-Compute Hugging Face org.
+ * @param commitSha immutable revision the download URL resolves; unlike the
+ *   upstream tag-based URLs this cannot be retargeted after the fact.
+ * @param zipSha256Hex lowercase hex SHA-256 of the exact archive bytes.
+ * @param zipSizeBytes exact archive size; enforced mid-download so a
+ *   substituted response is cut off instead of filling the disk.
+ */
+data class ModelPin(
+    val hfRepo: String,
+    val commitSha: String,
+    val zipSha256Hex: String,
+    val zipSizeBytes: Long,
+)
+
+/**
+ * Hardcoded integrity pins for the on-device Cactus model archives. The
+ * download URL is pinned to an immutable commit and the received bytes are
+ * verified against a build-time SHA-256 and exact size, so neither a
+ * retargeted tag nor a compromised repository or CDN can swap the weights
+ * that feed the native libcactus_engine.so parser; the bundled asset goes
+ * through the same digest gate.
+ *
+ * Re-pin procedure when bumping to a new release (each step is an
+ * independent source; all three must agree before the new values land):
+ *  1. Tag to commit: `https://huggingface.co/api/models/Cactus-Compute/
+ *     <repo>/refs` and read the target commit of the release tag.
+ *  2. Declared metadata: HEAD `https://huggingface.co/Cactus-Compute/
+ *     <repo>/resolve/<commit>/<zip>` and read `x-linked-size` and
+ *     `x-linked-etag` (the etag is the payload's SHA-256).
+ *  3. Independent bytes: download that URL fresh and run `sha256sum` and
+ *     a size check locally; this is the value pair that goes in the table,
+ *     with 1 and 2 as cross-checks.
+ * When the STT pin changes, also bump CACTUS_WEIGHTS_VERSION: the reinstall
+ * itself is driven by the pin (the on-disk marker stops matching), but the
+ * system notification in CommonAppDelegate dedupes on the tag string, so
+ * without a bump users get the in-app SttModelUpdatePrompt and no
+ * notification.
+ */
+object CactusModelPins {
+    /**
+     * Marker value written by installs that predate digest pinning, when
+     * .cactus_version carried the CACTUS_WEIGHTS_VERSION tag. Grandfathered
+     * per model for as long as the model's pin still points at the archive
+     * that tag shipped ([legacyV201Sha256]): those installs hold bytes
+     * identical to today's pinned archive, so re-downloading hundreds of MB
+     * (or downgrading users to remote-only STT while it happens) would buy
+     * nothing. The first real pin bump breaks the equality and forces a
+     * verified reinstall.
+     */
+    const val LEGACY_TAG_MARKER = "v2.0.1"
+
+    // Values derived 2026-08-01 via the three-source procedure above; both
+    // archives are the v2.0.1 release of the Cactus cq4 quantization.
+    private val PINS = mapOf(
+        "parakeet-tdt-0.6b-v3" to ModelPin(
+            hfRepo = "parakeet-tdt-0.6b-v3",
+            commitSha = "26fa0fdba867416e6df970c517ac95c9bdce7c4b",
+            zipSha256Hex = "f3225606761c1c38d8ac9a057d6d95cc5ff63cb4236a9ee63880a9f56ab57e1b",
+            zipSizeBytes = 383_664_950,
+        ),
+        "needle-pebble-ft" to ModelPin(
+            hfRepo = "needle-pebble-ft",
+            commitSha = "fbfe3b5ac54b50cba17b700313f98b3311829eb9",
+            zipSha256Hex = "7e08fa6a6ef38f79429bc95b1ae31f326b53a67fcb8768df19f875fa67ec852e",
+            zipSizeBytes = 13_732_623,
+        ),
+    )
+
+    /**
+     * SHA-256 of the archive each model shipped under the "v2.0.1" tag
+     * markers; the historical anchor for [LEGACY_TAG_MARKER] acceptance.
+     * These never change once recorded, unlike the live pins above.
+     */
+    private val LEGACY_V201_SHAS = mapOf(
+        "parakeet-tdt-0.6b-v3" to "f3225606761c1c38d8ac9a057d6d95cc5ff63cb4236a9ee63880a9f56ab57e1b",
+        "needle-pebble-ft" to "7e08fa6a6ef38f79429bc95b1ae31f326b53a67fcb8768df19f875fa67ec852e",
+    )
+
+    fun pinFor(modelName: String): ModelPin? = PINS[modelName]
+
+    private fun legacyV201Sha256(modelName: String): String? = LEGACY_V201_SHAS[modelName]
+
+    /**
+     * Whether an on-disk .cactus_version marker proves the installed model
+     * matches the current pin: either it is the pin's own digest (written
+     * by every verified install) or the grandfathered legacy tag while the
+     * pin still names the same archive that tag shipped.
+     */
+    fun markerMatches(modelName: String, marker: String): Boolean {
+        val pin = pinFor(modelName) ?: return false
+        return markerMatchesPin(marker, pin, legacyV201Sha256(modelName))
+    }
+
+    // Pure so the grandfather semantics are testable against fabricated
+    // pins, not just today's table.
+    internal fun markerMatchesPin(marker: String, pin: ModelPin, legacySha256: String?): Boolean =
+        marker == pin.zipSha256Hex ||
+            (marker == LEGACY_TAG_MARKER && legacySha256 != null && pin.zipSha256Hex == legacySha256)
+}

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/CactusModelPins.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/CactusModelPins.kt
@@ -40,9 +40,23 @@ data class ModelPin(
  * itself is driven by the pin (the on-disk marker stops matching), but the
  * system notification in CommonAppDelegate dedupes on the tag string, so
  * without a bump users get the in-app SttModelUpdatePrompt and no
- * notification.
+ * notification. Then record the new tag in [DERIVED_FROM_WEIGHTS_TAG].
+ *
+ * The reverse direction, an upstream bump of CACTUS_WEIGHTS_VERSION, is
+ * otherwise silently inert here (the tag merges conflict-free in
+ * util/build.gradle.kts, but downloads resolve the pinned commits, so
+ * users would keep the old weights with no signal anywhere); the
+ * [DERIVED_FROM_WEIGHTS_TAG] tripwire in CactusModelPinsTest turns that
+ * into a red test naming this re-pin procedure.
  */
 object CactusModelPins {
+    /**
+     * The CACTUS_WEIGHTS_VERSION tag the [PINS] table was derived from.
+     * Exists only for the unit-suite tripwire that catches an upstream tag
+     * bump; nothing at runtime reads it.
+     */
+    const val DERIVED_FROM_WEIGHTS_TAG = "v2.0.1"
+
     /**
      * Marker value written by installs that predate digest pinning, when
      * .cactus_version carried the CACTUS_WEIGHTS_VERSION tag. Grandfathered

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/CactusModelProvider.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/CactusModelProvider.kt
@@ -35,8 +35,9 @@ import java.util.concurrent.ConcurrentHashMap
  * and its androidMain actual into one class. Those originals stay in-tree (the unplugged
  * module keeps its sources for cheap merges) and keep receiving upstream
  * changes that will merge conflict-free WITHOUT touching this copy. After
- * every upstream merge, re-diff this file against them and port whatever
- * matters; drift here breaks dictation.
+ * every upstream merge, re-diff this file AND [ModelZipInstaller] (which
+ * carries the extracted download/extract pipeline) against them and port
+ * whatever matters; drift here breaks dictation.
  *
  * Fork security deviation: installs are verified. Downloads resolve the
  * immutable commit pinned in [CactusModelPins] (upstream downloads a
@@ -72,6 +73,28 @@ class CactusModelProvider(
             versionMatches: Boolean,
             bundledInApp: Boolean,
         ): Boolean = name !in compatibleNames || (!versionMatches && !bundledInApp)
+
+        // Static like modelNeedsReplacement so the file-reading decision
+        // logic stays under JVM tests with temp dirs; a regression here
+        // silently forces a 383 MB re-download for every existing user, or
+        // downgrades them to RemoteOnly STT through the incompatible-model
+        // sweep. The instance methods below just bind the real modelsDir.
+        internal fun versionMatchesIn(modelsDir: File, modelName: String): Boolean {
+            val versionFile = modelsDir.resolve(modelName).resolve(ModelZipInstaller.VERSION_MARKER)
+            val marker = versionFile.takeIf { it.exists() }?.readText()?.trim() ?: return false
+            return CactusModelPins.markerMatches(modelName, marker)
+        }
+
+        internal fun needsInstallIn(modelsDir: File, modelName: String): Boolean =
+            !modelsDir.resolve(modelName).resolve(ModelZipInstaller.CONFIG_FILE).exists() ||
+                !versionMatchesIn(modelsDir, modelName)
+
+        // Fail closed on an unpinned model name: without integrity data
+        // there is no verifiable download, and the native parser must never
+        // see an unverified archive.
+        internal fun requirePin(modelName: String): ModelPin =
+            CactusModelPins.pinFor(modelName)
+                ?: throw IllegalStateException("No integrity pin for model '$modelName'; refusing to download")
     }
 
     private val modelsDir: File get() = context.filesDir.resolve("models").also { it.mkdirs() }
@@ -90,12 +113,12 @@ class CactusModelProvider(
 
     override fun isModelDownloaded(modelName: String): Boolean {
         val modelDir = modelsDir.resolve(modelName)
-        return modelDir.exists() && modelDir.resolve("config.txt").exists()
+        return modelDir.exists() && modelDir.resolve(ModelZipInstaller.CONFIG_FILE).exists()
     }
 
     override fun getDownloadedModels(): List<String> {
         return modelsDir.listFiles()
-            ?.filter { it.isDirectory && it.resolve("config.txt").exists() }
+            ?.filter { it.isDirectory && it.resolve(ModelZipInstaller.CONFIG_FILE).exists() }
             ?.map { it.name }
             ?: emptyList()
     }
@@ -107,11 +130,7 @@ class CactusModelProvider(
         }
     }
 
-    private fun versionMatches(modelName: String): Boolean {
-        val versionFile = modelsDir.resolve(modelName).resolve(ModelZipInstaller.VERSION_MARKER)
-        val marker = versionFile.takeIf { it.exists() }?.readText()?.trim() ?: return false
-        return CactusModelPins.markerMatches(modelName, marker)
-    }
+    private fun versionMatches(modelName: String): Boolean = versionMatchesIn(modelsDir, modelName)
 
     private fun isBundled(modelName: String): Boolean =
         context.assets.list("models")?.contains(ModelZipInstaller.zipNameFor(modelName)) == true
@@ -132,16 +151,8 @@ class CactusModelProvider(
     private suspend fun resolveModelPath(modelName: String): String = mutexFor(modelName).withLock {
         val modelDir = modelsDir.resolve(modelName)
 
-        val needsInstall = !modelDir.resolve(ModelZipInstaller.CONFIG_FILE).exists()
-            || !versionMatches(modelName)
-
-        if (needsInstall) {
-            // Fail closed on an unpinned model name: without integrity data
-            // there is no verifiable download, and the native parser must
-            // never see an unverified archive.
-            val pin = CactusModelPins.pinFor(modelName)
-                ?: throw IllegalStateException("No integrity pin for model '$modelName'; refusing to download")
-            downloadAndExtract(modelName, pin)
+        if (needsInstallIn(modelsDir, modelName)) {
+            downloadAndExtract(modelName, requirePin(modelName))
         }
 
         logger.d { "Model '$modelName' at: ${modelDir.absolutePath}" }
@@ -150,11 +161,10 @@ class CactusModelProvider(
 
     private suspend fun downloadAndExtract(modelName: String, pin: ModelPin) = withContext(Dispatchers.IO) {
         val zipName = ModelZipInstaller.zipNameFor(modelName)
-        val bundled = context.assets.list("models")?.contains(zipName) == true
         installer.install(
             modelName = modelName,
             pin = pin,
-            copyBundledZip = if (bundled) {
+            copyBundledZip = if (isBundled(modelName)) {
                 { dest: File ->
                     logger.i { "Found included model zip in assets: $zipName, extracting..." }
                     context.assets.open("models/$zipName").use { input ->

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/CactusModelProvider.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/CactusModelProvider.kt
@@ -38,8 +38,20 @@ import java.util.concurrent.ConcurrentHashMap
  * every upstream merge, re-diff this file against them and port whatever
  * matters; drift here breaks dictation.
  *
+ * Fork security deviation: installs are verified. Downloads resolve the
+ * immutable commit pinned in [CactusModelPins] (upstream downloads a
+ * mutable tag), the archive must match its pinned SHA-256 and exact size
+ * before extraction (bundled assets included), and extraction is bounded
+ * and staged so a failed or hostile install never destroys a working
+ * model. The .cactus_version marker holds the pinned archive digest;
+ * installs from before the pinning scheme hold the old release tag, which
+ * [CactusModelPins.markerMatches] grandfathers while the pin still names
+ * the same archive that tag shipped, so existing users are not forced
+ * through a pointless re-download (or silently dropped to RemoteOnly STT
+ * by CommonAppDelegate's incompatible-model sweep in the meantime).
+ *
  * Models are stored at: <filesDir>/models/<modelName>/ with config.txt,
- * vocab.txt, and .weights files, plus a .cactus_version marker.
+ * vocab.txt, and .weights files, plus the .cactus_version marker.
  */
 class CactusModelProvider(
     private val context: Context,
@@ -69,13 +81,11 @@ class CactusModelProvider(
     private val installer by lazy { ModelZipInstaller(httpClient, context.cacheDir, modelsDir) }
 
     override suspend fun getSTTModelPath(): String = withContext(Dispatchers.IO) {
-        val modelName = CommonBuildKonfig.CACTUS_STT_MODEL
-        return@withContext resolveModelPath(modelName, CommonBuildKonfig.CACTUS_WEIGHTS_VERSION)
+        return@withContext resolveModelPath(CommonBuildKonfig.CACTUS_STT_MODEL)
     }
 
     override suspend fun getLMModelPath(): String = withContext(Dispatchers.IO) {
-        val modelName = CommonBuildKonfig.CACTUS_LM_MODEL_NAME
-        return@withContext resolveModelPath(modelName, CommonBuildKonfig.CACTUS_WEIGHTS_VERSION)
+        return@withContext resolveModelPath(CommonBuildKonfig.CACTUS_LM_MODEL_NAME)
     }
 
     override fun isModelDownloaded(modelName: String): Boolean {
@@ -98,9 +108,9 @@ class CactusModelProvider(
     }
 
     private fun versionMatches(modelName: String): Boolean {
-        val versionFile = modelsDir.resolve(modelName).resolve(".cactus_version")
-        return versionFile.exists() &&
-            versionFile.readText().trim() == CommonBuildKonfig.CACTUS_WEIGHTS_VERSION
+        val versionFile = modelsDir.resolve(modelName).resolve(ModelZipInstaller.VERSION_MARKER)
+        val marker = versionFile.takeIf { it.exists() }?.readText()?.trim() ?: return false
+        return CactusModelPins.markerMatches(modelName, marker)
     }
 
     private fun isBundled(modelName: String): Boolean =
@@ -119,30 +129,31 @@ class CactusModelProvider(
         // Fork: never configure the native cactus telemetry environment.
     }
 
-    private suspend fun resolveModelPath(modelName: String, version: String): String = mutexFor(modelName).withLock {
+    private suspend fun resolveModelPath(modelName: String): String = mutexFor(modelName).withLock {
         val modelDir = modelsDir.resolve(modelName)
-        val versionFile = modelDir.resolve(".cactus_version")
 
-        val needsDownload = !modelDir.exists()
-            || !modelDir.resolve("config.txt").exists()
-            || !versionFile.exists()
-            || versionFile.readText().trim() != version
+        val needsInstall = !modelDir.resolve(ModelZipInstaller.CONFIG_FILE).exists()
+            || !versionMatches(modelName)
 
-        if (needsDownload) {
-            downloadAndExtract(modelName, version)
-            versionFile.writeText(version)
+        if (needsInstall) {
+            // Fail closed on an unpinned model name: without integrity data
+            // there is no verifiable download, and the native parser must
+            // never see an unverified archive.
+            val pin = CactusModelPins.pinFor(modelName)
+                ?: throw IllegalStateException("No integrity pin for model '$modelName'; refusing to download")
+            downloadAndExtract(modelName, pin)
         }
 
         logger.d { "Model '$modelName' at: ${modelDir.absolutePath}" }
         return modelDir.absolutePath
     }
 
-    private suspend fun downloadAndExtract(modelName: String, version: String) = withContext(Dispatchers.IO) {
+    private suspend fun downloadAndExtract(modelName: String, pin: ModelPin) = withContext(Dispatchers.IO) {
         val zipName = ModelZipInstaller.zipNameFor(modelName)
         val bundled = context.assets.list("models")?.contains(zipName) == true
         installer.install(
             modelName = modelName,
-            version = version,
+            pin = pin,
             copyBundledZip = if (bundled) {
                 { dest: File ->
                     logger.i { "Found included model zip in assets: $zipName, extracting..." }

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/CactusModelProvider.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/CactusModelProvider.kt
@@ -3,24 +3,15 @@ package coredevices.coreapp.model
 import android.content.Context
 import co.touchlab.kermit.Logger
 import coredevices.util.CommonBuildKonfig
-import coredevices.util.models.promoteSingleRootDir
 import coredevices.util.transcription.CactusModelPathProvider
-import kotlinx.coroutines.CancellationException
+import io.ktor.client.HttpClient
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import kotlinx.io.files.Path
-import okhttp3.OkHttpClient
-import okhttp3.Request
 import java.io.File
 import java.io.FileOutputStream
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
-import java.util.zip.ZipInputStream
 
 /**
  * Fork-owned Cactus model provider: resolves, downloads (Hugging Face), and
@@ -31,11 +22,13 @@ import java.util.zip.ZipInputStream
  * transcription is a core watch feature, and the only alternative STT paths
  * are cloud services or the GMS-backed platform recognizer, both dead on a
  * de-Googled ROM. This copy keeps dictation working. Fork deviations from
- * the upstream class: Context is constructor-injected instead of
- * service-located, the ring-only setCloudApiKey is dropped, and
- * initTelemetry is a no-op (the native cactus lib's telemetry environment is
- * never configured; a strings sweep of libcactus_engine.so found no
- * endpoints, so this is belt on top of suspenders).
+ * the upstream class: Context and the app's shared Ktor HttpClient are
+ * constructor-injected (upstream service-locates the Context and builds a
+ * one-off OkHttpClient per download), the download/extract pipeline lives
+ * in the testable [ModelZipInstaller] core, the ring-only setCloudApiKey is
+ * dropped, and initTelemetry is a no-op (the native cactus lib's telemetry
+ * environment is never configured; a strings sweep of libcactus_engine.so
+ * found no endpoints, so this is belt on top of suspenders).
  *
  * Provenance: copied from the tree as of commit ecdfa123, flattening
  * experimental/src/commonMain/kotlin/coredevices/ring/model/CactusModelProvider.kt
@@ -48,12 +41,12 @@ import java.util.zip.ZipInputStream
  * Models are stored at: <filesDir>/models/<modelName>/ with config.txt,
  * vocab.txt, and .weights files, plus a .cactus_version marker.
  */
-class CactusModelProvider(private val context: Context) : CactusModelPathProvider {
+class CactusModelProvider(
+    private val context: Context,
+    private val httpClient: HttpClient,
+) : CactusModelPathProvider {
     companion object {
         private val logger = Logger.withTag("CactusModelProvider")
-        private const val HF_BASE = "https://huggingface.co/Cactus-Compute"
-        private const val QUANTIZATION = "cq4"
-        private const val DOWNLOAD_BUFFER_SIZE = 256 * 1024
 
         // One mutex per model so an in-progress STT download doesn't head-of-line
         // block an unrelated LM resolve (or vice versa).
@@ -70,6 +63,10 @@ class CactusModelProvider(private val context: Context) : CactusModelPathProvide
     }
 
     private val modelsDir: File get() = context.filesDir.resolve("models").also { it.mkdirs() }
+
+    // Lazy so resolving the provider from the DI graph stays free of
+    // filesystem access; the dirs are only touched once an install runs.
+    private val installer by lazy { ModelZipInstaller(httpClient, context.cacheDir, modelsDir) }
 
     override suspend fun getSTTModelPath(): String = withContext(Dispatchers.IO) {
         val modelName = CommonBuildKonfig.CACTUS_STT_MODEL
@@ -107,7 +104,7 @@ class CactusModelProvider(private val context: Context) : CactusModelPathProvide
     }
 
     private fun isBundled(modelName: String): Boolean =
-        context.assets.list("models")?.contains("${modelName.lowercase()}-$QUANTIZATION.zip") == true
+        context.assets.list("models")?.contains(ModelZipInstaller.zipNameFor(modelName)) == true
 
     override fun deleteModel(modelName: String) {
         modelsDir.resolve(modelName).deleteRecursively()
@@ -132,7 +129,7 @@ class CactusModelProvider(private val context: Context) : CactusModelPathProvide
             || versionFile.readText().trim() != version
 
         if (needsDownload) {
-            downloadAndExtract(modelName, modelDir, version)
+            downloadAndExtract(modelName, version)
             versionFile.writeText(version)
         }
 
@@ -140,129 +137,24 @@ class CactusModelProvider(private val context: Context) : CactusModelPathProvide
         return modelDir.absolutePath
     }
 
-    private suspend fun downloadAndExtract(modelName: String, targetDir: File, version: String) = withContext(Dispatchers.IO) {
-        val zipName = "${modelName.lowercase()}-$QUANTIZATION.zip"
-
-        val tempZip = if (context.assets.list("models")?.contains(zipName) == true) {
-            logger.i { "Found included model zip in assets: $zipName, extracting..." }
-            val tempZip = File(context.cacheDir, "cactus_asset_$modelName.zip")
-            withContext(Dispatchers.IO) {
-                context.assets.open("models/$zipName").use { input ->
-                    FileOutputStream(tempZip).use { output ->
-                        input.copyTo(output)
-                    }
-                }
-            }
-            tempZip
-        } else {
-            val url = "$HF_BASE/$modelName/resolve/$version/$zipName"
-            logger.i { "Downloading model: $url" }
-
-            val tempZip = File(context.cacheDir, "cactus_download_$modelName.zip")
-            // Cancel the in-flight HTTP call if the coroutine is cancelled so a blocked
-            // socket read unblocks promptly instead of hanging until readTimeout.
-            val client = OkHttpClient.Builder()
-                .connectTimeout(30, TimeUnit.SECONDS)
-                .readTimeout(60, TimeUnit.SECONDS)
-                .followRedirects(true)
-                .followSslRedirects(true)
-                .build()
-            val call = client.newCall(Request.Builder().url(url).build())
-            val cancelHandle = currentCoroutineContext()[Job]?.invokeOnCompletion { cause ->
-                if (cause != null) call.cancel()
-            }
-            try {
-                call.execute().use { response ->
-                    if (!response.isSuccessful) {
-                        val errorBody = response.body?.string()?.take(500) ?: "no body"
-                        throw Exception("Download failed: HTTP ${response.code} for $url: $errorBody")
-                    }
-
-                    val body = response.body
-                        ?: throw Exception("Download failed: empty response body for $url")
-                    val totalBytes = body.contentLength()
-                    var downloadedBytes = 0L
-                    var lastLoggedPct = -1
-
-                    body.byteStream().use { input ->
-                        FileOutputStream(tempZip).use { output ->
-                            val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
-                            var bytesRead: Int
-                            while (input.read(buffer).also { bytesRead = it } != -1) {
-                                currentCoroutineContext().ensureActive()
-                                output.write(buffer, 0, bytesRead)
-                                downloadedBytes += bytesRead
-                                if (totalBytes > 0) {
-                                    val pct = (downloadedBytes * 100 / totalBytes).toInt()
-                                    if (pct / 10 > lastLoggedPct / 10) {
-                                        lastLoggedPct = pct
-                                        logger.d { "Download progress: $pct% ($downloadedBytes / $totalBytes)" }
-                                    }
-                                }
-                            }
+    private suspend fun downloadAndExtract(modelName: String, version: String) = withContext(Dispatchers.IO) {
+        val zipName = ModelZipInstaller.zipNameFor(modelName)
+        val bundled = context.assets.list("models")?.contains(zipName) == true
+        installer.install(
+            modelName = modelName,
+            version = version,
+            copyBundledZip = if (bundled) {
+                { dest: File ->
+                    logger.i { "Found included model zip in assets: $zipName, extracting..." }
+                    context.assets.open("models/$zipName").use { input ->
+                        FileOutputStream(dest).use { output ->
+                            input.copyTo(output)
                         }
                     }
                 }
-                logger.i { "Download complete: ${tempZip.length()} bytes" }
-                tempZip
-            } catch (e: CancellationException) {
-                logger.i { "Model download cancelled for $modelName" }
-                throw e
-            } catch (e: Exception) {
-                // A cancelled coroutine cancels the OkHttp call, surfacing as IOException;
-                // re-check liveness so cancellation propagates as CancellationException.
-                currentCoroutineContext().ensureActive()
-                logger.e(e) { "Model download failed for $modelName" }
-                throw e
-            } finally {
-                cancelHandle?.dispose()
-            }
-        }
-
-        try {
-            // Clear old model if present
-            if (targetDir.exists()) {
-                targetDir.deleteRecursively()
-            }
-            targetDir.mkdirs()
-
-            // Extract
-            ZipInputStream(tempZip.inputStream().buffered()).use { zis ->
-                var entry = zis.nextEntry
-                while (entry != null) {
-                    currentCoroutineContext().ensureActive()
-                    val outputFile = File(targetDir, entry.name)
-                    // ZIP Slip protection
-                    if (!outputFile.canonicalPath.startsWith(targetDir.canonicalPath)) {
-                        throw SecurityException("ZIP entry outside target dir: ${entry.name}")
-                    }
-                    if (entry.isDirectory) {
-                        outputFile.mkdirs()
-                    } else {
-                        outputFile.parentFile?.mkdirs()
-                        FileOutputStream(outputFile).use { fos ->
-                            zis.copyTo(fos)
-                        }
-                    }
-                    zis.closeEntry()
-                    entry = zis.nextEntry
-                }
-            }
-            promoteSingleRootDir(Path(targetDir.absolutePath))
-            logger.i { "Extraction complete to ${targetDir.absolutePath}" }
-        } catch (e: CancellationException) {
-            logger.i { "Model download cancelled for $modelName" }
-            targetDir.deleteRecursively()
-            throw e
-        } catch (e: Exception) {
-            // A cancelled coroutine cancels the OkHttp call, surfacing as IOException;
-            // re-check liveness so cancellation propagates as CancellationException.
-            currentCoroutineContext().ensureActive()
-            logger.e(e) { "Model download/extract failed for $modelName" }
-            targetDir.deleteRecursively()
-            throw e
-        } finally {
-            tempZip.delete()
-        }
+            } else {
+                null
+            },
+        )
     }
 }

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/ModelZipInstaller.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/ModelZipInstaller.kt
@@ -5,7 +5,6 @@ import coredevices.util.models.promoteSingleRootDir
 import io.ktor.client.HttpClient
 import io.ktor.client.request.prepareGet
 import io.ktor.client.statement.bodyAsChannel
-import io.ktor.http.contentLength
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.readAvailable
 import kotlinx.coroutines.CancellationException
@@ -15,26 +14,40 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.io.files.Path
 import java.io.File
 import java.io.FileOutputStream
+import java.security.MessageDigest
 import java.util.zip.ZipInputStream
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Download/extract core behind [CactusModelProvider]: obtains a model zip
- * (bundled asset or Hugging Face download) and installs it under
- * [modelsDir]/<model>.
+ * Verified download/extract core behind [CactusModelProvider]: obtains a
+ * model zip (bundled asset or Hugging Face download), verifies it against
+ * its [ModelPin], and installs it under [modelsDir]/<model>.
  *
- * Extracted from the provider so the whole obtain-and-install pipeline runs
- * under JVM unit tests with a mock HTTP engine and temp directories. The
- * class is deliberately Context-free: everything that needs an Android
+ * The archive feeds the native libcactus_engine.so parser, so nothing
+ * unverified may reach extraction. The layers, each defensible alone:
+ *  - the download URL resolves an immutable commit ([ModelPin.commitSha]),
+ *    so a retargeted release tag cannot swap the archive;
+ *  - the received bytes are hashed while streaming and checked against the
+ *    pinned SHA-256 and exact size before extraction, with a mid-stream
+ *    abort as soon as the pinned size is exceeded; bundled assets are
+ *    hashed through the same gate, so an APK repack cannot sneak weights
+ *    past it either;
+ *  - extraction is bounded (entry count, total uncompressed bytes) and
+ *    confined (separator-boundary Zip-Slip check), limiting even an
+ *    archive that matched a wrongly updated pin;
+ *  - everything lands in a staging directory that only replaces the live
+ *    model after full verification, so no failure mode destroys a working
+ *    install.
+ *
+ * The class is deliberately Context-free: everything that needs an Android
  * Context (asset access, directory roots) stays in the provider and is
- * handed in from outside.
+ * handed in from outside, which keeps the whole pipeline under JVM unit
+ * tests with a mock HTTP engine and temp directories.
  *
- * Transport is the app's shared Ktor [HttpClient] (the same one the
- * verified firmware installer uses). Instead of a whole-request read
- * timeout, each individual read gets [READ_STALL_TIMEOUT]: a healthy
- * multi-hundred-MB transfer legitimately takes minutes, while a stalled
- * socket should fail promptly. Coroutine cancellation aborts the in-flight
- * request through Ktor itself.
+ * Instead of a whole-request read timeout, each individual read gets
+ * [READ_STALL_TIMEOUT]: a healthy multi-hundred-MB transfer legitimately
+ * takes minutes, while a stalled socket should fail promptly. Coroutine
+ * cancellation aborts the in-flight request through Ktor itself.
  *
  * Callers hold the provider's per-model mutex and run [install] on an
  * IO-capable dispatcher; this class stays dispatcher-agnostic so tests can
@@ -52,49 +65,117 @@ class ModelZipInstaller(
         private const val DOWNLOAD_BUFFER_SIZE = 256 * 1024
         private val READ_STALL_TIMEOUT = 30.seconds
 
+        // Staging lives under modelsDir so the final swap is a same-filesystem
+        // rename; the dot name keeps it out of getDownloadedModels, which only
+        // looks at direct children carrying a config.txt.
+        internal const val STAGING_DIR = ".staging"
+        internal const val VERSION_MARKER = ".cactus_version"
+        internal const val CONFIG_FILE = "config.txt"
+
+        // Bounds for a hostile archive that somehow passed the digest gate
+        // (a wrongly updated pin): real model zips hold a handful of files
+        // and the cq4 weights barely compress, so both caps sit far above
+        // anything legitimate while still stopping zip bombs.
+        internal const val MAX_ENTRIES = 10_000
+        internal const val UNCOMPRESSED_CAP_FACTOR = 4L
+
         /** Zip naming convention shared by the HF repos and the bundled assets. */
         fun zipNameFor(modelName: String): String = "${modelName.lowercase()}-$QUANTIZATION.zip"
     }
 
     /**
-     * Obtains the zip for [modelName] and installs it to modelsDir/<model>,
-     * replacing whatever was there. [copyBundledZip] is non-null when the
-     * zip ships inside the APK; it writes the asset to the given file and
-     * skips the network entirely. The temp zip lives in [cacheDir] and is
-     * removed on every exit path, success or failure.
+     * Obtains the zip for [modelName], verifies it against [pin], and swaps
+     * it into modelsDir/<model>. [copyBundledZip] is non-null when the zip
+     * ships inside the APK; it writes the asset to the given file and skips
+     * the network entirely. The existing model directory survives every
+     * failure mode: it is only deleted after the staged replacement passed
+     * all checks, immediately before the rename. The temp zip lives in
+     * [cacheDir] and is removed on every exit path.
      */
     suspend fun install(
         modelName: String,
-        version: String,
+        pin: ModelPin,
         copyBundledZip: (suspend (dest: File) -> Unit)?,
     ) {
         val targetDir = modelsDir.resolve(modelName)
+        val stagingDir = modelsDir.resolve(STAGING_DIR).resolve(modelName)
         val tempZip = cacheDir.resolve(
             if (copyBundledZip != null) "cactus_asset_$modelName.zip" else "cactus_download_$modelName.zip",
         )
         try {
-            if (copyBundledZip != null) {
+            // A crashed or cancelled earlier install may have left staging
+            // behind; it was never verified as a whole, so start clean.
+            stagingDir.deleteRecursively()
+
+            val (obtainedBytes, obtainedSha256) = if (copyBundledZip != null) {
                 copyBundledZip(tempZip)
+                hashFile(tempZip)
             } else {
-                download(modelName, version, tempZip)
+                download(modelName, pin, tempZip)
             }
-            extract(modelName, tempZip, targetDir)
+            if (obtainedBytes != pin.zipSizeBytes || obtainedSha256 != pin.zipSha256Hex) {
+                throw SecurityException(
+                    "Model archive for $modelName failed verification: " +
+                        "got $obtainedBytes bytes / sha256 $obtainedSha256, " +
+                        "pinned ${pin.zipSizeBytes} bytes / sha256 ${pin.zipSha256Hex}",
+                )
+            }
+
+            extractToStaging(tempZip, stagingDir, pin)
+            promoteSingleRootDir(Path(stagingDir.absolutePath))
+            // Structural sanity on top of the digest: a verified archive
+            // that still does not look like a model means the pin itself is
+            // wrong, and must not replace a working install.
+            if (!stagingDir.resolve(CONFIG_FILE).exists()) {
+                throw SecurityException(
+                    "Verified archive for $modelName contains no $CONFIG_FILE; refusing to install it",
+                )
+            }
+            // Written into staging so the swap below is all-or-nothing: a
+            // model directory either carries the marker of a fully verified
+            // install or gets reinstalled.
+            stagingDir.resolve(VERSION_MARKER).writeText(pin.zipSha256Hex)
+
+            if (targetDir.exists()) {
+                targetDir.deleteRecursively()
+            }
+            if (!stagingDir.renameTo(targetDir)) {
+                throw Exception("Could not move the verified model for $modelName into place")
+            }
+            logger.i { "Installed verified model '$modelName' to ${targetDir.absolutePath}" }
+        } catch (e: CancellationException) {
+            logger.i { "Model install cancelled for $modelName" }
+            stagingDir.deleteRecursively()
+            throw e
+        } catch (e: Exception) {
+            // Transport failures can surface while the coroutine is being
+            // cancelled; re-check liveness so cancellation propagates as
+            // CancellationException rather than an install error.
+            currentCoroutineContext().ensureActive()
+            logger.e(e) { "Model install failed for $modelName" }
+            stagingDir.deleteRecursively()
+            throw e
         } finally {
             tempZip.delete()
         }
     }
 
-    private suspend fun download(modelName: String, version: String, tempZip: File) {
-        val url = "$HF_BASE/$modelName/resolve/$version/${zipNameFor(modelName)}"
+    /**
+     * Streams the pinned commit URL to [tempZip] while hashing, aborting as
+     * soon as more than the pinned byte count arrives. Returns received
+     * byte count and lowercase hex SHA-256 for the caller's gate.
+     */
+    private suspend fun download(modelName: String, pin: ModelPin, tempZip: File): Pair<Long, String> {
+        val url = "$HF_BASE/${pin.hfRepo}/resolve/${pin.commitSha}/${zipNameFor(modelName)}"
         logger.i { "Downloading model: $url" }
+        val digest = MessageDigest.getInstance("SHA-256")
+        var received = 0L
         try {
             httpClient.prepareGet(url).execute { response ->
                 if (!response.status.isSuccess()) {
                     throw Exception("Download failed: HTTP ${response.status.value} for $url")
                 }
-                val totalBytes = response.contentLength() ?: -1L
                 val channel = response.bodyAsChannel()
-                var downloadedBytes = 0L
                 var lastLoggedPct = -1
                 FileOutputStream(tempZip).use { output ->
                     val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
@@ -104,72 +185,101 @@ class ModelZipInstaller(
                         } ?: throw Exception("Download stalled for $url")
                         if (read == -1) break
                         if (read == 0) continue
+                        received += read
+                        if (received > pin.zipSizeBytes) {
+                            throw SecurityException(
+                                "Download for $modelName exceeded the pinned ${pin.zipSizeBytes} bytes; aborting",
+                            )
+                        }
                         output.write(buffer, 0, read)
-                        downloadedBytes += read
-                        if (totalBytes > 0) {
-                            val pct = (downloadedBytes * 100 / totalBytes).toInt()
-                            if (pct / 10 > lastLoggedPct / 10) {
-                                lastLoggedPct = pct
-                                logger.d { "Download progress: $pct% ($downloadedBytes / $totalBytes)" }
-                            }
+                        digest.update(buffer, 0, read)
+                        val pct = (received * 100 / pin.zipSizeBytes).toInt()
+                        if (pct / 10 > lastLoggedPct / 10) {
+                            lastLoggedPct = pct
+                            logger.d { "Download progress: $pct% ($received / ${pin.zipSizeBytes})" }
                         }
                     }
                 }
             }
-            logger.i { "Download complete: ${tempZip.length()} bytes" }
         } catch (e: CancellationException) {
             logger.i { "Model download cancelled for $modelName" }
             throw e
         } catch (e: Exception) {
-            // Transport failures can surface while the coroutine is being
-            // cancelled; re-check liveness so cancellation propagates as
-            // CancellationException rather than a download error.
             currentCoroutineContext().ensureActive()
             logger.e(e) { "Model download failed for $modelName" }
             throw e
         }
+        logger.i { "Download complete: $received bytes" }
+        return received to digest.toHexString()
     }
 
-    private suspend fun extract(modelName: String, tempZip: File, targetDir: File) {
-        try {
-            // Clear old model if present
-            if (targetDir.exists()) {
-                targetDir.deleteRecursively()
+    /** Size and SHA-256 of an already-local zip; the bundled-asset gate. */
+    private fun hashFile(file: File): Pair<Long, String> {
+        val digest = MessageDigest.getInstance("SHA-256")
+        var size = 0L
+        file.inputStream().buffered().use { input ->
+            val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
+            while (true) {
+                val read = input.read(buffer)
+                if (read == -1) break
+                size += read
+                digest.update(buffer, 0, read)
             }
-            targetDir.mkdirs()
+        }
+        return size to digest.toHexString()
+    }
 
-            ZipInputStream(tempZip.inputStream().buffered()).use { zis ->
-                var entry = zis.nextEntry
-                while (entry != null) {
-                    currentCoroutineContext().ensureActive()
-                    val outputFile = File(targetDir, entry.name)
-                    // ZIP Slip protection
-                    if (!outputFile.canonicalPath.startsWith(targetDir.canonicalPath)) {
-                        throw SecurityException("ZIP entry outside target dir: ${entry.name}")
-                    }
-                    if (entry.isDirectory) {
-                        outputFile.mkdirs()
-                    } else {
-                        outputFile.parentFile?.mkdirs()
-                        FileOutputStream(outputFile).use { fos ->
-                            zis.copyTo(fos)
+    private suspend fun extractToStaging(tempZip: File, stagingDir: File, pin: ModelPin) {
+        stagingDir.mkdirs()
+        // Separator-boundary confinement: comparing against the bare prefix
+        // would accept an escape to a sibling whose name merely starts with
+        // the staging dir's (entry "../<model>-evil/...").
+        val stagingRoot = stagingDir.canonicalPath
+        val stagingPrefix = stagingRoot + File.separator
+        val uncompressedCap = pin.zipSizeBytes * UNCOMPRESSED_CAP_FACTOR
+        var entryCount = 0
+        var totalUncompressed = 0L
+        val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
+        ZipInputStream(tempZip.inputStream().buffered()).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                currentCoroutineContext().ensureActive()
+                entryCount++
+                if (entryCount > MAX_ENTRIES) {
+                    throw SecurityException("Model archive has more than $MAX_ENTRIES entries; refusing to extract")
+                }
+                val outputFile = File(stagingDir, entry.name)
+                val canonical = outputFile.canonicalPath
+                if (canonical != stagingRoot && !canonical.startsWith(stagingPrefix)) {
+                    throw SecurityException("ZIP entry outside target dir: ${entry.name}")
+                }
+                if (entry.isDirectory) {
+                    outputFile.mkdirs()
+                } else {
+                    outputFile.parentFile?.mkdirs()
+                    FileOutputStream(outputFile).use { fos ->
+                        // Count what actually inflates rather than trusting
+                        // the entry's declared size.
+                        while (true) {
+                            val read = zis.read(buffer)
+                            if (read == -1) break
+                            totalUncompressed += read
+                            if (totalUncompressed > uncompressedCap) {
+                                throw SecurityException(
+                                    "Model archive inflates past $uncompressedCap bytes; refusing to extract",
+                                )
+                            }
+                            fos.write(buffer, 0, read)
                         }
                     }
-                    zis.closeEntry()
-                    entry = zis.nextEntry
                 }
+                zis.closeEntry()
+                entry = zis.nextEntry
             }
-            promoteSingleRootDir(Path(targetDir.absolutePath))
-            logger.i { "Extraction complete to ${targetDir.absolutePath}" }
-        } catch (e: CancellationException) {
-            logger.i { "Model install cancelled for $modelName" }
-            targetDir.deleteRecursively()
-            throw e
-        } catch (e: Exception) {
-            currentCoroutineContext().ensureActive()
-            logger.e(e) { "Model extract failed for $modelName" }
-            targetDir.deleteRecursively()
-            throw e
         }
+        logger.i { "Extraction complete to ${stagingDir.absolutePath}" }
     }
+
+    private fun MessageDigest.toHexString(): String =
+        digest().joinToString("") { "%02x".format(it) }
 }

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/ModelZipInstaller.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/ModelZipInstaller.kt
@@ -1,0 +1,175 @@
+package coredevices.coreapp.model
+
+import co.touchlab.kermit.Logger
+import coredevices.util.models.promoteSingleRootDir
+import io.ktor.client.HttpClient
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.http.contentLength
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.readAvailable
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.io.files.Path
+import java.io.File
+import java.io.FileOutputStream
+import java.util.zip.ZipInputStream
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Download/extract core behind [CactusModelProvider]: obtains a model zip
+ * (bundled asset or Hugging Face download) and installs it under
+ * [modelsDir]/<model>.
+ *
+ * Extracted from the provider so the whole obtain-and-install pipeline runs
+ * under JVM unit tests with a mock HTTP engine and temp directories. The
+ * class is deliberately Context-free: everything that needs an Android
+ * Context (asset access, directory roots) stays in the provider and is
+ * handed in from outside.
+ *
+ * Transport is the app's shared Ktor [HttpClient] (the same one the
+ * verified firmware installer uses). Instead of a whole-request read
+ * timeout, each individual read gets [READ_STALL_TIMEOUT]: a healthy
+ * multi-hundred-MB transfer legitimately takes minutes, while a stalled
+ * socket should fail promptly. Coroutine cancellation aborts the in-flight
+ * request through Ktor itself.
+ *
+ * Callers hold the provider's per-model mutex and run [install] on an
+ * IO-capable dispatcher; this class stays dispatcher-agnostic so tests can
+ * drive it on a virtual-time dispatcher.
+ */
+class ModelZipInstaller(
+    private val httpClient: HttpClient,
+    private val cacheDir: File,
+    private val modelsDir: File,
+) {
+    companion object {
+        private val logger = Logger.withTag("ModelZipInstaller")
+        private const val HF_BASE = "https://huggingface.co/Cactus-Compute"
+        private const val QUANTIZATION = "cq4"
+        private const val DOWNLOAD_BUFFER_SIZE = 256 * 1024
+        private val READ_STALL_TIMEOUT = 30.seconds
+
+        /** Zip naming convention shared by the HF repos and the bundled assets. */
+        fun zipNameFor(modelName: String): String = "${modelName.lowercase()}-$QUANTIZATION.zip"
+    }
+
+    /**
+     * Obtains the zip for [modelName] and installs it to modelsDir/<model>,
+     * replacing whatever was there. [copyBundledZip] is non-null when the
+     * zip ships inside the APK; it writes the asset to the given file and
+     * skips the network entirely. The temp zip lives in [cacheDir] and is
+     * removed on every exit path, success or failure.
+     */
+    suspend fun install(
+        modelName: String,
+        version: String,
+        copyBundledZip: (suspend (dest: File) -> Unit)?,
+    ) {
+        val targetDir = modelsDir.resolve(modelName)
+        val tempZip = cacheDir.resolve(
+            if (copyBundledZip != null) "cactus_asset_$modelName.zip" else "cactus_download_$modelName.zip",
+        )
+        try {
+            if (copyBundledZip != null) {
+                copyBundledZip(tempZip)
+            } else {
+                download(modelName, version, tempZip)
+            }
+            extract(modelName, tempZip, targetDir)
+        } finally {
+            tempZip.delete()
+        }
+    }
+
+    private suspend fun download(modelName: String, version: String, tempZip: File) {
+        val url = "$HF_BASE/$modelName/resolve/$version/${zipNameFor(modelName)}"
+        logger.i { "Downloading model: $url" }
+        try {
+            httpClient.prepareGet(url).execute { response ->
+                if (!response.status.isSuccess()) {
+                    throw Exception("Download failed: HTTP ${response.status.value} for $url")
+                }
+                val totalBytes = response.contentLength() ?: -1L
+                val channel = response.bodyAsChannel()
+                var downloadedBytes = 0L
+                var lastLoggedPct = -1
+                FileOutputStream(tempZip).use { output ->
+                    val buffer = ByteArray(DOWNLOAD_BUFFER_SIZE)
+                    while (true) {
+                        val read = withTimeoutOrNull(READ_STALL_TIMEOUT) {
+                            channel.readAvailable(buffer, 0, buffer.size)
+                        } ?: throw Exception("Download stalled for $url")
+                        if (read == -1) break
+                        if (read == 0) continue
+                        output.write(buffer, 0, read)
+                        downloadedBytes += read
+                        if (totalBytes > 0) {
+                            val pct = (downloadedBytes * 100 / totalBytes).toInt()
+                            if (pct / 10 > lastLoggedPct / 10) {
+                                lastLoggedPct = pct
+                                logger.d { "Download progress: $pct% ($downloadedBytes / $totalBytes)" }
+                            }
+                        }
+                    }
+                }
+            }
+            logger.i { "Download complete: ${tempZip.length()} bytes" }
+        } catch (e: CancellationException) {
+            logger.i { "Model download cancelled for $modelName" }
+            throw e
+        } catch (e: Exception) {
+            // Transport failures can surface while the coroutine is being
+            // cancelled; re-check liveness so cancellation propagates as
+            // CancellationException rather than a download error.
+            currentCoroutineContext().ensureActive()
+            logger.e(e) { "Model download failed for $modelName" }
+            throw e
+        }
+    }
+
+    private suspend fun extract(modelName: String, tempZip: File, targetDir: File) {
+        try {
+            // Clear old model if present
+            if (targetDir.exists()) {
+                targetDir.deleteRecursively()
+            }
+            targetDir.mkdirs()
+
+            ZipInputStream(tempZip.inputStream().buffered()).use { zis ->
+                var entry = zis.nextEntry
+                while (entry != null) {
+                    currentCoroutineContext().ensureActive()
+                    val outputFile = File(targetDir, entry.name)
+                    // ZIP Slip protection
+                    if (!outputFile.canonicalPath.startsWith(targetDir.canonicalPath)) {
+                        throw SecurityException("ZIP entry outside target dir: ${entry.name}")
+                    }
+                    if (entry.isDirectory) {
+                        outputFile.mkdirs()
+                    } else {
+                        outputFile.parentFile?.mkdirs()
+                        FileOutputStream(outputFile).use { fos ->
+                            zis.copyTo(fos)
+                        }
+                    }
+                    zis.closeEntry()
+                    entry = zis.nextEntry
+                }
+            }
+            promoteSingleRootDir(Path(targetDir.absolutePath))
+            logger.i { "Extraction complete to ${targetDir.absolutePath}" }
+        } catch (e: CancellationException) {
+            logger.i { "Model install cancelled for $modelName" }
+            targetDir.deleteRecursively()
+            throw e
+        } catch (e: Exception) {
+            currentCoroutineContext().ensureActive()
+            logger.e(e) { "Model extract failed for $modelName" }
+            targetDir.deleteRecursively()
+            throw e
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/ModelZipInstaller.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/model/ModelZipInstaller.kt
@@ -44,6 +44,14 @@ import kotlin.time.Duration.Companion.seconds
  * handed in from outside, which keeps the whole pipeline under JVM unit
  * tests with a mock HTTP engine and temp directories.
  *
+ * Provenance: the download loop, buffer size, zip naming convention,
+ * extraction loop, and temp-file handling were extracted from the fork's
+ * [CactusModelProvider] copy and so ultimately derive from the unplugged
+ * upstream class (experimental/src/commonMain/kotlin/coredevices/ring/
+ * model/CactusModelProvider.kt). The provider's re-diff-after-upstream-merge
+ * instruction names this file as a porting target; upstream fixes to their
+ * download/extract logic belong here.
+ *
  * Instead of a whole-request read timeout, each individual read gets
  * [READ_STALL_TIMEOUT]: a healthy multi-hundred-MB transfer legitimately
  * takes minutes, while a stalled socket should fail promptly. Coroutine
@@ -72,6 +80,10 @@ class ModelZipInstaller(
         internal const val VERSION_MARKER = ".cactus_version"
         internal const val CONFIG_FILE = "config.txt"
 
+        // Where the live model is parked during the swap; under STAGING_DIR
+        // so it shares the dot-dir invisibility and the same filesystem.
+        internal const val OLD_ASIDE_SUFFIX = ".old"
+
         // Bounds for a hostile archive that somehow passed the digest gate
         // (a wrongly updated pin): real model zips hold a handful of files
         // and the cq4 weights barely compress, so both caps sit far above
@@ -88,9 +100,10 @@ class ModelZipInstaller(
      * it into modelsDir/<model>. [copyBundledZip] is non-null when the zip
      * ships inside the APK; it writes the asset to the given file and skips
      * the network entirely. The existing model directory survives every
-     * failure mode: it is only deleted after the staged replacement passed
-     * all checks, immediately before the rename. The temp zip lives in
-     * [cacheDir] and is removed on every exit path.
+     * failure mode: it is parked aside (never deleted) until the staged
+     * replacement that passed all checks has been renamed into place, and a
+     * failed swap renames it straight back. The temp zip and the staging
+     * directory are removed on every exit path.
      */
     suspend fun install(
         modelName: String,
@@ -99,13 +112,27 @@ class ModelZipInstaller(
     ) {
         val targetDir = modelsDir.resolve(modelName)
         val stagingDir = modelsDir.resolve(STAGING_DIR).resolve(modelName)
+        val oldAsideDir = modelsDir.resolve(STAGING_DIR).resolve("$modelName$OLD_ASIDE_SUFFIX")
         val tempZip = cacheDir.resolve(
             if (copyBundledZip != null) "cactus_asset_$modelName.zip" else "cactus_download_$modelName.zip",
         )
         try {
+            // A process death between the two swap renames below leaves the
+            // working install parked aside and no live model dir; restore it
+            // first so even that crash never costs the install.
+            if (!targetDir.exists() && oldAsideDir.exists()) {
+                oldAsideDir.renameTo(targetDir)
+            }
             // A crashed or cancelled earlier install may have left staging
-            // behind; it was never verified as a whole, so start clean.
+            // or a swapped-out old model behind; neither is trusted as a
+            // whole, so start clean. The parked copy is only swept while a
+            // live install exists: if the restore above failed it is the
+            // sole copy, and deleting it would turn a rename hiccup into a
+            // lost install.
             stagingDir.deleteRecursively()
+            if (targetDir.exists()) {
+                oldAsideDir.deleteRecursively()
+            }
 
             val (obtainedBytes, obtainedSha256) = if (copyBundledZip != null) {
                 copyBundledZip(tempZip)
@@ -136,16 +163,24 @@ class ModelZipInstaller(
             // install or gets reinstalled.
             stagingDir.resolve(VERSION_MARKER).writeText(pin.zipSha256Hex)
 
-            if (targetDir.exists()) {
-                targetDir.deleteRecursively()
+            // Swap by parking the live install aside instead of deleting it:
+            // an I/O failure at any single step leaves either the old or the
+            // new model in place (a delete-then-rename would lose both to a
+            // partial delete), and the recovery at the top of install covers
+            // a process death between the renames.
+            if (targetDir.exists() && !targetDir.renameTo(oldAsideDir)) {
+                throw Exception("Could not move the old model for $modelName aside; keeping it")
             }
             if (!stagingDir.renameTo(targetDir)) {
+                oldAsideDir.renameTo(targetDir)
                 throw Exception("Could not move the verified model for $modelName into place")
+            }
+            if (!oldAsideDir.deleteRecursively()) {
+                logger.w { "Old model for $modelName not fully removed; leftovers are swept on the next install" }
             }
             logger.i { "Installed verified model '$modelName' to ${targetDir.absolutePath}" }
         } catch (e: CancellationException) {
             logger.i { "Model install cancelled for $modelName" }
-            stagingDir.deleteRecursively()
             throw e
         } catch (e: Exception) {
             // Transport failures can surface while the coroutine is being
@@ -153,9 +188,13 @@ class ModelZipInstaller(
             // CancellationException rather than an install error.
             currentCoroutineContext().ensureActive()
             logger.e(e) { "Model install failed for $modelName" }
-            stagingDir.deleteRecursively()
             throw e
         } finally {
+            // Cleanup lives here, not in the catch arms, so it also runs
+            // when ensureActive above rethrows as CancellationException;
+            // after a successful swap the staging dir is already gone and
+            // this is a no-op.
+            stagingDir.deleteRecursively()
             tempZip.delete()
         }
     }

--- a/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/BoostRefCounterTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/BoostRefCounterTest.kt
@@ -1,0 +1,82 @@
+package coredevices.coreapp
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the boost lifecycle policy: one service instance across
+ * overlapping transcriptions, stop only after the count drains and only
+ * through the re-checked main-thread hop, and a start failure (the
+ * API 31+ background-start restriction outside the companion-device
+ * exemption) degrades quietly instead of taking dictation down with it.
+ */
+class BoostRefCounterTest {
+
+    private var starts = 0
+    private var stops = 0
+    private var startThrows = false
+    private val mainQueue = mutableListOf<() -> Unit>()
+
+    private val counter = BoostRefCounter(
+        start = {
+            starts++
+            if (startThrows) throw IllegalStateException("background start not allowed")
+        },
+        stop = { stops++ },
+        postToMain = { action -> mainQueue += action },
+    )
+
+    private fun drainMain() {
+        while (mainQueue.isNotEmpty()) mainQueue.removeAt(0).invoke()
+    }
+
+    @Test
+    fun outerAcquireStartsExactlyOnce() {
+        counter.acquire()
+        counter.acquire()
+        assertEquals(1, starts, "nested acquires must share the running service")
+    }
+
+    @Test
+    fun innerReleaseDoesNotStop() {
+        counter.acquire()
+        counter.acquire()
+        counter.release()
+        drainMain()
+        assertEquals(0, stops, "the service must survive while any transcription still holds it")
+    }
+
+    @Test
+    fun drainingToZeroStopsViaTheMainThreadHop() {
+        counter.acquire()
+        counter.release()
+        assertEquals(0, stops, "stop must be posted, not run inline, so onStartCommand wins the race")
+        drainMain()
+        assertEquals(1, stops)
+    }
+
+    @Test
+    fun reacquireWhileStopIsPendingSuppressesIt() {
+        counter.acquire()
+        counter.release()
+        counter.acquire()
+        drainMain()
+        assertEquals(0, stops, "a transcription that began while the stop was queued keeps the service")
+        assertEquals(2, starts)
+    }
+
+    @Test
+    fun startFailureDegradesQuietlyAndStaysConsistent() {
+        startThrows = true
+        counter.acquire()
+        counter.acquire()
+        counter.release()
+        counter.release()
+        drainMain()
+        assertEquals(1, starts)
+        assertEquals(1, stops, "the drain still posts its stop; stopping a never-started service is harmless")
+        startThrows = false
+        counter.acquire()
+        assertEquals(2, starts, "the next session must retry the boost")
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/BoostRefCounterTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/BoostRefCounterTest.kt
@@ -5,10 +5,13 @@ import kotlin.test.assertEquals
 
 /**
  * Pins the boost lifecycle policy: one service instance across
- * overlapping transcriptions, stop only after the count drains and only
- * through the re-checked main-thread hop, and a start failure (the
- * API 31+ background-start restriction outside the companion-device
- * exemption) degrades quietly instead of taking dictation down with it.
+ * overlapping transcriptions, stop only after the count drains, and both
+ * start and stop serialized through the main-thread queue (an inline
+ * start could be overtaken by a posted stop's re-check and leave a held
+ * boost without its service; the upstream-inherited race this fork
+ * closes). A start failure (the API 31+ background-start restriction
+ * outside the companion-device exemption) degrades quietly instead of
+ * taking dictation down with it.
  */
 class BoostRefCounterTest {
 
@@ -31,9 +34,18 @@ class BoostRefCounterTest {
     }
 
     @Test
+    fun startGoesThroughTheMainQueue() {
+        counter.acquire()
+        assertEquals(0, starts, "start must be queued, not inline: inline starts race a posted stop's re-check")
+        drainMain()
+        assertEquals(1, starts)
+    }
+
+    @Test
     fun outerAcquireStartsExactlyOnce() {
         counter.acquire()
         counter.acquire()
+        drainMain()
         assertEquals(1, starts, "nested acquires must share the running service")
     }
 
@@ -50,7 +62,7 @@ class BoostRefCounterTest {
     fun drainingToZeroStopsViaTheMainThreadHop() {
         counter.acquire()
         counter.release()
-        assertEquals(0, stops, "stop must be posted, not run inline, so onStartCommand wins the race")
+        assertEquals(0, stops, "stop must be queued, not run inline, so the re-check serializes with starts")
         drainMain()
         assertEquals(1, stops)
     }
@@ -58,10 +70,24 @@ class BoostRefCounterTest {
     @Test
     fun reacquireWhileStopIsPendingSuppressesIt() {
         counter.acquire()
+        drainMain()
         counter.release()
         counter.acquire()
         drainMain()
         assertEquals(0, stops, "a transcription that began while the stop was queued keeps the service")
+        assertEquals(2, starts, "the queued start refreshes the service behind the suppressed stop")
+    }
+
+    @Test
+    fun releaseAfterTheSuppressedStopStillStops() {
+        counter.acquire()
+        drainMain()
+        counter.release()
+        counter.acquire()
+        drainMain()
+        counter.release()
+        drainMain()
+        assertEquals(1, stops, "the final release must still shut the service down")
         assertEquals(2, starts)
     }
 
@@ -77,6 +103,7 @@ class BoostRefCounterTest {
         assertEquals(1, stops, "the drain still posts its stop; stopping a never-started service is harmless")
         startThrows = false
         counter.acquire()
+        drainMain()
         assertEquals(2, starts, "the next session must retry the boost")
     }
 }

--- a/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/InferenceBoostServiceContractTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/InferenceBoostServiceContractTest.kt
@@ -1,0 +1,26 @@
+package coredevices.coreapp
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+/**
+ * Pins the one piece of InferenceBoostService that upstream's equivalent
+ * lacks and that nothing would catch if it silently disappeared: the
+ * onTimeout override. When the shortService budget (about 3 minutes)
+ * expires, a service that does not stop promptly ANRs the whole app, and
+ * the failure only reproduces on transcriptions long enough to blow the
+ * budget, so it would ship unnoticed. The service's start/stop behavior
+ * itself is covered on-device by InferenceBoostLifecycleTest.
+ */
+class InferenceBoostServiceContractTest {
+
+    @Test
+    fun onTimeoutOverrideIsDeclared() {
+        // getDeclaredMethod sees only methods declared on the class itself,
+        // so inheriting the framework's no-op default fails this test.
+        assertNotNull(
+            InferenceBoostService::class.java.getDeclaredMethod("onTimeout", Int::class.javaPrimitiveType),
+            "InferenceBoostService must override onTimeout or a long transcription ANRs the app",
+        )
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/model/CactusModelPinsTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/model/CactusModelPinsTest.kt
@@ -1,0 +1,109 @@
+package coredevices.coreapp.model
+
+import coredevices.util.CommonBuildKonfig
+import java.io.File
+import java.security.MessageDigest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Pins the pin table itself: every model the build can request must have
+ * well-formed integrity data, the marker semantics must reinstall exactly
+ * when the pin moves (grandfathering the pre-pinning tag markers until
+ * then), and the bundled LM asset in the repo must match its pin, so a
+ * silently swapped or drifted asset fails the suite (the runtime digest
+ * gate would refuse it only at install time, on a user's device).
+ */
+class CactusModelPinsTest {
+
+    private val stt = CommonBuildKonfig.CACTUS_STT_MODEL
+    private val lm = CommonBuildKonfig.CACTUS_LM_MODEL_NAME
+
+    @Test
+    fun everyBuildKonfigModelHasAPin() {
+        assertNotNull(CactusModelPins.pinFor(stt), "STT model '$stt' must be pinned")
+        assertNotNull(CactusModelPins.pinFor(lm), "LM model '$lm' must be pinned")
+    }
+
+    @Test
+    fun pinsAreWellFormed() {
+        listOf(stt, lm).forEach { name ->
+            val pin = assertNotNull(CactusModelPins.pinFor(name))
+            assertTrue(pin.commitSha.matches(Regex("[0-9a-f]{40}")), "$name commitSha malformed: ${pin.commitSha}")
+            assertTrue(pin.zipSha256Hex.matches(Regex("[0-9a-f]{64}")), "$name sha256 malformed: ${pin.zipSha256Hex}")
+            assertTrue(pin.zipSizeBytes > 0, "$name size must be positive")
+        }
+    }
+
+    @Test
+    fun unknownModelHasNoPinAndNeverMatches() {
+        assertNull(CactusModelPins.pinFor("whisper-tiny"))
+        assertFalse(CactusModelPins.markerMatches("whisper-tiny", "anything"))
+    }
+
+    @Test
+    fun pinnedDigestMarkerMatches() {
+        listOf(stt, lm).forEach { name ->
+            val pin = assertNotNull(CactusModelPins.pinFor(name))
+            assertTrue(CactusModelPins.markerMatches(name, pin.zipSha256Hex))
+        }
+    }
+
+    @Test
+    fun legacyTagMarkersAreGrandfatheredWhileThePinsStillNameTheV201Archives() {
+        // Both current pins are the v2.0.1 archives, so installs whose
+        // marker predates digest pinning must not be reinstalled (383 MB
+        // re-download) or flagged incompatible (RemoteOnly downgrade).
+        listOf(stt, lm).forEach { name ->
+            assertTrue(
+                CactusModelPins.markerMatches(name, CactusModelPins.LEGACY_TAG_MARKER),
+                "legacy marker must stay valid for '$name' while its pin is unchanged",
+            )
+        }
+    }
+
+    @Test
+    fun aMovedPinRejectsTheLegacyMarkerAndTheOldDigest() {
+        val oldSha = "aa".repeat(32)
+        val newSha = "bb".repeat(32)
+        val moved = ModelPin(
+            hfRepo = "some-model",
+            commitSha = "cc".repeat(20),
+            zipSha256Hex = newSha,
+            zipSizeBytes = 1,
+        )
+        // Once a pin names a new archive, everything older must reinstall:
+        // the legacy tag, and markers of the previously pinned digest.
+        assertFalse(CactusModelPins.markerMatchesPin(CactusModelPins.LEGACY_TAG_MARKER, moved, legacySha256 = oldSha))
+        assertFalse(CactusModelPins.markerMatchesPin(oldSha, moved, legacySha256 = oldSha))
+        assertTrue(CactusModelPins.markerMatchesPin(newSha, moved, legacySha256 = oldSha))
+        // A model with no legacy history never accepts the tag marker.
+        assertFalse(CactusModelPins.markerMatchesPin(CactusModelPins.LEGACY_TAG_MARKER, moved, legacySha256 = null))
+        // The grandfather clause: legacy marker accepted only while the pin
+        // still names the archive the tag shipped.
+        val unmoved = moved.copy(zipSha256Hex = oldSha)
+        assertTrue(CactusModelPins.markerMatchesPin(CactusModelPins.LEGACY_TAG_MARKER, unmoved, legacySha256 = oldSha))
+    }
+
+    @Test
+    fun bundledLmAssetMatchesItsPin() {
+        val pin = assertNotNull(CactusModelPins.pinFor(lm))
+        // The asset in androidMain/assets/models is a symlink to this file;
+        // walk up from the test working dir so the check is independent of
+        // where Gradle runs it.
+        val asset = generateSequence(File(System.getProperty("user.dir")).absoluteFile) { it.parentFile }
+            .map { it.resolve("models/${ModelZipInstaller.zipNameFor(lm)}") }
+            .firstOrNull { it.isFile }
+            ?: fail("could not locate the bundled LM asset from ${System.getProperty("user.dir")}")
+        assertEquals(pin.zipSizeBytes, asset.length(), "bundled LM asset size drifted from its pin")
+        val sha = MessageDigest.getInstance("SHA-256")
+            .digest(asset.readBytes())
+            .joinToString("") { "%02x".format(it) }
+        assertEquals(pin.zipSha256Hex, sha, "bundled LM asset digest drifted from its pin")
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/model/CactusModelPinsTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/model/CactusModelPinsTest.kt
@@ -15,7 +15,9 @@ import kotlin.test.fail
  * Pins the pin table itself: every model the build can request must have
  * well-formed integrity data, the marker semantics must reinstall exactly
  * when the pin moves (grandfathering the pre-pinning tag markers until
- * then), and the bundled LM asset in the repo must match its pin, so a
+ * then), the table must have been derived from the weights tag the build
+ * ships (so an upstream tag bump cannot be silently inert), and the
+ * bundled LM asset at the path the APK packages must match its pin, so a
  * silently swapped or drifted asset fails the suite (the runtime digest
  * gate would refuse it only at install time, on a user's device).
  */
@@ -28,6 +30,19 @@ class CactusModelPinsTest {
     fun everyBuildKonfigModelHasAPin() {
         assertNotNull(CactusModelPins.pinFor(stt), "STT model '$stt' must be pinned")
         assertNotNull(CactusModelPins.pinFor(lm), "LM model '$lm' must be pinned")
+    }
+
+    @Test
+    fun pinsWereDerivedFromTheCurrentWeightsTag() {
+        // An upstream CACTUS_WEIGHTS_VERSION bump merges conflict-free and
+        // changes nothing at runtime here (downloads resolve the pinned
+        // commits, not the tag), so without this tripwire users would just
+        // silently keep the old weights forever.
+        assertEquals(
+            CommonBuildKonfig.CACTUS_WEIGHTS_VERSION,
+            CactusModelPins.DERIVED_FROM_WEIGHTS_TAG,
+            "the weights tag moved; run the re-pin procedure in the CactusModelPins KDoc",
+        )
     }
 
     @Test
@@ -93,13 +108,16 @@ class CactusModelPinsTest {
     @Test
     fun bundledLmAssetMatchesItsPin() {
         val pin = assertNotNull(CactusModelPins.pinFor(lm))
-        // The asset in androidMain/assets/models is a symlink to this file;
-        // walk up from the test working dir so the check is independent of
-        // where Gradle runs it.
+        // Hash the path the APK actually packages (currently a symlink into
+        // the repo-root models/, resolved on read), not its target: this way
+        // a retargeted, replaced, or broken symlink goes red too, not just
+        // an edit to the target file. The walk up from the test working dir
+        // keeps the check independent of where Gradle runs it.
+        val assetPath = "composeApp/src/androidMain/assets/models/${ModelZipInstaller.zipNameFor(lm)}"
         val asset = generateSequence(File(System.getProperty("user.dir")).absoluteFile) { it.parentFile }
-            .map { it.resolve("models/${ModelZipInstaller.zipNameFor(lm)}") }
+            .map { it.resolve(assetPath) }
             .firstOrNull { it.isFile }
-            ?: fail("could not locate the bundled LM asset from ${System.getProperty("user.dir")}")
+            ?: fail("could not locate $assetPath from ${System.getProperty("user.dir")}")
         assertEquals(pin.zipSizeBytes, asset.length(), "bundled LM asset size drifted from its pin")
         val sha = MessageDigest.getInstance("SHA-256")
             .digest(asset.readBytes())

--- a/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/model/CactusModelProviderDecisionTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/model/CactusModelProviderDecisionTest.kt
@@ -1,0 +1,103 @@
+package coredevices.coreapp.model
+
+import coredevices.util.CommonBuildKonfig
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the provider's install decision against real marker files in temp
+ * dirs: the file-reading glue production runs (marker filename, trim,
+ * existence checks) on top of the markerMatchesPin semantics that
+ * CactusModelPinsTest covers in the pure form, plus the fail-closed
+ * refusal for unpinned model names. A regression in any of these silently
+ * forces a 383 MB re-download for every existing user, downgrades them to
+ * RemoteOnly STT via the incompatible-model sweep, or reopens the
+ * unverified tag-download path the pin gate closed.
+ */
+class CactusModelProviderDecisionTest {
+
+    private val modelsDir = Files.createTempDirectory("model-decision-test").toFile()
+    private val stt = CommonBuildKonfig.CACTUS_STT_MODEL
+    private val sttPin = assertNotNull(CactusModelPins.pinFor(stt))
+
+    private fun seed(marker: String? = null, config: Boolean = true) {
+        val dir = modelsDir.resolve(stt).also { it.mkdirs() }
+        if (config) dir.resolve(ModelZipInstaller.CONFIG_FILE).writeText("cfg")
+        marker?.let { dir.resolve(ModelZipInstaller.VERSION_MARKER).writeText(it) }
+    }
+
+    @Test
+    fun missingModelDirNeedsInstall() {
+        assertTrue(CactusModelProvider.needsInstallIn(modelsDir, stt))
+        assertFalse(CactusModelProvider.versionMatchesIn(modelsDir, stt))
+    }
+
+    @Test
+    fun configWithoutMarkerNeedsInstall() {
+        seed(marker = null)
+        assertTrue(CactusModelProvider.needsInstallIn(modelsDir, stt))
+    }
+
+    @Test
+    fun markerWithoutConfigNeedsInstall() {
+        seed(marker = sttPin.zipSha256Hex, config = false)
+        assertTrue(CactusModelProvider.needsInstallIn(modelsDir, stt))
+    }
+
+    @Test
+    fun verifiedDigestMarkerSkipsInstall() {
+        seed(marker = sttPin.zipSha256Hex)
+        assertFalse(CactusModelProvider.needsInstallIn(modelsDir, stt))
+    }
+
+    @Test
+    fun markerIsTrimmedBeforeComparison() {
+        // The pre-pinning installer wrote the marker without a newline, but
+        // the read must stay tolerant of one; a dropped trim would force a
+        // reinstall on every launch for affected installs.
+        seed(marker = "${sttPin.zipSha256Hex}\n")
+        assertFalse(CactusModelProvider.needsInstallIn(modelsDir, stt))
+    }
+
+    @Test
+    fun legacyTagMarkerIsGrandfatheredThroughTheFileGlue() {
+        seed(marker = CactusModelPins.LEGACY_TAG_MARKER)
+        assertFalse(CactusModelProvider.needsInstallIn(modelsDir, stt))
+    }
+
+    @Test
+    fun staleMarkerForcesReinstall() {
+        seed(marker = "aa".repeat(32))
+        assertTrue(CactusModelProvider.needsInstallIn(modelsDir, stt))
+    }
+
+    @Test
+    fun unpinnedModelNeverVersionMatches() {
+        val dir = modelsDir.resolve("whisper-tiny").also { it.mkdirs() }
+        dir.resolve(ModelZipInstaller.CONFIG_FILE).writeText("cfg")
+        dir.resolve(ModelZipInstaller.VERSION_MARKER).writeText("aa".repeat(32))
+        assertFalse(CactusModelProvider.versionMatchesIn(modelsDir, "whisper-tiny"))
+        assertTrue(CactusModelProvider.needsInstallIn(modelsDir, "whisper-tiny"))
+    }
+
+    @Test
+    fun requirePinFailsClosedForUnpinnedModels() {
+        // The old code shape (fall back to a tag-based download) still
+        // exists in util's ModelManager, so the refusal must stay pinned
+        // against a quiet reintroduction.
+        val e = assertFailsWith<IllegalStateException> {
+            CactusModelProvider.requirePin("whisper-tiny")
+        }
+        assertTrue(e.message.orEmpty().contains("No integrity pin"), "unexpected message: ${e.message}")
+    }
+
+    @Test
+    fun requirePinReturnsThePinForPinnedModels() {
+        assertEquals(sttPin, CactusModelProvider.requirePin(stt))
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/model/ModelZipInstallerTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/model/ModelZipInstallerTest.kt
@@ -1,0 +1,185 @@
+package coredevices.coreapp.model
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
+import io.ktor.http.HttpStatusCode
+import io.ktor.utils.io.ByteChannel
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.writeFully
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins the extracted model install pipeline against synthetic zips and a
+ * mock HTTP engine: the happy path (download, extract, single-root
+ * promotion, temp cleanup), the bundled-asset path, and the failure
+ * behavior the provider relies on (download failures leave an existing
+ * model untouched, Zip-Slip entries refuse the install, a stalled transfer
+ * fails instead of hanging). Lives in androidUnitTest because the fixtures
+ * are built with java.util.zip.
+ */
+class ModelZipInstallerTest {
+
+    private val root = Files.createTempDirectory("model-zip-test").toFile()
+    private val cacheDir = root.resolve("cache").also { it.mkdirs() }
+    private val modelsDir = root.resolve("models").also { it.mkdirs() }
+
+    private val model = "parakeet-tdt-0.6b-v3"
+    private val targetDir: File get() = modelsDir.resolve(model)
+
+    private val requestedUrls = mutableListOf<String>()
+
+    private fun installer(
+        handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData,
+    ) = ModelZipInstaller(
+        httpClient = HttpClient(MockEngine { request ->
+            requestedUrls += request.url.toString()
+            handler(request)
+        }),
+        cacheDir = cacheDir,
+        modelsDir = modelsDir,
+    )
+
+    // --- Fixtures ---
+
+    private fun zip(entries: Map<String, ByteArray>): ByteArray {
+        val out = ByteArrayOutputStream()
+        ZipOutputStream(out).use { zos ->
+            entries.forEach { (name, bytes) ->
+                zos.putNextEntry(ZipEntry(name))
+                zos.write(bytes)
+                zos.closeEntry()
+            }
+        }
+        return out.toByteArray()
+    }
+
+    /** Minimal shape of a real model archive; [prefix] nests it under a root dir. */
+    private fun modelZip(prefix: String = ""): ByteArray = zip(
+        mapOf(
+            "${prefix}config.txt" to "cfg".encodeToByteArray(),
+            "${prefix}vocab.txt" to "vocab".encodeToByteArray(),
+            "${prefix}model.weights" to ByteArray(64) { it.toByte() },
+        ),
+    )
+
+    private fun serving(bytes: ByteArray): suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData =
+        { respond(ByteReadChannel(bytes), HttpStatusCode.OK) }
+
+    private fun seedOldModel() {
+        targetDir.mkdirs()
+        targetDir.resolve("config.txt").writeText("old")
+        targetDir.resolve("old.weights").writeText("old-weights")
+    }
+
+    private fun cacheFilesLeft(): List<String> = cacheDir.listFiles()?.map { it.name } ?: emptyList()
+
+    // --- Tests ---
+
+    @Test
+    fun downloadHappyPathInstallsModel() = runTest {
+        installer(serving(modelZip())).install(model, "v2.0.1", copyBundledZip = null)
+        assertEquals("cfg", targetDir.resolve("config.txt").readText())
+        assertEquals(
+            listOf("https://huggingface.co/Cactus-Compute/$model/resolve/v2.0.1/${model.lowercase()}-cq4.zip"),
+            requestedUrls,
+        )
+        assertTrue(cacheFilesLeft().isEmpty(), "temp zip should be deleted after install")
+    }
+
+    @Test
+    fun singleRootDirectoryIsPromoted() = runTest {
+        installer(serving(modelZip(prefix = "$model/"))).install(model, "v2.0.1", copyBundledZip = null)
+        assertTrue(targetDir.resolve("config.txt").exists(), "contents should be promoted to the model dir")
+        assertFalse(targetDir.resolve(model).exists(), "the wrapping root dir should be gone")
+    }
+
+    @Test
+    fun existingModelIsReplaced() = runTest {
+        seedOldModel()
+        installer(serving(modelZip())).install(model, "v2.0.1", copyBundledZip = null)
+        assertEquals("cfg", targetDir.resolve("config.txt").readText())
+        assertFalse(targetDir.resolve("old.weights").exists(), "stale files must not survive a reinstall")
+    }
+
+    @Test
+    fun bundledAssetInstallsWithoutTouchingTheNetwork() = runTest {
+        val zipBytes = modelZip()
+        installer(serving(zipBytes)).install(model, "v2.0.1", copyBundledZip = { dest ->
+            dest.writeBytes(zipBytes)
+        })
+        assertTrue(targetDir.resolve("config.txt").exists())
+        assertEquals(emptyList(), requestedUrls)
+        assertTrue(cacheFilesLeft().isEmpty())
+    }
+
+    @Test
+    fun httpErrorFailsAndLeavesExistingModelIntact() = runTest {
+        seedOldModel()
+        val e = assertFailsWith<Exception> {
+            installer { respond(ByteReadChannel("gone".encodeToByteArray()), HttpStatusCode.NotFound) }
+                .install(model, "v2.0.1", copyBundledZip = null)
+        }
+        assertTrue(e.message.orEmpty().contains("HTTP 404"), "unexpected failure: $e")
+        assertEquals("old", targetDir.resolve("config.txt").readText())
+        assertTrue(cacheFilesLeft().isEmpty())
+    }
+
+    @Test
+    fun parentTraversalEntryIsRefused() = runTest {
+        val evil = zip(mapOf("../evil.txt" to "evil".encodeToByteArray()))
+        assertFailsWith<SecurityException> {
+            installer(serving(evil)).install(model, "v2.0.1", copyBundledZip = null)
+        }
+        assertFalse(modelsDir.resolve("evil.txt").exists(), "entry must not escape the target dir")
+        assertFalse(targetDir.exists(), "a refused install should not leave a partial model dir")
+        assertTrue(cacheFilesLeft().isEmpty())
+    }
+
+    @Test
+    fun stalledDownloadFailsInsteadOfHangingForever() = runTest {
+        // A channel that serves a few bytes and then goes quiet, like a dead
+        // socket the peer never closes.
+        val stalled = ByteChannel(autoFlush = true)
+        stalled.writeFully(ByteArray(10))
+        val e = assertFailsWith<Exception> {
+            installer { respond(stalled, HttpStatusCode.OK) }.install(model, "v2.0.1", copyBundledZip = null)
+        }
+        assertTrue(e.message.orEmpty().contains("stalled"), "unexpected failure: $e")
+        assertTrue(cacheFilesLeft().isEmpty())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun cancellationMidDownloadLeavesExistingModelIntact() = runTest {
+        seedOldModel()
+        val open = ByteChannel(autoFlush = true)
+        open.writeFully(ByteArray(1024))
+        val job = launch {
+            installer { respond(open, HttpStatusCode.OK) }.install(model, "v2.0.1", copyBundledZip = null)
+        }
+        // Let the download start and suspend on the never-closing channel,
+        // then cancel it the way an aborted STT resolve would.
+        runCurrent()
+        job.cancelAndJoin()
+        assertEquals("old", targetDir.resolve("config.txt").readText())
+        assertTrue(cacheFilesLeft().isEmpty(), "a cancelled download should not leave a temp zip behind")
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/model/ModelZipInstallerTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/model/ModelZipInstallerTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.test.runTest
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.file.Files
+import java.security.MessageDigest
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import kotlin.test.Test
@@ -27,13 +28,15 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * Pins the extracted model install pipeline against synthetic zips and a
- * mock HTTP engine: the happy path (download, extract, single-root
- * promotion, temp cleanup), the bundled-asset path, and the failure
- * behavior the provider relies on (download failures leave an existing
- * model untouched, Zip-Slip entries refuse the install, a stalled transfer
- * fails instead of hanging). Lives in androidUnitTest because the fixtures
- * are built with java.util.zip.
+ * Pins the verified model install pipeline against synthetic zips and a
+ * mock HTTP engine: the happy path (commit-pinned URL, digest gate, staged
+ * swap, marker content, temp cleanup), the bundled-asset path through the
+ * same gate, and every refusal branch (digest and size mismatches,
+ * mid-stream oversize abort, Zip-Slip in its three shapes, entry-count and
+ * inflation caps, stalls, cancellation). The invariant asserted
+ * throughout: no failure mode ever costs the existing model, and nothing
+ * unverified is left behind in staging or cache. Lives in androidUnitTest
+ * because the fixtures are built with java.util.zip.
  */
 class ModelZipInstallerTest {
 
@@ -43,6 +46,7 @@ class ModelZipInstallerTest {
 
     private val model = "parakeet-tdt-0.6b-v3"
     private val targetDir: File get() = modelsDir.resolve(model)
+    private val stagingDir: File get() = modelsDir.resolve(".staging").resolve(model)
 
     private val requestedUrls = mutableListOf<String>()
 
@@ -58,6 +62,19 @@ class ModelZipInstallerTest {
     )
 
     // --- Fixtures ---
+
+    private fun sha256Hex(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString("") { "%02x".format(it) }
+
+    private val testCommit = "0123456789abcdef0123456789abcdef01234567"
+
+    /** A pin that genuinely matches [bytes], as a correct pin table would. */
+    private fun pinFor(bytes: ByteArray, sizeBytes: Long = bytes.size.toLong()) = ModelPin(
+        hfRepo = model,
+        commitSha = testCommit,
+        zipSha256Hex = sha256Hex(bytes),
+        zipSizeBytes = sizeBytes,
+    )
 
     private fun zip(entries: Map<String, ByteArray>): ByteArray {
         val out = ByteArrayOutputStream()
@@ -91,22 +108,39 @@ class ModelZipInstallerTest {
 
     private fun cacheFilesLeft(): List<String> = cacheDir.listFiles()?.map { it.name } ?: emptyList()
 
-    // --- Tests ---
+    private fun assertNothingLeftBehind() {
+        assertTrue(cacheFilesLeft().isEmpty(), "temp zip should be deleted")
+        assertFalse(stagingDir.exists(), "staging should be cleaned up")
+    }
+
+    private fun assertOldModelIntact() {
+        assertEquals("old", targetDir.resolve("config.txt").readText(), "existing model must survive a failed install")
+        assertTrue(targetDir.resolve("old.weights").exists())
+    }
+
+    // --- Happy paths ---
 
     @Test
-    fun downloadHappyPathInstallsModel() = runTest {
-        installer(serving(modelZip())).install(model, "v2.0.1", copyBundledZip = null)
+    fun downloadHappyPathInstallsVerifiedModel() = runTest {
+        val bytes = modelZip()
+        installer(serving(bytes)).install(model, pinFor(bytes), copyBundledZip = null)
         assertEquals("cfg", targetDir.resolve("config.txt").readText())
         assertEquals(
-            listOf("https://huggingface.co/Cactus-Compute/$model/resolve/v2.0.1/${model.lowercase()}-cq4.zip"),
+            listOf("https://huggingface.co/Cactus-Compute/$model/resolve/$testCommit/${model.lowercase()}-cq4.zip"),
             requestedUrls,
         )
-        assertTrue(cacheFilesLeft().isEmpty(), "temp zip should be deleted after install")
+        assertEquals(
+            sha256Hex(bytes),
+            targetDir.resolve(".cactus_version").readText(),
+            "marker must carry the pinned digest so a pin change forces reinstall",
+        )
+        assertNothingLeftBehind()
     }
 
     @Test
     fun singleRootDirectoryIsPromoted() = runTest {
-        installer(serving(modelZip(prefix = "$model/"))).install(model, "v2.0.1", copyBundledZip = null)
+        val bytes = modelZip(prefix = "$model/")
+        installer(serving(bytes)).install(model, pinFor(bytes), copyBundledZip = null)
         assertTrue(targetDir.resolve("config.txt").exists(), "contents should be promoted to the model dir")
         assertFalse(targetDir.resolve(model).exists(), "the wrapping root dir should be gone")
     }
@@ -114,43 +148,183 @@ class ModelZipInstallerTest {
     @Test
     fun existingModelIsReplaced() = runTest {
         seedOldModel()
-        installer(serving(modelZip())).install(model, "v2.0.1", copyBundledZip = null)
+        val bytes = modelZip()
+        installer(serving(bytes)).install(model, pinFor(bytes), copyBundledZip = null)
         assertEquals("cfg", targetDir.resolve("config.txt").readText())
         assertFalse(targetDir.resolve("old.weights").exists(), "stale files must not survive a reinstall")
     }
 
     @Test
     fun bundledAssetInstallsWithoutTouchingTheNetwork() = runTest {
-        val zipBytes = modelZip()
-        installer(serving(zipBytes)).install(model, "v2.0.1", copyBundledZip = { dest ->
-            dest.writeBytes(zipBytes)
+        val bytes = modelZip()
+        installer(serving(bytes)).install(model, pinFor(bytes), copyBundledZip = { dest ->
+            dest.writeBytes(bytes)
         })
         assertTrue(targetDir.resolve("config.txt").exists())
+        assertEquals(sha256Hex(bytes), targetDir.resolve(".cactus_version").readText())
         assertEquals(emptyList(), requestedUrls)
-        assertTrue(cacheFilesLeft().isEmpty())
+        assertNothingLeftBehind()
     }
 
     @Test
-    fun httpErrorFailsAndLeavesExistingModelIntact() = runTest {
-        seedOldModel()
-        val e = assertFailsWith<Exception> {
-            installer { respond(ByteReadChannel("gone".encodeToByteArray()), HttpStatusCode.NotFound) }
-                .install(model, "v2.0.1", copyBundledZip = null)
-        }
-        assertTrue(e.message.orEmpty().contains("HTTP 404"), "unexpected failure: $e")
-        assertEquals("old", targetDir.resolve("config.txt").readText())
-        assertTrue(cacheFilesLeft().isEmpty())
+    fun staleStagingIsSweptBeforeInstall() = runTest {
+        stagingDir.mkdirs()
+        stagingDir.resolve("junk.txt").writeText("left by a crashed install")
+        val bytes = modelZip()
+        installer(serving(bytes)).install(model, pinFor(bytes), copyBundledZip = null)
+        assertFalse(targetDir.resolve("junk.txt").exists(), "unverified leftovers must not ride into the model dir")
+        assertNothingLeftBehind()
     }
+
+    // --- Integrity gate ---
+
+    @Test
+    fun digestMismatchRefusesInstall() = runTest {
+        seedOldModel()
+        val served = modelZip()
+        // Same length, different bytes: only the digest can catch it.
+        val expected = served.copyOf().also { it[10] = (it[10] + 1).toByte() }
+        val e = assertFailsWith<SecurityException> {
+            installer(serving(served)).install(model, pinFor(expected), copyBundledZip = null)
+        }
+        assertTrue(e.message.orEmpty().contains("failed verification"), "unexpected failure: $e")
+        assertOldModelIntact()
+        assertNothingLeftBehind()
+    }
+
+    @Test
+    fun shortBodyFailsTheExactSizeCheck() = runTest {
+        seedOldModel()
+        val bytes = modelZip()
+        // Pin expects more bytes than the server delivers; digest of the
+        // truncated body may or may not differ, size alone must refuse.
+        val e = assertFailsWith<SecurityException> {
+            installer(serving(bytes)).install(model, pinFor(bytes, sizeBytes = bytes.size + 5L), copyBundledZip = null)
+        }
+        assertTrue(e.message.orEmpty().contains("failed verification"), "unexpected failure: $e")
+        assertOldModelIntact()
+        assertNothingLeftBehind()
+    }
+
+    @Test
+    fun oversizeStreamIsAbortedMidDownload() = runTest {
+        seedOldModel()
+        val bytes = modelZip()
+        // Server keeps sending past the pinned size: the abort must happen
+        // mid-stream, before the payload is fully consumed.
+        val oversize = bytes + ByteArray(4096)
+        val e = assertFailsWith<SecurityException> {
+            installer(serving(oversize)).install(model, pinFor(bytes), copyBundledZip = null)
+        }
+        assertTrue(e.message.orEmpty().contains("exceeded the pinned"), "unexpected failure: $e")
+        assertOldModelIntact()
+        assertNothingLeftBehind()
+    }
+
+    @Test
+    fun bundledAssetGoesThroughTheSameDigestGate() = runTest {
+        seedOldModel()
+        val genuine = modelZip()
+        val tampered = genuine.copyOf().also { it[10] = (it[10] + 1).toByte() }
+        val e = assertFailsWith<SecurityException> {
+            installer(serving(genuine)).install(model, pinFor(genuine), copyBundledZip = { dest ->
+                dest.writeBytes(tampered)
+            })
+        }
+        assertTrue(e.message.orEmpty().contains("failed verification"), "unexpected failure: $e")
+        assertOldModelIntact()
+        assertNothingLeftBehind()
+    }
+
+    @Test
+    fun archiveWithoutConfigRefusesToReplaceAWorkingModel() = runTest {
+        seedOldModel()
+        val bytes = zip(mapOf("readme.txt" to "not a model".encodeToByteArray()))
+        val e = assertFailsWith<SecurityException> {
+            installer(serving(bytes)).install(model, pinFor(bytes), copyBundledZip = null)
+        }
+        assertTrue(e.message.orEmpty().contains("config.txt"), "unexpected failure: $e")
+        assertOldModelIntact()
+        assertNothingLeftBehind()
+    }
+
+    // --- Extraction confinement ---
 
     @Test
     fun parentTraversalEntryIsRefused() = runTest {
         val evil = zip(mapOf("../evil.txt" to "evil".encodeToByteArray()))
         assertFailsWith<SecurityException> {
-            installer(serving(evil)).install(model, "v2.0.1", copyBundledZip = null)
+            installer(serving(evil)).install(model, pinFor(evil), copyBundledZip = null)
         }
-        assertFalse(modelsDir.resolve("evil.txt").exists(), "entry must not escape the target dir")
-        assertFalse(targetDir.exists(), "a refused install should not leave a partial model dir")
-        assertTrue(cacheFilesLeft().isEmpty())
+        assertFalse(modelsDir.resolve(".staging").resolve("evil.txt").exists(), "entry must not escape staging")
+        assertFalse(targetDir.exists(), "a refused install should not leave a model dir")
+        assertNothingLeftBehind()
+    }
+
+    @Test
+    fun siblingPrefixEntryIsRefused() = runTest {
+        // "../<model>-evil/x" canonicalizes to a sibling whose name starts
+        // with the staging dir's: a bare prefix comparison would accept it.
+        val evil = zip(mapOf("../$model-evil/x.txt" to "evil".encodeToByteArray()))
+        assertFailsWith<SecurityException> {
+            installer(serving(evil)).install(model, pinFor(evil), copyBundledZip = null)
+        }
+        assertFalse(modelsDir.resolve(".staging").resolve("$model-evil").exists(), "sibling dir must not be created")
+        assertNothingLeftBehind()
+    }
+
+    @Test
+    fun absolutePathEntryStaysConfined() = runTest {
+        // java.io.File resolves an absolute child under the parent, so the
+        // entry lands inside the model dir; this pins that containment.
+        val bytes = zip(
+            mapOf(
+                "config.txt" to "cfg".encodeToByteArray(),
+                "/evil.txt" to "evil".encodeToByteArray(),
+            ),
+        )
+        installer(serving(bytes)).install(model, pinFor(bytes), copyBundledZip = null)
+        assertTrue(targetDir.resolve("evil.txt").exists(), "absolute entry should be confined to the model dir")
+        assertFalse(modelsDir.resolve("evil.txt").exists())
+    }
+
+    @Test
+    fun entryCountCapRefusesTheArchive() = runTest {
+        val many = zip(
+            (0..ModelZipInstaller.MAX_ENTRIES).associate { "f$it.txt" to ByteArray(0) },
+        )
+        val e = assertFailsWith<SecurityException> {
+            installer(serving(many)).install(model, pinFor(many), copyBundledZip = null)
+        }
+        assertTrue(e.message.orEmpty().contains("entries"), "unexpected failure: $e")
+        assertNothingLeftBehind()
+    }
+
+    @Test
+    fun inflationCapRefusesAZipBomb() = runTest {
+        // A megabyte of zeros compresses to ~1 KB, so the pinned zip size is
+        // tiny while the inflated output blows past the cap factor.
+        val bomb = zip(mapOf("config.txt" to ByteArray(1024 * 1024)))
+        val e = assertFailsWith<SecurityException> {
+            installer(serving(bomb)).install(model, pinFor(bomb), copyBundledZip = null)
+        }
+        assertTrue(e.message.orEmpty().contains("inflates"), "unexpected failure: $e")
+        assertNothingLeftBehind()
+    }
+
+    // --- Transport failure behavior ---
+
+    @Test
+    fun httpErrorFailsAndLeavesExistingModelIntact() = runTest {
+        seedOldModel()
+        val bytes = modelZip()
+        val e = assertFailsWith<Exception> {
+            installer { respond(ByteReadChannel("gone".encodeToByteArray()), HttpStatusCode.NotFound) }
+                .install(model, pinFor(bytes), copyBundledZip = null)
+        }
+        assertTrue(e.message.orEmpty().contains("HTTP 404"), "unexpected failure: $e")
+        assertOldModelIntact()
+        assertNothingLeftBehind()
     }
 
     @Test
@@ -160,10 +334,10 @@ class ModelZipInstallerTest {
         val stalled = ByteChannel(autoFlush = true)
         stalled.writeFully(ByteArray(10))
         val e = assertFailsWith<Exception> {
-            installer { respond(stalled, HttpStatusCode.OK) }.install(model, "v2.0.1", copyBundledZip = null)
+            installer { respond(stalled, HttpStatusCode.OK) }.install(model, pinFor(modelZip()), copyBundledZip = null)
         }
         assertTrue(e.message.orEmpty().contains("stalled"), "unexpected failure: $e")
-        assertTrue(cacheFilesLeft().isEmpty())
+        assertNothingLeftBehind()
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -173,13 +347,13 @@ class ModelZipInstallerTest {
         val open = ByteChannel(autoFlush = true)
         open.writeFully(ByteArray(1024))
         val job = launch {
-            installer { respond(open, HttpStatusCode.OK) }.install(model, "v2.0.1", copyBundledZip = null)
+            installer { respond(open, HttpStatusCode.OK) }.install(model, pinFor(modelZip(), sizeBytes = 1 shl 20), copyBundledZip = null)
         }
         // Let the download start and suspend on the never-closing channel,
         // then cancel it the way an aborted STT resolve would.
         runCurrent()
         job.cancelAndJoin()
-        assertEquals("old", targetDir.resolve("config.txt").readText())
-        assertTrue(cacheFilesLeft().isEmpty(), "a cancelled download should not leave a temp zip behind")
+        assertOldModelIntact()
+        assertNothingLeftBehind()
     }
 }

--- a/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/model/ModelZipInstallerTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/model/ModelZipInstallerTest.kt
@@ -11,12 +11,15 @@ import io.ktor.utils.io.ByteChannel
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.writeFully
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.io.IOException
 import java.nio.file.Files
 import java.security.MessageDigest
 import java.util.zip.ZipEntry
@@ -46,7 +49,9 @@ class ModelZipInstallerTest {
 
     private val model = "parakeet-tdt-0.6b-v3"
     private val targetDir: File get() = modelsDir.resolve(model)
-    private val stagingDir: File get() = modelsDir.resolve(".staging").resolve(model)
+    private val stagingDir: File get() = modelsDir.resolve(ModelZipInstaller.STAGING_DIR).resolve(model)
+    private val oldAsideDir: File get() =
+        modelsDir.resolve(ModelZipInstaller.STAGING_DIR).resolve("$model${ModelZipInstaller.OLD_ASIDE_SUFFIX}")
 
     private val requestedUrls = mutableListOf<String>()
 
@@ -111,6 +116,7 @@ class ModelZipInstallerTest {
     private fun assertNothingLeftBehind() {
         assertTrue(cacheFilesLeft().isEmpty(), "temp zip should be deleted")
         assertFalse(stagingDir.exists(), "staging should be cleaned up")
+        assertFalse(oldAsideDir.exists(), "no parked old model should remain")
     }
 
     private fun assertOldModelIntact() {
@@ -131,7 +137,7 @@ class ModelZipInstallerTest {
         )
         assertEquals(
             sha256Hex(bytes),
-            targetDir.resolve(".cactus_version").readText(),
+            targetDir.resolve(ModelZipInstaller.VERSION_MARKER).readText(),
             "marker must carry the pinned digest so a pin change forces reinstall",
         )
         assertNothingLeftBehind()
@@ -161,7 +167,7 @@ class ModelZipInstallerTest {
             dest.writeBytes(bytes)
         })
         assertTrue(targetDir.resolve("config.txt").exists())
-        assertEquals(sha256Hex(bytes), targetDir.resolve(".cactus_version").readText())
+        assertEquals(sha256Hex(bytes), targetDir.resolve(ModelZipInstaller.VERSION_MARKER).readText())
         assertEquals(emptyList(), requestedUrls)
         assertNothingLeftBehind()
     }
@@ -256,7 +262,7 @@ class ModelZipInstallerTest {
         assertFailsWith<SecurityException> {
             installer(serving(evil)).install(model, pinFor(evil), copyBundledZip = null)
         }
-        assertFalse(modelsDir.resolve(".staging").resolve("evil.txt").exists(), "entry must not escape staging")
+        assertFalse(modelsDir.resolve(ModelZipInstaller.STAGING_DIR).resolve("evil.txt").exists(), "entry must not escape staging")
         assertFalse(targetDir.exists(), "a refused install should not leave a model dir")
         assertNothingLeftBehind()
     }
@@ -269,7 +275,7 @@ class ModelZipInstallerTest {
         assertFailsWith<SecurityException> {
             installer(serving(evil)).install(model, pinFor(evil), copyBundledZip = null)
         }
-        assertFalse(modelsDir.resolve(".staging").resolve("$model-evil").exists(), "sibling dir must not be created")
+        assertFalse(modelsDir.resolve(ModelZipInstaller.STAGING_DIR).resolve("$model-evil").exists(), "sibling dir must not be created")
         assertNothingLeftBehind()
     }
 
@@ -355,5 +361,82 @@ class ModelZipInstallerTest {
         job.cancelAndJoin()
         assertOldModelIntact()
         assertNothingLeftBehind()
+    }
+
+    @Test
+    fun failureSurfacingDuringCancellationStillCleansUp() = runTest {
+        val job = launch {
+            installer(serving(modelZip())).install(model, pinFor(modelZip()), copyBundledZip = { dest ->
+                // Stand-in for a transport teardown mid-pipeline: staging
+                // already holds partial output when a plain IOException
+                // surfaces on an already-cancelled coroutine (the
+                // ensureActive re-check rethrows it as cancellation).
+                stagingDir.mkdirs()
+                stagingDir.resolve("partial.weights").writeText("partial")
+                dest.writeBytes(ByteArray(3))
+                currentCoroutineContext().cancel()
+                throw IOException("stream torn down during cancellation")
+            })
+        }
+        job.join()
+        assertNothingLeftBehind()
+    }
+
+    // --- Swap robustness ---
+
+    @Test
+    fun verificationRunsBeforeAnyExtraction() = runTest {
+        seedOldModel()
+        // Non-zip garbage whose digest mismatches its pin: if extraction
+        // ever ran ahead of the digest gate, this would surface as a
+        // ZipException from the garbage instead of the verification
+        // refusal.
+        val garbage = ByteArray(512) { 0x41 }
+        val wrongPin = pinFor(garbage).copy(zipSha256Hex = "ee".repeat(32))
+        val e = assertFailsWith<SecurityException> {
+            installer(serving(garbage)).install(model, wrongPin, copyBundledZip = null)
+        }
+        assertTrue(e.message.orEmpty().contains("failed verification"), "unexpected failure: $e")
+        assertOldModelIntact()
+        assertNothingLeftBehind()
+    }
+
+    @Test
+    fun aParkedInstallFromACrashedSwapIsRestored() = runTest {
+        // The state a process death between the two swap renames leaves:
+        // no live model dir, the old install parked aside.
+        oldAsideDir.mkdirs()
+        oldAsideDir.resolve("config.txt").writeText("old")
+        oldAsideDir.resolve("old.weights").writeText("old-weights")
+        // Even an install attempt that itself fails must first restore it.
+        assertFailsWith<Exception> {
+            installer { respond(ByteReadChannel("gone".encodeToByteArray()), HttpStatusCode.NotFound) }
+                .install(model, pinFor(modelZip()), copyBundledZip = null)
+        }
+        assertOldModelIntact()
+        assertNothingLeftBehind()
+    }
+
+    @Test
+    fun aStaleParkedCopyNextToALiveInstallIsSwept() = runTest {
+        seedOldModel()
+        oldAsideDir.mkdirs()
+        oldAsideDir.resolve("junk.weights").writeText("stale")
+        val bytes = modelZip()
+        installer(serving(bytes)).install(model, pinFor(bytes), copyBundledZip = null)
+        assertEquals("cfg", targetDir.resolve("config.txt").readText())
+        assertNothingLeftBehind()
+    }
+
+    // --- On-disk contract ---
+
+    @Test
+    fun onDiskNamesAreAStableContract() {
+        // Existing installs on user devices carry these exact names; a
+        // rename must be a conscious migration, not a refactor side effect.
+        assertEquals("config.txt", ModelZipInstaller.CONFIG_FILE)
+        assertEquals(".cactus_version", ModelZipInstaller.VERSION_MARKER)
+        assertEquals(".staging", ModelZipInstaller.STAGING_DIR)
+        assertEquals(".old", ModelZipInstaller.OLD_ASIDE_SUFFIX)
     }
 }

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -5,7 +5,6 @@ import CommonRoutes
 import CoreAppVersion
 import NextBugReportContext
 import PlatformUiContext
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -161,15 +160,11 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import coreapp.pebble.generated.resources.Res
-import coreapp.pebble.generated.resources.wispr_flow_logo_black
-import coreapp.pebble.generated.resources.wispr_flow_logo_white
-import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import theme.CoreAppTheme
 import theme.ThemeProvider
-import theme.currentColorScheme
 import kotlin.math.roundToLong
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
@@ -1483,31 +1478,6 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                     topLevelType = TopLevelType.Phone,
                     section = Section.Speech,
                     action = { showSpokenLanguageDialog = true },
-                ),
-                SettingsItem(
-                    title = "Cloud Recognition Provider",
-                    isDebugSetting = false,
-                    topLevelType = TopLevelType.Phone,
-                    section = Section.Speech,
-                    keywords = "",
-                    item = {
-                        val logo = if (currentColorScheme().isDark) {
-                            Res.drawable.wispr_flow_logo_white
-                        } else {
-                            Res.drawable.wispr_flow_logo_black
-                        }
-                        ListItem(
-                            headlineContent = { Text("Cloud Recognition Provider") },
-                            trailingContent = {
-                                Image(
-                                    painter = painterResource(logo),
-                                    contentDescription = "Wispr Flow",
-                                    modifier = Modifier.height(20.dp),
-                                )
-                            },
-                            shadowElevation = ELEVATION,
-                        )
-                    }
                 ),
                 basicSettingsToggleItem(
                     title = "Ignore other Pebble apps",


### PR DESCRIPTION
On-device STT had two hardening gaps: model weights were downloaded
with nothing between Hugging Face and the native parser but TLS, and
local transcription lost its process-priority boost when the
watch-connection foreground service was toggled off (the upstream boost
service lives in a module this fork does not build).

Model installs are now verified end to end. A per-model pin table
records the immutable commit each download URL resolves plus the
SHA-256 and exact size of the archive; received bytes are hashed while
streaming with a mid-stream abort past the pinned size, bundled assets
go through the same gate, extraction is bounded (entry and inflation
caps, separator-boundary Zip-Slip check), and everything lands in a
staging directory that replaces the live model only after full
verification, with the old install parked aside so no failure mode,
including a partial delete or a process death mid-swap, costs a working
model. The .cactus_version marker now carries the pinned digest, with
pre-pinning tag markers grandfathered while the pin still names the
same archive (the accepted residual is recorded in KNOWN_ISSUES.md).
The pipeline lives in a Context-free ModelZipInstaller core so the
whole thing runs under JVM tests with a mock HTTP engine.

The boost returns as a fork-owned shortService foreground service with
a ref-counted start/stop policy whose start and stop decisions are
serialized through the main-thread queue (closing an upstream-inherited
race where a posted stop could tear down a freshly re-acquired
service), an onTimeout override so a transcription that outlives the
shortService budget loses its boost instead of ANRing the app, and a
quiet unboosted degrade when the background-start exemption is absent.
The dead always-visible Cloud Recognition Provider row is gone from
speech settings; the fork cannot use that provider and the mode picker
already hides the cloud modes.

Verification record:

- Tests: 49 unit tests across the pin table, installer, provider
  decision logic, and boost policy, including every refusal branch
  (digest, size, mid-stream abort, tampered bundled asset, Zip-Slip in
  three shapes, both extraction caps, stall, cancellation), swap
  robustness (parked-install crash recovery, stale-park sweep,
  failure-during-cancellation cleanup), a verify-before-extract
  ordering tripwire, a derivation-tag tripwire that turns a silently
  inert upstream weights bump into a red test, a bundled-asset hash
  against the exact path the APK packages, and an on-disk-names
  contract test. The three behavior-fix regression tests were run
  against the pre-fix code and fail there. Two instrumented tests
  drive the DI seam and the full boost lifecycle on device.
- Built-APK audit (release, minified): the pin constants are present
  in the dex, no unexpected network endpoints; the remaining
  tag-based URL strings are attributed to display metadata only.
- Device e2e on a Pixel running GrapheneOS: a real pinned STT download
  (exact pinned byte count, staged verified install), and an
  end-to-end watch dictation with the watch-connection foreground
  service off, the boost service visible in the foreground during
  inference, and a correct transcription returned.
- The pre-merge review's 17 confirmed findings were resolved in the
  two review-fix commits, except one informational finding accepted
  with rationale (a cache-directory TOCTOU that requires same-UID code
  execution, at which point the app is already owned). Honesty note:
  installs from before the pinning scheme are trusted on their legacy
  marker until the first pin bump, recorded with rationale in
  KNOWN_ISSUES.md.