### PR TITLE
Gate the exported PebbleKit surface and encrypt the account token

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -92,3 +92,19 @@ set of every watch of that model on that release. That residue is accepted:
 those columns exist so companions can do feature detection by model and
 firmware, and serving them per-caller-differently would break that purpose
 without hiding anything a Bluetooth scan does not already reveal.
+
+## No backups at all on Android 8.0 and 8.1
+
+**Status: accepted; these API levels cannot encrypt backups client-side.**
+
+The backup policy is that no copy of app data leaves the device unless it
+can be client-side encrypted (`backup_rules.xml` on API 31 and above,
+`requireFlags` in `res/xml-v28/full_backup_content.xml` on API 28 to 30).
+Android 8.x has no client-side backup encryption, and its rule parser has no
+`requireFlags` to express the condition (it rejects the attribute outright),
+so the only policy-compliant behaviour there is no backup at all:
+`res/xml/full_backup_content.xml` deliberately allowlists a single path that
+never exists, which disables Auto Backup, the O-era device-to-device
+transfer path, and `adb backup` alike on those devices. `BackupRulesTest`
+pins the shape of all three rule files. This entry leaves the file when
+minSdk reaches 28.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -46,3 +46,34 @@ against a purely historical exposure window. The grandfather clause and
 its frozen anchor digests live in `CactusModelPins.kt`; the first pin
 bump ends the exception automatically, and this entry leaves the file
 with it.
+
+## Classic PebbleKit app start and stop cannot be restricted to authorized callers
+
+**Status: accepted, no fix available on Android.**
+
+`com.getpebble.action.app.START` and `.STOP` are ordered broadcasts that any
+installed application can send, and acting on one launches or stops a
+watchapp on the connected watch. Every other cross-app entry point in this
+fork is gated on the caller being a declared companion of the watchapp it is
+addressing, but a `BroadcastReceiver` is given no caller identity at all:
+`onReceive` sees the intent and nothing about who sent it, and no platform
+API recovers it after the fact. There is nothing to check.
+
+The obvious alternative, requiring a permission on the receiver, is not
+available either. Classic PebbleKit has never declared a permission, so every
+existing third-party watchapp companion would break, and a custom permission
+at `normal` protection level is granted to anything that asks for it, which
+would look protective while stopping nobody.
+
+Impact is bounded to nuisance rather than disclosure: start and stop take a
+watchapp UUID and return nothing to the sender, so an app abusing them can
+launch or close watchapps but learns nothing about the watch or its data. The
+adjacent leaks have been closed separately: the classic provider exposes no
+serial, watch data broadcast back out is narrowed to the watchapp's declared
+companions where one is declared, and a message send is ignored unless it
+addresses the session's own watchapp. The equivalent PebbleKit 2 operations
+travel over a bound service, where the caller is authoritative, and are
+authorization-gated there.
+
+This entry leaves the file if a future Android release attaches sender
+identity to broadcasts, or if the classic surface is retired.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -47,36 +47,75 @@ its frozen anchor digests live in `CactusModelPins.kt`; the first pin
 bump ends the exception automatically, and this entry leaves the file
 with it.
 
-## Classic PebbleKit app start and stop cannot be restricted to authorized callers
+## Classic PebbleKit broadcasts cannot be restricted to authorized callers
 
 **Status: accepted, no fix available on Android.**
 
-`com.getpebble.action.app.START` and `.STOP` are ordered broadcasts that any
-installed application can send, and acting on one launches or stops a
-watchapp on the connected watch. Every other cross-app entry point in this
-fork is gated on the caller being a declared companion of the watchapp it is
-addressing, but a `BroadcastReceiver` is given no caller identity at all:
-`onReceive` sees the intent and nothing about who sent it, and no platform
-API recovers it after the fact. There is nothing to check.
+Classic PebbleKit's cross-app surface is broadcasts, and a
+`BroadcastReceiver` is given no caller identity at all: `onReceive` sees the
+intent and nothing about who sent it, and no platform API recovers it after
+the fact. There is nothing to check. The obvious alternative, requiring a
+permission on the receivers, is not available either: classic PebbleKit has
+never declared one, so every existing third-party watchapp companion would
+break, and a custom permission at `normal` protection level is granted to
+anything that asks for it, which would look protective while stopping
+nobody.
 
-The obvious alternative, requiring a permission on the receiver, is not
-available either. Classic PebbleKit has never declared a permission, so every
-existing third-party watchapp companion would break, and a custom permission
-at `normal` protection level is granted to anything that asks for it, which
-would look protective while stopping nobody.
+That leaves the following classic entry points open to any installed
+application, deliberately:
 
-Impact is bounded to nuisance rather than disclosure: start and stop take a
-watchapp UUID and return nothing to the sender, so an app abusing them can
-launch or close watchapps but learns nothing about the watch or its data. The
-adjacent leaks have been closed separately: the classic provider exposes no
-serial, watch data broadcast back out is narrowed to the watchapp's declared
-companions where one is declared, and a message send is ignored unless it
-addresses the session's own watchapp. The equivalent PebbleKit 2 operations
-travel over a bound service, where the caller is authoritative, and are
-authorization-gated there.
+- `com.getpebble.action.app.START` and `.STOP` launch or close a watchapp
+  on the connected watch. Nuisance only: they take a watchapp UUID and
+  return nothing to the sender.
+- `com.getpebble.action.app.SEND` injects an app message into a live
+  classic session as if it came from the watchapp's real companion. The
+  session relays a SEND only when it addresses the session's own watchapp,
+  but that filter is routing, not authorization: it exists to stop one
+  watchapp's session relaying another watchapp's messages (and two
+  concurrent sessions each transmitting the same message), and watchapp
+  UUIDs are public, so any installed app that names the running watchapp
+  passes it. A mis-addressed SEND is dropped without a NACK broadcast, so
+  a companion that sent one waits out its own ACK timeout.
+- `com.getpebble.action.app.ACK` and `.NACK` forge acknowledgements for
+  outbound messages; transaction ids are a single byte, so a hostile app
+  can confuse a companion's in-flight sends by guessing.
+
+Watch data flowing out of a classic session is broadcast untargeted in
+practice. `broadcastToCompanions` narrows delivery with `setPackage` when
+the watchapp declares Android companion packages, but a watchapp that
+declares one is routed to PebbleKit 2 instead of a classic session, so a
+classic session never has a declared companion to narrow to; the targeted
+branch is kept as future-proofing should that routing change. Any installed
+app can therefore read what a classic watchapp sends out, and combined with
+SEND injection can prompt a running classic watchapp and read its reply.
+
+The PebbleKit 2 surface does not share this hole: it travels over a bound
+service and a ContentProvider, where the caller is authoritative, and every
+entry point there is gated on the caller being a declared companion of the
+watchapp it addresses.
 
 This entry leaves the file if a future Android release attaches sender
 identity to broadcasts, or if the classic surface is retired.
+
+## Classic PebbleKit content provider stays exported without a caller gate
+
+**Status: accepted for compatibility; revisit if its exposure grows.**
+
+`content://com.getpebble.android.provider.basalt` serves whether a watch is
+connected, whether it supports AppMessage, and the running firmware version
+to any installed application, with no permission and no caller check. Unlike
+the classic broadcasts above, a ContentProvider does receive the caller's
+identity, so the companion-registry gate that protects the PebbleKit 2
+provider is technically possible here. It is deliberately not applied:
+classic-era companions predate companion declarations, so the registry would
+have nothing to authorize most of them against, and classic clients poll
+this provider before any watchapp relationship exists, typically to show
+connection state up front. Gating it would break every classic companion
+while protecting little: the provider serves no identifier of any kind, and
+connection state already leaks through the untargeted classic broadcasts
+described above. This entry leaves the file if the provider ever grows a
+column beyond connection state and firmware version, at which point it gets
+the registry gate regardless of the compatibility cost.
 
 ## PebbleKit 2 watch metadata is identical across callers at model level
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -77,3 +77,18 @@ authorization-gated there.
 
 This entry leaves the file if a future Android release attaches sender
 identity to broadcasts, or if the classic surface is retired.
+
+## PebbleKit 2 watch metadata is identical across callers at model level
+
+**Status: accepted; the shared columns identify no individual device.**
+
+Each PebbleKit 2 companion sees a per-caller pseudonymous watch identifier,
+and the name column serves the advertised model name with its device-unique
+suffix stripped, never the user's nickname. What remains identical across
+callers is model-level metadata: platform codename, board revision, and the
+running firmware version. Two colluding companions can still narrow "is this
+the same watch" to "same model on the same firmware release", an anonymity
+set of every watch of that model on that release. That residue is accepted:
+those columns exist so companions can do feature detection by model and
+firmware, and serving them per-caller-differently would break that purpose
+without hiding anything a Bluetooth scan does not already reveal.

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -303,3 +303,114 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 }
+/**
+ * Components this app is allowed to export, pinned including whatever permission protects each
+ * one. Anything exported and absent from this set fails the release build.
+ *
+ * The exported surface is what any other app on the device can reach, and it grows silently: a
+ * dependency can contribute a component through manifest merging without a line of app code
+ * changing, which is how an exported Compose preview activity once reached a release build. It
+ * also survives review, because a branch diff shows no manifest change to notice.
+ *
+ * Deliberately checked against the merged manifest at build time rather than from an
+ * instrumentation test. A release variant cannot be instrumented at all (R8 renames the classes
+ * the test APK refers to), so a runtime test could only ever have pinned the debug surface,
+ * which is exactly where the preview activity looked harmless.
+ *
+ * Note this cannot see receivers registered at runtime with RECEIVER_EXPORTED, which are
+ * invisible to every manifest-based check. Classic PebbleKit registers several.
+ */
+val allowedExportedComponents = setOf(
+    "activity|coredevices.coreapp.MainActivity|perm=|read=|write=",
+    "activity-alias|coredevices.coreapp.HealthPermissionsRationaleActivity|perm=|read=|write=",
+    "activity-alias|coredevices.coreapp.ViewPermissionUsageActivity|perm=android.permission.START_VIEW_PERMISSION_USAGE|read=|write=",
+    "service|androidx.health.platform.client.impl.sdkservice.HealthDataSdkService|perm=|read=|write=",
+    "service|io.rebble.libpebblecommon.notification.LibPebbleNotificationListener|perm=android.permission.BIND_NOTIFICATION_LISTENER_SERVICE|read=|write=",
+    "service|io.rebble.libpebblecommon.calls.LibPebbleInCallService|perm=android.permission.BIND_INCALL_SERVICE|read=|write=",
+    "service|io.rebble.libpebblecommon.pebblekit.two.PebbleSenderReceiver|perm=|read=|write=",
+    "service|androidx.work.impl.background.systemjob.SystemJobService|perm=android.permission.BIND_JOB_SERVICE|read=|write=",
+    "receiver|androidx.work.impl.diagnostics.DiagnosticsReceiver|perm=android.permission.DUMP|read=|write=",
+    "receiver|androidx.profileinstaller.ProfileInstallReceiver|perm=android.permission.DUMP|read=|write=",
+    "provider|io.rebble.libpebblecommon.pebblekit.two.PebbleKitProvider|perm=|read=|write=",
+    "provider|io.rebble.libpebblecommon.pebblekit.classic.PebbleKitProvider|perm=|read=|write=",
+)
+
+abstract class VerifyExportedComponents : DefaultTask() {
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val mergedManifest: RegularFileProperty
+
+    @get:Input
+    abstract val allowed: SetProperty<String>
+
+    @TaskAction
+    fun verify() {
+        val android = "http://schemas.android.com/apk/res/android"
+        val document = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+            .apply { isNamespaceAware = true }
+            .newDocumentBuilder()
+            .parse(mergedManifest.get().asFile)
+
+        val found = mutableSetOf<String>()
+        listOf("activity", "activity-alias", "service", "receiver", "provider").forEach { tag ->
+            val nodes = document.getElementsByTagName(tag)
+            for (index in 0 until nodes.length) {
+                val element = nodes.item(index) as org.w3c.dom.Element
+                if (element.getAttributeNS(android, "exported") != "true") continue
+                val name = element.getAttributeNS(android, "name")
+                val permission = element.getAttributeNS(android, "permission")
+                val read = element.getAttributeNS(android, "readPermission")
+                val write = element.getAttributeNS(android, "writePermission")
+                found += "$tag|$name|perm=$permission|read=$read|write=$write"
+            }
+        }
+
+        val allowedSet = allowed.get()
+        val unexpected = (found - allowedSet).sorted()
+        // A stale entry is reported too: it usually means a component was renamed or its
+        // permission changed, and the matching new entry is sitting in `unexpected`.
+        val stale = (allowedSet - found).sorted()
+
+        if (unexpected.isEmpty() && stale.isEmpty()) {
+            logger.lifecycle("Exported components verified: ${found.size}, all allowlisted.")
+            return
+        }
+
+        val report = buildString {
+            appendLine("Exported component surface changed.")
+            if (unexpected.isNotEmpty()) {
+                appendLine()
+                appendLine("Exported but NOT allowlisted:")
+                unexpected.forEach { appendLine("  $it") }
+                appendLine()
+                appendLine("Each of these is reachable by any app on the device. Confirm it is")
+                appendLine("meant to be, and that the permission shown actually protects it,")
+                appendLine("before adding it to allowedExportedComponents.")
+            }
+            if (stale.isNotEmpty()) {
+                appendLine()
+                appendLine("Allowlisted but no longer exported as described:")
+                stale.forEach { appendLine("  $it") }
+            }
+        }
+        throw GradleException(report)
+    }
+}
+
+androidComponents {
+    onVariants(selector().withBuildType("release")) { variant ->
+        val verify = tasks.register<VerifyExportedComponents>(
+            "verify${variant.name.replaceFirstChar { it.uppercase() }}ExportedComponents"
+        ) {
+            group = "verification"
+            description = "Fails if the release manifest exports anything not on the allowlist."
+            mergedManifest.set(variant.artifacts.get(com.android.build.api.artifact.SingleArtifact.MERGED_MANIFEST))
+            allowed.set(allowedExportedComponents)
+        }
+        // Matched lazily rather than looked up: in this Kotlin Multiplatform project the
+        // assemble tasks do not exist yet while onVariants is running.
+        val assembleName = "assemble${variant.name.replaceFirstChar { it.uppercase() }}"
+        tasks.matching { it.name == assembleName }.configureEach { dependsOn(verify) }
+    }
+}

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -403,17 +403,44 @@ abstract class VerifyExportedComponents : DefaultTask() {
 
 androidComponents {
     onVariants(selector().withBuildType("release")) { variant ->
-        val verify = tasks.register<VerifyExportedComponents>(
-            "verify${variant.name.replaceFirstChar { it.uppercase() }}ExportedComponents"
-        ) {
+        val verifyName = "verify${variant.name.replaceFirstChar { it.uppercase() }}ExportedComponents"
+        val verify = tasks.register<VerifyExportedComponents>(verifyName) {
             group = "verification"
             description = "Fails if the release manifest exports anything not on the allowlist."
             mergedManifest.set(variant.artifacts.get(com.android.build.api.artifact.SingleArtifact.MERGED_MANIFEST))
             allowed.set(allowedExportedComponents)
         }
-        // Matched lazily rather than looked up: in this Kotlin Multiplatform project the
-        // assemble tasks do not exist yet while onVariants is running.
-        val assembleName = "assemble${variant.name.replaceFirstChar { it.uppercase() }}"
-        tasks.matching { it.name == assembleName }.configureEach { dependsOn(verify) }
+        // Attached to the packaging tasks rather than the assemble lifecycle anchor: every
+        // path that produces or deploys a release artifact (assembleRelease, installRelease,
+        // bundleRelease) runs through packageRelease or packageReleaseBundle, whereas only
+        // assembleRelease runs through the anchor, so anchoring there let an AAB or a direct
+        // install ship with the check never executing. Matched lazily rather than looked up:
+        // in this Kotlin Multiplatform project the packaging tasks do not exist yet while
+        // onVariants is running.
+        val variantName = variant.name.replaceFirstChar { it.uppercase() }
+        val packageNames = setOf("package$variantName", "package${variantName}Bundle")
+        tasks.matching { it.name in packageNames }.configureEach { dependsOn(verify) }
+
+        // tasks.matching is silent when nothing matches, which is the same silent-failure
+        // shape the verification exists to prevent, so assert the wiring itself: a release
+        // packaging task in the executed graph without its verify task means the name-based
+        // attachment above has rotted (an AGP task rename, most likely) and must fail loudly
+        // rather than ship an unchecked artifact.
+        gradle.taskGraph.whenReady {
+            val projectPath = project.path
+            val packaging = allTasks.any {
+                it.name in packageNames && it.project.path == projectPath
+            }
+            val verifying = allTasks.any {
+                it.name == verifyName && it.project.path == projectPath
+            }
+            if (packaging && !verifying) {
+                throw GradleException(
+                    "$verifyName is not in the task graph although a $variantName packaging " +
+                        "task is. The exported-component check has silently detached; fix the " +
+                        "wiring in composeApp/build.gradle.kts before building a release."
+                )
+            }
+        }
     }
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -162,6 +162,9 @@ kotlin {
             implementation(libs.androidx.test.rules)
             implementation(libs.ktor.client.okhttp)
             implementation(project(":util"))
+            // Same artifact and version the app already ships via libpebble3; test-scope only,
+            // so the binder test can speak the PebbleKit 2 AIDL types to the exported service.
+            implementation(libs.pebblekit)
         }
         androidUnitTest.dependencies {
             implementation(libs.ktor.client.okhttp)

--- a/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/util/ClassicPebbleKitSessionTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/util/ClassicPebbleKitSessionTest.kt
@@ -1,0 +1,296 @@
+package coredevices.coreapp.util
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.core.content.ContextCompat
+import androidx.test.platform.app.InstrumentationRegistry
+import io.rebble.libpebblecommon.connection.ConnectedPebble
+import io.rebble.libpebblecommon.connection.PebbleIdentifier
+import io.rebble.libpebblecommon.di.ConnectionCoroutineScope
+import io.rebble.libpebblecommon.js.CompanionAppDevice
+import io.rebble.libpebblecommon.metadata.WatchColor
+import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
+import io.rebble.libpebblecommon.metadata.pbw.appinfo.AndroidCompanionAppInstance
+import io.rebble.libpebblecommon.metadata.pbw.appinfo.AndroidCompanionAppRoot
+import io.rebble.libpebblecommon.metadata.pbw.appinfo.CompanionApp
+import io.rebble.libpebblecommon.metadata.pbw.appinfo.PbwAppInfo
+import io.rebble.libpebblecommon.metadata.pbw.appinfo.Resources
+import io.rebble.libpebblecommon.pebblekit.classic.PebbleKitClassic
+import io.rebble.libpebblecommon.services.FirmwareVersion
+import io.rebble.libpebblecommon.services.WatchInfo
+import io.rebble.libpebblecommon.services.appmessage.AppMessageData
+import io.rebble.libpebblecommon.services.appmessage.AppMessageResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Test
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * Drives a real classic PebbleKit session against a fake watch, pinning the two behaviors whose
+ * pieces are tested elsewhere but whose wiring was not: the SEND handler relays a broadcast
+ * only when it addresses the session's own watchapp (one session must not transmit another
+ * watchapp's messages, or a message twice), and inbound watch data is broadcast per declared
+ * companion with setPackage, falling back to an untargeted broadcast only when the watchapp
+ * declares no companion. Upstream's version of PebbleKitClassic has neither the UUID filter nor
+ * the targeting, so a mis-resolved upstream merge would revert exactly these lines; these tests
+ * are what notices.
+ *
+ * Run with:
+ * adb shell am instrument -w -e class \
+ *   coredevices.coreapp.util.ClassicPebbleKitSessionTest \
+ *   com.anopticlabs.gravel.test/androidx.test.runner.AndroidJUnitRunner
+ */
+class ClassicPebbleKitSessionTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private var session: PebbleKitClassic? = null
+    private var sessionScope: ConnectionCoroutineScope? = null
+    private var registeredReceiver: BroadcastReceiver? = null
+
+    @After
+    fun tearDown() {
+        runBlocking { session?.stop() }
+        sessionScope?.cancel()
+        registeredReceiver?.let { context.unregisterReceiver(it) }
+        session = null
+        sessionScope = null
+        registeredReceiver = null
+    }
+
+    @Test
+    fun relaysASendAddressedToTheSessionWatchapp() {
+        val watch = startSession()
+
+        val relayed = awaitSendRelayed(watch)
+
+        assertEquals(SESSION_UUID, relayed.uuid.toString())
+    }
+
+    @Test
+    fun dropsASendAddressedToAnotherWatchapp() {
+        val watch = startSession()
+        // Prove the receiver is live first, so silence below means "filtered", not "not yet
+        // registered", then let the in-flight relays drain.
+        awaitSendRelayed(watch)
+        while (watch.sent.poll(700, TimeUnit.MILLISECONDS) != null) Unit
+
+        broadcastSend(OTHER_UUID, transactionId = MISADDRESSED_TID)
+
+        var message = watch.sent.poll(1500, TimeUnit.MILLISECONDS)
+        while (message != null) {
+            assertTrue(
+                message.transactionId.toInt() != MISADDRESSED_TID,
+                "a SEND addressed to another watchapp was relayed to the watch",
+            )
+            message = watch.sent.poll(500, TimeUnit.MILLISECONDS)
+        }
+    }
+
+    @Test
+    fun broadcastsInboundDataUntargetedWhenNoCompanionIsDeclared() {
+        val received = deliverInbound(companionPackages = emptyList())
+
+        assertNull(
+            received.`package`,
+            "with no declared companion the broadcast must stay untargeted",
+        )
+    }
+
+    @Test
+    fun targetsInboundDataAtTheDeclaredCompanion() {
+        val received = deliverInbound(companionPackages = listOf(context.packageName))
+
+        assertEquals(
+            context.packageName,
+            received.`package`,
+            "the broadcast was not narrowed to the declared companion",
+        )
+    }
+
+    @Test
+    fun inboundDataTargetedAtAnotherCompanionDoesNotReachThisPackage() {
+        val incoming = MutableSharedFlow<AppMessageData>(extraBufferCapacity = 4)
+        startSession(
+            companionPackages = listOf("com.example.not.this.package"),
+            incoming = incoming,
+        )
+        val broadcasts = captureReceiveBroadcasts()
+        awaitInboundCollected(incoming)
+
+        assertTrue(incoming.tryEmit(inboundMessage()))
+
+        assertNull(
+            broadcasts.poll(1500, TimeUnit.MILLISECONDS),
+            "watch data declared for another companion reached this package",
+        )
+    }
+
+    // -- helpers --
+
+    /** Fake watch: records what the session relays to it and ACKs everything. */
+    private class RecordingWatch : ConnectedPebble.AppMessages {
+        val sent = LinkedBlockingQueue<AppMessageData>()
+
+        override val transactionSequence: Iterator<UByte> =
+            generateSequence(0) { it + 1 }.map { it.toUByte() }.iterator()
+
+        override suspend fun sendAppMessage(appMessageData: AppMessageData): AppMessageResult {
+            sent.put(appMessageData)
+            return AppMessageResult.ACK(appMessageData.transactionId)
+        }
+
+        override suspend fun sendAppMessageResult(appMessageResult: AppMessageResult) {}
+
+        override fun inboundAppMessages(appUuid: Uuid): Flow<AppMessageData> = emptyFlow()
+    }
+
+    private fun startSession(
+        companionPackages: List<String> = emptyList(),
+        incoming: Flow<AppMessageData> = emptyFlow(),
+    ): RecordingWatch {
+        val watch = RecordingWatch()
+        val device = CompanionAppDevice(
+            identifier = object : PebbleIdentifier {
+                override val asString = "test-watch"
+            },
+            watchInfo = testWatchInfo(),
+            appMessages = watch,
+        )
+        val scope = ConnectionCoroutineScope(SupervisorJob() + Dispatchers.Default)
+        sessionScope = scope
+        val classic = PebbleKitClassic(device, appInfo(companionPackages), scope)
+        session = classic
+        runBlocking { classic.start(incoming) }
+        return watch
+    }
+
+    /**
+     * The session's receivers register asynchronously after start(), so broadcast repeatedly
+     * until the first relay lands rather than racing a single broadcast against registration.
+     */
+    private fun awaitSendRelayed(watch: RecordingWatch): AppMessageData {
+        repeat(25) {
+            broadcastSend(SESSION_UUID, transactionId = LIVENESS_TID)
+            watch.sent.poll(200, TimeUnit.MILLISECONDS)?.let { return it }
+        }
+        fail("the session never relayed a correctly addressed SEND")
+    }
+
+    private fun broadcastSend(uuid: String, transactionId: Int) {
+        val intent = Intent("com.getpebble.action.app.SEND").apply {
+            putExtra("uuid", uuid)
+            putExtra("transaction_id", transactionId)
+            putExtra("msg_data", """[{"key":1,"type":"string","length":0,"value":"ping"}]""")
+        }
+        context.sendOrderedBroadcast(intent, null)
+    }
+
+    /** Starts a session, feeds it one inbound message, and returns the RECEIVE broadcast. */
+    private fun deliverInbound(companionPackages: List<String>): Intent {
+        val incoming = MutableSharedFlow<AppMessageData>(extraBufferCapacity = 4)
+        startSession(companionPackages = companionPackages, incoming = incoming)
+        val broadcasts = captureReceiveBroadcasts()
+        awaitInboundCollected(incoming)
+
+        assertTrue(incoming.tryEmit(inboundMessage()))
+
+        return broadcasts.poll(5, TimeUnit.SECONDS)
+            ?: fail("inbound watch data was never broadcast")
+    }
+
+    private fun captureReceiveBroadcasts(): LinkedBlockingQueue<Intent> {
+        val queue = LinkedBlockingQueue<Intent>()
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                intent?.let(queue::put)
+            }
+        }
+        ContextCompat.registerReceiver(
+            context,
+            receiver,
+            IntentFilter("com.getpebble.action.app.RECEIVE"),
+            ContextCompat.RECEIVER_EXPORTED,
+        )
+        registeredReceiver = receiver
+        return queue
+    }
+
+    private fun awaitInboundCollected(incoming: MutableSharedFlow<AppMessageData>) {
+        val deadline = System.currentTimeMillis() + 5000
+        while (incoming.subscriptionCount.value == 0) {
+            if (System.currentTimeMillis() > deadline) {
+                fail("the session never collected the inbound message flow")
+            }
+            Thread.sleep(50)
+        }
+    }
+
+    private fun inboundMessage() =
+        AppMessageData(transactionId = 1u, uuid = Uuid.parse(SESSION_UUID), data = mapOf(1 to "pong"))
+
+    private fun appInfo(companionPackages: List<String>) = PbwAppInfo(
+        uuid = SESSION_UUID,
+        shortName = "test",
+        versionLabel = "1.0",
+        resources = Resources(),
+        companionApp = if (companionPackages.isEmpty()) null else CompanionApp(
+            android = AndroidCompanionAppRoot(
+                apps = companionPackages.map { AndroidCompanionAppInstance(pkg = it) },
+            ),
+        ),
+    )
+
+    private fun testWatchInfo() = WatchInfo(
+        runningFwVersion = testFirmwareVersion(),
+        recoveryFwVersion = null,
+        platform = WatchHardwarePlatform.UNKNOWN,
+        bootloaderTimestamp = Instant.DISTANT_PAST,
+        board = "test",
+        serial = "TESTSERIAL",
+        btAddress = "00:00:00:00:00:00",
+        resourceCrc = 0L,
+        resourceTimestamp = Instant.DISTANT_PAST,
+        language = "en_US",
+        languageVersion = 1,
+        capabilities = emptySet(),
+        isUnfaithful = false,
+        healthInsightsVersion = null,
+        javascriptVersion = null,
+        color = WatchColor.entries.first(),
+    )
+
+    private fun testFirmwareVersion() = FirmwareVersion(
+        stringVersion = "1.0.0",
+        timestamp = Instant.DISTANT_PAST,
+        major = 1,
+        minor = 0,
+        patch = 0,
+        suffix = null,
+        gitHash = "",
+        isRecovery = false,
+        isDualSlot = false,
+        isSlot0 = false,
+    )
+
+    private companion object {
+        const val SESSION_UUID = "864369ab-1f37-4a2e-9243-dd6b21af9c14"
+        const val OTHER_UUID = "5f2c1e08-9f61-4d3e-8a35-0d2f8e1b7a90"
+        const val LIVENESS_TID = 1
+        const val MISADDRESSED_TID = 99
+    }
+}

--- a/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/util/KeystoreSecretCipherTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/util/KeystoreSecretCipherTest.kt
@@ -1,0 +1,81 @@
+package coredevices.coreapp.util
+
+import coredevices.util.security.KeystoreSecretCipher
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+
+/**
+ * Exercises the real Android Keystore. The unit tests for the storage wrapper run against a fake
+ * cipher, so without this nothing would catch a Keystore misconfiguration (wrong block mode,
+ * padding, or IV framing) until it silently failed to protect a real user's account token.
+ *
+ * Run with:
+ * adb shell am instrument -w -e class \
+ *   coredevices.coreapp.util.KeystoreSecretCipherTest \
+ *   com.anopticlabs.gravel.test/androidx.test.runner.AndroidJUnitRunner
+ */
+class KeystoreSecretCipherTest {
+
+    @Test
+    fun roundTripsASecret() {
+        val cipher = KeystoreSecretCipher()
+
+        val encrypted = cipher.encrypt(SECRET)
+
+        assertNotEquals(SECRET, encrypted)
+        assertEquals(SECRET, cipher.decrypt(encrypted!!))
+    }
+
+    @Test
+    fun ciphertextDoesNotContainThePlaintext() {
+        val encrypted = KeystoreSecretCipher().encrypt(SECRET)
+
+        assertFalse(encrypted!!.contains(SECRET), "ciphertext leaked the plaintext")
+    }
+
+    @Test
+    fun encryptingTwiceProducesDifferentCiphertexts() {
+        // GCM reuses of an IV are catastrophic, so the per-operation IV must actually vary.
+        // Identical outputs here would mean a fixed IV had been introduced.
+        val cipher = KeystoreSecretCipher()
+
+        val first = cipher.encrypt(SECRET)
+        val second = cipher.encrypt(SECRET)
+
+        assertNotEquals(first, second)
+        assertEquals(SECRET, cipher.decrypt(first!!))
+        assertEquals(SECRET, cipher.decrypt(second!!))
+    }
+
+    @Test
+    fun survivesANewCipherInstance() {
+        // The token is read by a fresh object graph on every cold start, so the key has to be
+        // looked up from the Keystore rather than held only in the instance that created it.
+        val encrypted = KeystoreSecretCipher().encrypt(SECRET)
+
+        assertEquals(SECRET, KeystoreSecretCipher().decrypt(encrypted!!))
+    }
+
+    @Test
+    fun rejectsATamperedCiphertext() {
+        // Stands in for a value that arrived from another device or was modified at rest: GCM
+        // authentication must reject it rather than return garbage.
+        val cipher = KeystoreSecretCipher()
+        val encrypted = cipher.encrypt(SECRET)!!
+        val tampered = encrypted.dropLast(2) + if (encrypted.endsWith("AA")) "BB" else "AA"
+
+        assertNull(cipher.decrypt(tampered))
+    }
+
+    @Test
+    fun returnsNullForGarbageInput() {
+        assertNull(KeystoreSecretCipher().decrypt("not-base64-at-all!!"))
+    }
+
+    private companion object {
+        const val SECRET = "account-bearer-token-0123456789"
+    }
+}

--- a/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/util/KeystoreSecretCipherTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/util/KeystoreSecretCipherTest.kt
@@ -1,11 +1,12 @@
 package coredevices.coreapp.util
 
+import coredevices.util.security.DecryptResult
 import coredevices.util.security.KeystoreSecretCipher
 import org.junit.Test
+import java.security.KeyStore
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
-import kotlin.test.assertNull
 
 /**
  * Exercises the real Android Keystore. The unit tests for the storage wrapper run against a fake
@@ -26,7 +27,7 @@ class KeystoreSecretCipherTest {
         val encrypted = cipher.encrypt(SECRET)
 
         assertNotEquals(SECRET, encrypted)
-        assertEquals(SECRET, cipher.decrypt(encrypted!!))
+        assertEquals(SECRET, cipher.decryptOrNull(encrypted!!))
     }
 
     @Test
@@ -46,8 +47,8 @@ class KeystoreSecretCipherTest {
         val second = cipher.encrypt(SECRET)
 
         assertNotEquals(first, second)
-        assertEquals(SECRET, cipher.decrypt(first!!))
-        assertEquals(SECRET, cipher.decrypt(second!!))
+        assertEquals(SECRET, cipher.decryptOrNull(first!!))
+        assertEquals(SECRET, cipher.decryptOrNull(second!!))
     }
 
     @Test
@@ -56,26 +57,55 @@ class KeystoreSecretCipherTest {
         // looked up from the Keystore rather than held only in the instance that created it.
         val encrypted = KeystoreSecretCipher().encrypt(SECRET)
 
-        assertEquals(SECRET, KeystoreSecretCipher().decrypt(encrypted!!))
+        assertEquals(SECRET, KeystoreSecretCipher().decryptOrNull(encrypted!!))
     }
 
     @Test
-    fun rejectsATamperedCiphertext() {
+    fun rejectsATamperedCiphertextAsUnrecoverable() {
         // Stands in for a value that arrived from another device or was modified at rest: GCM
-        // authentication must reject it rather than return garbage.
+        // authentication must reject it, and deterministically, so the caller may discard it.
         val cipher = KeystoreSecretCipher()
         val encrypted = cipher.encrypt(SECRET)!!
         val tampered = encrypted.dropLast(2) + if (encrypted.endsWith("AA")) "BB" else "AA"
 
-        assertNull(cipher.decrypt(tampered))
+        assertEquals(DecryptResult.Unrecoverable, cipher.decrypt(tampered))
     }
 
     @Test
-    fun returnsNullForGarbageInput() {
-        assertNull(KeystoreSecretCipher().decrypt("not-base64-at-all!!"))
+    fun garbageInputIsUnrecoverable() {
+        // Ensure the key exists first, so this exercises the malformed-input classification
+        // rather than the missing-key branch.
+        val cipher = KeystoreSecretCipher()
+        cipher.encrypt(SECRET)
+
+        assertEquals(DecryptResult.Unrecoverable, cipher.decrypt("not-base64-at-all!!"))
     }
+
+    @Test
+    fun missingKeyIsUnrecoverableAndDecryptCreatesNoKey() {
+        // A fresh device, or a backup restored onto new hardware, has the ciphertext but not
+        // the key. Decrypt must report that as unrecoverable WITHOUT generating a key: a fresh
+        // key cannot decrypt the value anyway, and its existence would turn every later read
+        // into a misleading authentication failure instead of a clean "nothing stored here".
+        val cipher = KeystoreSecretCipher()
+        val encrypted = cipher.encrypt(SECRET)!!
+        val keyStore = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        keyStore.deleteEntry(KEY_ALIAS)
+
+        assertEquals(DecryptResult.Unrecoverable, cipher.decrypt(encrypted))
+        assertFalse(
+            keyStore.containsAlias(KEY_ALIAS),
+            "decrypt generated a key; it must never create one",
+        )
+    }
+
+    private fun KeystoreSecretCipher.decryptOrNull(stored: String): String? =
+        (decrypt(stored) as? DecryptResult.Success)?.plaintext
 
     private companion object {
         const val SECRET = "account-bearer-token-0123456789"
+
+        /** Mirrors KeystoreSecretCipher.KEY_ALIAS, which is deliberately not public API. */
+        const val KEY_ALIAS = "gravel_secret_v1"
     }
 }

--- a/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/util/PebbleKitProviderGateTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/util/PebbleKitProviderGateTest.kt
@@ -1,0 +1,48 @@
+package coredevices.coreapp.util
+
+import android.net.Uri
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Test
+import kotlin.test.assertNull
+
+/**
+ * Exercises the PebbleKit 2 provider's authorization gate from the outside, through the real
+ * exported ContentProvider. This process is not a declared companion of any installed watchapp,
+ * so every query must be refused with a null cursor. The pin is non-vacuous: the ungated base
+ * class answers the connectedWatches path with a cursor unconditionally (empty when no watch is
+ * connected), so a regression that reverts query() to a plain super call, for example an
+ * upstream merge taking upstream's ungated version of the file, turns these into failures.
+ *
+ * Run with:
+ * adb shell am instrument -w -e class \
+ *   coredevices.coreapp.util.PebbleKitProviderGateTest \
+ *   com.anopticlabs.gravel.test/androidx.test.runner.AndroidJUnitRunner
+ */
+class PebbleKitProviderGateTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun connectedWatchesQueryFromANonCompanionIsRefused() {
+        assertRefused(Uri.parse("content://${context.packageName}.pebblekit/connectedWatches"))
+    }
+
+    @Test
+    fun activeAppQueryFromANonCompanionIsRefused() {
+        assertRefused(Uri.parse("content://${context.packageName}.pebblekit/activeApp/any-id"))
+    }
+
+    @Test
+    fun unknownPathQueryFromANonCompanionIsRefused() {
+        assertRefused(Uri.parse("content://${context.packageName}.pebblekit/somethingElse"))
+    }
+
+    private fun assertRefused(uri: Uri) {
+        val cursor = context.contentResolver.query(uri, null, null, null, null)
+        try {
+            assertNull(cursor, "query of $uri from a non-companion returned a cursor")
+        } finally {
+            cursor?.close()
+        }
+    }
+}

--- a/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/util/PebbleKitSenderAuthorizationTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/util/PebbleKitSenderAuthorizationTest.kt
@@ -1,0 +1,107 @@
+package coredevices.coreapp.util
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.Bundle
+import android.os.IBinder
+import androidx.test.platform.app.InstrumentationRegistry
+import io.rebble.pebblekit2.common.SendDataCallback
+import io.rebble.pebblekit2.common.UniversalRequestResponse
+import org.junit.After
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Drives the AuthorizingBinder in [io.rebble.libpebblecommon.pebblekit.two.PebbleSenderReceiver]
+ * through a real bind to the exported service. This process is not a declared companion of any
+ * watchapp, so a START_APP or STOP_APP request must be denied, and the denial contract is an
+ * EMPTY reply bundle: a request waved through to the library instead produces a reply carrying
+ * the transmission-results key (even with zero watches connected), so an inverted or removed
+ * authorization check turns these tests into failures rather than passing silently.
+ *
+ * The request keys duplicated here are the wire protocol pinned by
+ * PebbleKitRequestProtocolTest; if that pin moves, this moves with it.
+ *
+ * Run with:
+ * adb shell am instrument -w -e class \
+ *   coredevices.coreapp.util.PebbleKitSenderAuthorizationTest \
+ *   com.anopticlabs.gravel.test/androidx.test.runner.AndroidJUnitRunner
+ */
+class PebbleKitSenderAuthorizationTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private var connection: ServiceConnection? = null
+
+    @After
+    fun unbind() {
+        connection?.let { context.unbindService(it) }
+        connection = null
+    }
+
+    @Test
+    fun startAppFromANonCompanionGetsTheEmptyDenialReply() {
+        assertDenied("START_APP")
+    }
+
+    @Test
+    fun stopAppFromANonCompanionGetsTheEmptyDenialReply() {
+        assertDenied("STOP_APP")
+    }
+
+    private fun assertDenied(action: String) {
+        val service = bindSender()
+        val request = Bundle().apply {
+            putString("ACTION", action)
+            putString("WATCHAPP_UUID", "864369ab-1f37-4a2e-9243-dd6b21af9c14")
+        }
+
+        val replied = CountDownLatch(1)
+        var reply: Bundle? = null
+        service.request(request, object : SendDataCallback.Stub() {
+            override fun onResult(result: Bundle) {
+                reply = result
+                replied.countDown()
+            }
+        })
+
+        // The reply is synchronous on the denial path, but nothing in the contract promises
+        // that, so wait rather than assert immediately.
+        assertTrue(replied.await(10, TimeUnit.SECONDS), "the $action request got no reply")
+        val keys = reply!!.keySet()
+        assertTrue(
+            keys.isEmpty(),
+            "denied $action must get the empty reply, but the reply carried $keys, " +
+                "which means the request reached the library undenied",
+        )
+    }
+
+    private fun bindSender(): UniversalRequestResponse {
+        val bound = CountDownLatch(1)
+        var binder: IBinder? = null
+        val conn = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+                binder = service
+                bound.countDown()
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {}
+        }
+        val intent = Intent().setComponent(
+            ComponentName(
+                context,
+                "io.rebble.libpebblecommon.pebblekit.two.PebbleSenderReceiver",
+            )
+        )
+        if (!context.bindService(intent, conn, Context.BIND_AUTO_CREATE)) {
+            fail("could not bind io.rebble.libpebblecommon.pebblekit.two.PebbleSenderReceiver")
+        }
+        connection = conn
+        assertTrue(bound.await(10, TimeUnit.SECONDS), "service connection timed out")
+        return UniversalRequestResponse.Stub.asInterface(binder!!)
+    }
+}

--- a/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/util/PebbleKitWatchIdentityTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/util/PebbleKitWatchIdentityTest.kt
@@ -1,0 +1,106 @@
+package coredevices.coreapp.util
+
+import io.rebble.libpebblecommon.pebblekit.two.PebbleKitWatchIdentity
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Exercises the real Android Keystore HMAC path.
+ *
+ * The failure mode this guards is quiet: if key generation is rejected on a device, every
+ * identifier comes back null, the provider drops every row, and connected watches simply stop
+ * being visible to companion apps with nothing logged at the call site.
+ *
+ * Run with:
+ * adb shell am instrument -w -e class \
+ *   coredevices.coreapp.util.PebbleKitWatchIdentityTest \
+ *   com.anopticlabs.gravel.test/androidx.test.runner.AndroidJUnitRunner
+ */
+class PebbleKitWatchIdentityTest {
+
+    @Test
+    fun derivesAnIdentifier() {
+        val identifier = PebbleKitWatchIdentity().pseudonymFor(PACKAGE_A, SERIAL)
+
+        assertNotNull(identifier, "Keystore HMAC produced no identifier")
+        assertEquals(32, identifier.length, "expected 128 bits rendered as hex")
+    }
+
+    @Test
+    fun neverReturnsTheSerial() {
+        val identifier = PebbleKitWatchIdentity().pseudonymFor(PACKAGE_A, SERIAL)
+
+        assertNotEquals(SERIAL, identifier)
+        assertFalse(identifier!!.contains(SERIAL))
+    }
+
+    @Test
+    fun isStableForTheSameCallerAndWatch() {
+        // A companion app has to be able to recognise the same watch across calls and restarts.
+        assertEquals(
+            PebbleKitWatchIdentity().pseudonymFor(PACKAGE_A, SERIAL),
+            PebbleKitWatchIdentity().pseudonymFor(PACKAGE_A, SERIAL),
+        )
+    }
+
+    @Test
+    fun differsBetweenCallers() {
+        // The whole point: two apps comparing notes must not find a shared key for one watch.
+        assertNotEquals(
+            PebbleKitWatchIdentity().pseudonymFor(PACKAGE_A, SERIAL),
+            PebbleKitWatchIdentity().pseudonymFor(PACKAGE_B, SERIAL),
+        )
+    }
+
+    @Test
+    fun differsBetweenWatches() {
+        val identity = PebbleKitWatchIdentity()
+
+        assertNotEquals(
+            identity.pseudonymFor(PACKAGE_A, SERIAL),
+            identity.pseudonymFor(PACKAGE_A, "QQQ456"),
+        )
+    }
+
+    @Test
+    fun resolvesItsOwnIdentifierBackToTheSerial() {
+        val identity = PebbleKitWatchIdentity()
+        val identifier = identity.pseudonymFor(PACKAGE_A, SERIAL)!!
+
+        assertEquals(SERIAL, identity.resolveSerial(PACKAGE_A, identifier, listOf(SERIAL, "QQQ456")))
+    }
+
+    @Test
+    fun doesNotResolveAnotherCallersIdentifier() {
+        val identity = PebbleKitWatchIdentity()
+        val forB = identity.pseudonymFor(PACKAGE_B, SERIAL)!!
+
+        assertNull(identity.resolveSerial(PACKAGE_A, forB, listOf(SERIAL)))
+    }
+
+    @Test
+    fun stillAcceptsARealSerial() {
+        // Emitting a serial is the leak; accepting one back teaches a caller nothing new, and
+        // rejecting it would break callers that already hold one.
+        val identity = PebbleKitWatchIdentity()
+
+        assertEquals(SERIAL, identity.resolveSerial(PACKAGE_A, SERIAL, listOf(SERIAL)))
+    }
+
+    @Test
+    fun doesNotResolveAnUnknownIdentifier() {
+        val identity = PebbleKitWatchIdentity()
+
+        assertNull(identity.resolveSerial(PACKAGE_A, "nonsense", listOf(SERIAL)))
+    }
+
+    private companion object {
+        const val PACKAGE_A = "com.example.companion.a"
+        const val PACKAGE_B = "com.example.companion.b"
+        const val SERIAL = "ABC123456789"
+    }
+}

--- a/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/util/TargetedBroadcastDeliveryTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/coredevices/coreapp/util/TargetedBroadcastDeliveryTest.kt
@@ -1,0 +1,81 @@
+package coredevices.coreapp.util
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.core.content.ContextCompat
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private const val ACTION = "coredevices.coreapp.test.TARGETED_BROADCAST"
+private const val DELIVERED_TIMEOUT_SECONDS = 5L
+
+/**
+ * Verifies the platform behaviour the classic PebbleKit broadcast narrowing depends on.
+ *
+ * Classic PebbleKit clients register their receivers at runtime rather than in a manifest, so
+ * restricting delivery with Intent.setPackage is only useful if it also constrains dynamically
+ * registered receivers. If it did not, the narrowing would be inert and watch data would still
+ * reach every app while the code looked like it had been fixed. This asserts the behaviour
+ * directly instead of assuming it.
+ *
+ * Run with:
+ * adb shell am instrument -w -e class \
+ *   coredevices.coreapp.util.TargetedBroadcastDeliveryTest \
+ *   com.anopticlabs.gravel.test/androidx.test.runner.AndroidJUnitRunner
+ */
+class TargetedBroadcastDeliveryTest {
+
+    private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun untargetedBroadcastReachesARuntimeReceiver() {
+        assertTrue(
+            sendAndAwait { it },
+            "baseline failed: an untargeted broadcast did not reach the receiver at all",
+        )
+    }
+
+    @Test
+    fun broadcastTargetedAtThisPackageIsDelivered() {
+        // The companion case: a declared companion must still receive its watch data.
+        assertTrue(
+            sendAndAwait { it.setPackage(context.packageName) },
+            "a broadcast targeted at this package was not delivered",
+        )
+    }
+
+    @Test
+    fun broadcastTargetedElsewhereIsNotDelivered() {
+        // The case that matters: an app that is not a declared companion must see nothing.
+        assertFalse(
+            sendAndAwait { it.setPackage("com.example.not.this.package") },
+            "setPackage did not constrain delivery, so narrowing the broadcast is inert",
+        )
+    }
+
+    /** Returns whether a broadcast built by [configure] reached a runtime-registered receiver. */
+    private fun sendAndAwait(configure: (Intent) -> Intent): Boolean {
+        val delivered = CountDownLatch(1)
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) = delivered.countDown()
+        }
+        ContextCompat.registerReceiver(
+            context,
+            receiver,
+            IntentFilter(ACTION),
+            ContextCompat.RECEIVER_EXPORTED,
+        )
+        try {
+            context.sendOrderedBroadcast(configure(Intent(ACTION)), null)
+            return delivered.await(DELIVERED_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        } finally {
+            context.unregisterReceiver(receiver)
+        }
+    }
+}

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -18,6 +18,8 @@
         android:usesCleartextTraffic="true"
         android:networkSecurityConfig="@xml/network_security_config"
         android:allowBackup="true"
+        android:dataExtractionRules="@xml/backup_rules"
+        android:fullBackupContent="@xml/full_backup_content"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/di/androidDefaultModule.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/di/androidDefaultModule.kt
@@ -28,6 +28,8 @@ import coredevices.util.auth.NoOpSilentSignIn
 import coredevices.util.auth.SilentSignIn
 import coredevices.util.integrations.AndroidOAuthLauncher
 import coredevices.util.integrations.OAuthLauncher
+import coredevices.util.security.KeystoreSecretCipher
+import coredevices.util.security.SecretCipher
 import coredevices.util.models.ModelDownloadManager
 import coredevices.util.transcription.CactusModelPathProvider
 import coredevices.util.transcription.InferenceBoost
@@ -58,6 +60,7 @@ val androidDefaultModule = module {
     singleOf(::PlatformShareLauncher)
     singleOf(::AndroidPlatform) bind Platform::class
     singleOf(::AndroidOAuthLauncher) bind OAuthLauncher::class
+    singleOf(::KeystoreSecretCipher) bind SecretCipher::class
     single { CoreAppVersion(BuildConfig.VERSION_NAME) }
     singleOf(::PlatformContext)
     singleOf(::AndroidPermissionRequester) bind PermissionRequester::class

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/util/FirebaseResidueCleanup.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/util/FirebaseResidueCleanup.kt
@@ -16,12 +16,24 @@ import kotlin.concurrent.thread
  * ever touch that material again: the SDKs are off the classpath, the stub
  * signOut() is a no-op, and the sign-out UI is unreachable. Left alone, a
  * still-valid Core-account credential would sit at rest forever, riding
- * along in Auto Backup and device-to-device transfers (backup restore also
- * matches on package name, not signing certificate, so restored official-app
- * data can land in a fresh install of this fork). Deleting the residue at
- * startup closes that at-rest exposure; it runs every launch because the
- * checks are a few directory listings and idempotency beats a marker flag
- * that backup restore could carry separately from the data it describes.
+ * along in Auto Backup and device-to-device transfers.
+ *
+ * Two things have since narrowed this, and the original rationale here
+ * overstated what remains. It also argued that backup restore matches on
+ * package name rather than signing certificate, so restored official-app
+ * data could land in a fresh install of this fork; the rebrand moved the
+ * applicationId to com.anopticlabs.gravel, which no longer collides with
+ * upstream's, so that route is closed. And because the SDKs were removed
+ * before that rename, no build carrying Firebase ever ran under the current
+ * applicationId, so a data directory this cleanup can reach should never
+ * contain the residue in the first place.
+ *
+ * It is kept as a standing guard rather than because a path to it is known:
+ * the cost is a few directory listings on a background thread at startup,
+ * and it would cover a future build that reintroduced the SDKs, or a data
+ * directory arriving from somewhere not anticipated here. It runs every
+ * launch because idempotency beats a marker flag that backup restore could
+ * carry separately from the data it describes.
  */
 object FirebaseResidueCleanup {
 

--- a/composeApp/src/androidMain/kotlin/coredevices/coreapp/util/FirebaseResidueCleanup.kt
+++ b/composeApp/src/androidMain/kotlin/coredevices/coreapp/util/FirebaseResidueCleanup.kt
@@ -18,15 +18,13 @@ import kotlin.concurrent.thread
  * still-valid Core-account credential would sit at rest forever, riding
  * along in Auto Backup and device-to-device transfers.
  *
- * Two things have since narrowed this, and the original rationale here
- * overstated what remains. It also argued that backup restore matches on
- * package name rather than signing certificate, so restored official-app
- * data could land in a fresh install of this fork; the rebrand moved the
- * applicationId to com.anopticlabs.gravel, which no longer collides with
- * upstream's, so that route is closed. And because the SDKs were removed
- * before that rename, no build carrying Firebase ever ran under the current
- * applicationId, so a data directory this cleanup can reach should never
- * contain the residue in the first place.
+ * Two facts narrow what this can ever find. The applicationId is
+ * com.anopticlabs.gravel, which does not collide with upstream's, so a
+ * backup of the official app cannot restore into this fork's data
+ * directory (restore matches on package name). And the SDKs were removed
+ * before that rename, so no build carrying Firebase ever ran under the
+ * current applicationId, meaning a data directory this cleanup can reach
+ * should never contain the residue in the first place.
  *
  * It is kept as a standing guard rather than because a path to it is known:
  * the cost is a few directory listings on a background thread at startup,

--- a/composeApp/src/androidMain/res/xml-v28/full_backup_content.xml
+++ b/composeApp/src/androidMain/res/xml-v28/full_backup_content.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Backup rules for API 28 to 30: superseded by backup_rules.xml from API 31, and preceded by
+    the no-backup res/xml variant on API 26 and 27, whose parsers reject the requireFlags
+    attribute used here (they allow only domain and path) and have no client-side backup
+    encryption to require anyway.
+
+    requireFlags="clientSideEncryption" is the older spelling of the same intent: no backup
+    unless it can be client-side encrypted. It is an attribute of include rather than a
+    property of the whole file, which forces the shape below, because naming even one include
+    switches Auto Backup out of "back up almost everything" and into "back up only what is
+    listed". Every domain the app actually uses therefore has to be named explicitly, and
+    omitting one would silently stop backing that data up rather than fail loudly.
+
+    Device-protected storage domains (device_root, device_file, device_database,
+    device_sharedpref) are deliberately absent: nothing here is direct-boot aware, so they hold
+    no data. Anything that starts using them must be added here.
+
+    Cache and no-backup directories never need excluding; the platform always leaves them out.
+-->
+<full-backup-content>
+    <include domain="root" path="." requireFlags="clientSideEncryption" />
+    <include domain="file" path="." requireFlags="clientSideEncryption" />
+    <include domain="database" path="." requireFlags="clientSideEncryption" />
+    <include domain="sharedpref" path="." requireFlags="clientSideEncryption" />
+    <include domain="external" path="." requireFlags="clientSideEncryption" />
+
+    <!-- Re-downloadable model weights, hundreds of megabytes against a 25 MB per-app quota.
+         Over quota the system stops backing the app up altogether, so leaving these in would
+         cost the backup of everything else. Exclude takes precedence over include. -->
+    <exclude domain="file" path="models" />
+</full-backup-content>

--- a/composeApp/src/androidMain/res/xml/backup_rules.xml
+++ b/composeApp/src/androidMain/res/xml/backup_rules.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Backup rules for Android 12 (API 31) and above. See full_backup_content.xml for the
+    equivalent on API 26 to 30.
+
+    Backups stay enabled deliberately. The data here is worth being able to restore, and the
+    account token, the one credential the app controls, is encrypted at rest under a key that
+    never leaves the device, so a backup copy of it is inert on any other hardware.
+
+    disableIfNoEncryptionCapabilities stops a cloud backup happening at all unless it can be
+    client-side encrypted, which in practice means the user has a screen lock. Everything else
+    in the app's storage is plaintext, including notification bodies, health samples, calendar
+    and contact names, and whatever third-party watchapps have parked in their PebbleKit JS
+    localStorage, so shipping an unencrypted copy off the device is the case worth refusing.
+    Per Android's documentation this constrains cloud backup only; device-to-device transfer is
+    never sent to a server and keeps working regardless.
+
+    Only exclude elements are used. Adding a single include would switch these rules to
+    allowlist mode and silently stop backing up every domain not named, which is exactly the
+    "backups quietly stopped working" failure this file must not cause.
+-->
+<data-extraction-rules>
+    <cloud-backup disableIfNoEncryptionCapabilities="true">
+        <!-- Re-downloadable model weights, hundreds of megabytes against a 25 MB per-app
+             quota. Over quota the system calls onQuotaExceeded() and stops backing the app up
+             altogether, so leaving these in would cost the backup of everything else. -->
+        <exclude domain="file" path="models" />
+    </cloud-backup>
+    <device-transfer>
+        <!-- No quota applies here, but the weights are re-downloadable and would only slow a
+             migration down. -->
+        <exclude domain="file" path="models" />
+    </device-transfer>
+</data-extraction-rules>

--- a/composeApp/src/androidMain/res/xml/full_backup_content.xml
+++ b/composeApp/src/androidMain/res/xml/full_backup_content.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Backup rules for API 26 to 30, superseded by backup_rules.xml from API 31.
+
+    requireFlags="clientSideEncryption" is the older spelling of the same intent: no backup
+    unless it can be client-side encrypted. It is an attribute of include rather than a
+    property of the whole file, which forces the shape below, because naming even one include
+    switches Auto Backup out of "back up almost everything" and into "back up only what is
+    listed". Every domain the app actually uses therefore has to be named explicitly, and
+    omitting one would silently stop backing that data up rather than fail loudly.
+
+    Device-protected storage domains (device_root, device_file, device_database,
+    device_sharedpref) are deliberately absent: nothing here is direct-boot aware, so they hold
+    no data. Anything that starts using them must be added here.
+
+    Cache and no-backup directories never need excluding; the platform always leaves them out.
+-->
+<full-backup-content>
+    <include domain="root" path="." requireFlags="clientSideEncryption" />
+    <include domain="file" path="." requireFlags="clientSideEncryption" />
+    <include domain="database" path="." requireFlags="clientSideEncryption" />
+    <include domain="sharedpref" path="." requireFlags="clientSideEncryption" />
+    <include domain="external" path="." requireFlags="clientSideEncryption" />
+
+    <!-- Re-downloadable model weights, hundreds of megabytes against a 25 MB per-app quota.
+         Over quota the system stops backing the app up altogether, so leaving these in would
+         cost the backup of everything else. Exclude takes precedence over include. -->
+    <exclude domain="file" path="models" />
+</full-backup-content>

--- a/composeApp/src/androidMain/res/xml/full_backup_content.xml
+++ b/composeApp/src/androidMain/res/xml/full_backup_content.xml
@@ -1,29 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Backup rules for API 26 to 30, superseded by backup_rules.xml from API 31.
+    Backup rules for API 26 and 27 only: res/xml-v28 supersedes this from API 28, and
+    backup_rules.xml from API 31.
 
-    requireFlags="clientSideEncryption" is the older spelling of the same intent: no backup
-    unless it can be client-side encrypted. It is an attribute of include rather than a
-    property of the whole file, which forces the shape below, because naming even one include
-    switches Auto Backup out of "back up almost everything" and into "back up only what is
-    listed". Every domain the app actually uses therefore has to be named explicitly, and
-    omitting one would silently stop backing that data up rather than fail loudly.
+    Deliberately backs up nothing. The policy is "no backup copy unless it can be client-side
+    encrypted", and Android 8.x has no client-side backup encryption and no requireFlags
+    support to express the condition, so the only policy-compliant behaviour on these API
+    levels is no backup at all. The 8.x parser also rejects any include carrying a third
+    attribute, which would abort backup as a parse failure; this file exists so the no-backup
+    outcome is a deliberate, valid rule set rather than a parser accident.
 
-    Device-protected storage domains (device_root, device_file, device_database,
-    device_sharedpref) are deliberately absent: nothing here is direct-boot aware, so they hold
-    no data. Anything that starts using them must be added here.
-
-    Cache and no-backup directories never need excluding; the platform always leaves them out.
+    Mechanism: naming any include switches Auto Backup into "back up only what is listed", and
+    the one path listed never exists, so nothing matches. The O-era device-to-device transfer
+    path consumes the same rules and is therefore also disabled on 8.x; that trade-off is
+    recorded in KNOWN_ISSUES.md.
 -->
 <full-backup-content>
-    <include domain="root" path="." requireFlags="clientSideEncryption" />
-    <include domain="file" path="." requireFlags="clientSideEncryption" />
-    <include domain="database" path="." requireFlags="clientSideEncryption" />
-    <include domain="sharedpref" path="." requireFlags="clientSideEncryption" />
-    <include domain="external" path="." requireFlags="clientSideEncryption" />
-
-    <!-- Re-downloadable model weights, hundreds of megabytes against a 25 MB per-app quota.
-         Over quota the system stops backing the app up altogether, so leaving these in would
-         cost the backup of everything else. Exclude takes precedence over include. -->
-    <exclude domain="file" path="models" />
+    <include domain="file" path="gravel_no_backup_sentinel" />
 </full-backup-content>

--- a/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/BackupRulesTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/coredevices/coreapp/BackupRulesTest.kt
@@ -1,0 +1,101 @@
+package coredevices.coreapp
+
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Pins the semantics of the backup rule files that resource compilation and lint cannot check.
+ *
+ * The FullBackupContent lint check (fatal, runs in CI) already validates element names, domain
+ * values, and paths, but it knows nothing about requireFlags: a typo there is ignored by the
+ * platform parser at runtime, which silently turns "back up only when client-side encrypted"
+ * into "back up in the clear". It also does not know that a single include element in
+ * backup_rules.xml would flip those rules into allowlist mode and silently stop backing up
+ * every domain not named. These are exactly the failure modes pinned here, one test per file.
+ */
+class BackupRulesTest {
+
+    @Test
+    fun `api 28 to 30 rules gate every included domain on client-side encryption`() {
+        val document = parse(resFile("xml-v28", "full_backup_content.xml"))
+        val includes = document.elementsNamed("include")
+
+        // Allowlist mode covers only what is named, so the domain set must track what the app
+        // uses; a domain dropped here silently stops being backed up, and a domain added
+        // without the flag silently ships plaintext.
+        assertEquals(
+            setOf("root", "file", "database", "sharedpref", "external"),
+            includes.map { it.getAttribute("domain") }.toSet(),
+        )
+        includes.forEach { include ->
+            assertEquals(
+                "clientSideEncryption",
+                include.getAttribute("requireFlags"),
+                "include for domain '${include.getAttribute("domain")}' is not gated",
+            )
+        }
+    }
+
+    @Test
+    fun `api 26 and 27 rules are valid there and back up nothing`() {
+        val document = parse(resFile("xml", "full_backup_content.xml"))
+        val elements = document.elementsNamed("include") + document.elementsNamed("exclude")
+
+        // The 8.x parser throws on any include/exclude with more than two attributes (only
+        // domain and path exist there), and the default backup agent reacts to that parse
+        // failure by silently backing up nothing. The file must stay inside that limit so the
+        // no-backup outcome remains a deliberate rule set, not a swallowed exception.
+        elements.forEach { element ->
+            val names = (0 until element.attributes.length)
+                .map { element.attributes.item(it).nodeName }
+            assertTrue(
+                names.all { it == "domain" || it == "path" },
+                "<${element.tagName}> carries attributes the API 26/27 parser rejects: $names",
+            )
+        }
+
+        // One include switches Auto Backup into allowlist mode, and the sentinel path never
+        // exists, so the allowlist matches nothing. More includes, or an unexpected shape,
+        // would start backing data up on devices that cannot client-side encrypt it.
+        val includes = document.elementsNamed("include")
+        assertEquals(1, includes.size)
+        assertEquals("file", includes.single().getAttribute("domain"))
+        assertEquals("gravel_no_backup_sentinel", includes.single().getAttribute("path"))
+    }
+
+    @Test
+    fun `api 31 rules keep the encryption gate and stay exclude-only`() {
+        val document = parse(resFile("xml", "backup_rules.xml"))
+
+        val cloudBackup = document.elementsNamed("cloud-backup").single()
+        assertEquals("true", cloudBackup.getAttribute("disableIfNoEncryptionCapabilities"))
+
+        // A single include element would flip these rules into allowlist mode and silently
+        // stop backing up every domain not named.
+        assertEquals(emptyList(), document.elementsNamed("include"))
+    }
+
+    private fun parse(file: File) = DocumentBuilderFactory.newInstance()
+        .newDocumentBuilder()
+        .parse(file)
+
+    private fun org.w3c.dom.Document.elementsNamed(tag: String): List<Element> {
+        val nodes = getElementsByTagName(tag)
+        return (0 until nodes.length).map { nodes.item(it) as Element }
+    }
+
+    /** Locates the res file from wherever Gradle happens to set the test working directory. */
+    private fun resFile(qualifier: String, name: String): File {
+        var dir: File? = File(System.getProperty("user.dir"))
+        while (dir != null) {
+            val res = File(dir, "composeApp/src/androidMain/res")
+            if (res.isDirectory) return File(File(res, qualifier), name)
+            dir = dir.parentFile
+        }
+        error("could not locate composeApp/src/androidMain/res from ${System.getProperty("user.dir")}")
+    }
+}

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/di/LibPebbleModule.android.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/di/LibPebbleModule.android.kt
@@ -96,6 +96,6 @@ actual val platformModule: Module = module {
 
     single { PebbleKitClassicStartListeners(get(), get(), get()) }
     single { PebbleKitProviderNotifier(get<LibPebble>(), get(), get()) }
-    single { PebbleKitCompanionRegistry(get<LibPebble>(), get(), get()) }
+    single { PebbleKitCompanionRegistry.create(get<LibPebble>(), get(), get()) }
     single { PebbleKitWatchIdentity() }
 }

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/di/LibPebbleModule.android.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/di/LibPebbleModule.android.kt
@@ -39,6 +39,7 @@ import io.rebble.libpebblecommon.packets.ProtocolCapsFlag
 import io.rebble.libpebblecommon.pebblekit.classic.PebbleKitClassicStartListeners
 import io.rebble.libpebblecommon.pebblekit.classic.PebbleKitProviderNotifier
 import io.rebble.libpebblecommon.pebblekit.two.PebbleKitCompanionRegistry
+import io.rebble.libpebblecommon.pebblekit.two.PebbleKitWatchIdentity
 import io.rebble.libpebblecommon.util.OtherPebbleAndroidApps
 import io.rebble.libpebblecommon.util.SystemGeolocation
 import org.koin.core.module.Module
@@ -96,4 +97,5 @@ actual val platformModule: Module = module {
     single { PebbleKitClassicStartListeners(get(), get(), get()) }
     single { PebbleKitProviderNotifier(get<LibPebble>(), get(), get()) }
     single { PebbleKitCompanionRegistry(get<LibPebble>(), get(), get()) }
+    single { PebbleKitWatchIdentity() }
 }

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/di/LibPebbleModule.android.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/di/LibPebbleModule.android.kt
@@ -38,6 +38,7 @@ import io.rebble.libpebblecommon.packets.PhoneAppVersion
 import io.rebble.libpebblecommon.packets.ProtocolCapsFlag
 import io.rebble.libpebblecommon.pebblekit.classic.PebbleKitClassicStartListeners
 import io.rebble.libpebblecommon.pebblekit.classic.PebbleKitProviderNotifier
+import io.rebble.libpebblecommon.pebblekit.two.PebbleKitCompanionRegistry
 import io.rebble.libpebblecommon.util.OtherPebbleAndroidApps
 import io.rebble.libpebblecommon.util.SystemGeolocation
 import org.koin.core.module.Module
@@ -94,4 +95,5 @@ actual val platformModule: Module = module {
 
     single { PebbleKitClassicStartListeners(get(), get(), get()) }
     single { PebbleKitProviderNotifier(get<LibPebble>(), get(), get()) }
+    single { PebbleKitCompanionRegistry(get<LibPebble>(), get(), get()) }
 }

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/classic/io/rebble/libpebblecommon/pebblekit/classic/PebbleKitClassic.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/classic/io/rebble/libpebblecommon/pebblekit/classic/PebbleKitClassic.kt
@@ -46,6 +46,30 @@ class PebbleKitClassic(
 
     private val context: Context = getKoin().get()
 
+    private val companionPackages: List<String> by lazy { appInfo.androidCompanionPackages() }
+
+    /**
+     * Delivers watch data to the watchapp's declared companion apps rather than to every app on
+     * the device.
+     *
+     * Classic PebbleKit has no permission and never has, so an untargeted broadcast hands the
+     * contents of every message the watch sends to any app that registers a receiver. Watchapps
+     * predating companion declarations have nobody to target, so those keep broadcasting as
+     * before: narrowing where the declaration exists costs nothing, whereas dropping the
+     * fallback would break apps that still work today.
+     */
+    private fun broadcastToCompanions(intent: Intent) {
+        if (companionPackages.isEmpty()) {
+            // Regular broadcasts are sometimes delayed on Android 14+. Use ordered ones instead.
+            // https://stackoverflow.com/questions/77842817/slow-intent-broadcast-delivery-on-android-14
+            context.sendOrderedBroadcast(intent, null)
+            return
+        }
+        companionPackages.forEach { pkg ->
+            context.sendOrderedBroadcast(Intent(intent).setPackage(pkg), null)
+        }
+    }
+
     private suspend fun replyNACK(id: UByte) {
         withTimeoutOrNull(1000) {
             device.sendAppMessageResult(AppMessageResult.ACK(id))
@@ -70,9 +94,7 @@ class PebbleKitClassic(
                 putExtra(MSG_DATA, pebbleDictionary.toJsonString())
             }
 
-            // Regular broadcasts are sometimes delayed on Android 14+. Use ordered ones instead.
-            // https://stackoverflow.com/questions/77842817/slow-intent-broadcast-delivery-on-android-14
-            context.sendOrderedBroadcast(intent, null)
+            broadcastToCompanions(intent)
         }.catch {
             logger.e(it) { "Error receiving app message: ${it.message}" }
         }.launchIn(scope)
@@ -103,6 +125,14 @@ class PebbleKitClassic(
                 val uuid = (intent.getSerializableExtra(APP_UUID) as? UUID?)?.toKotlinUuid() ?:
                     // Fallback to string
                     intent.getStringExtra(APP_UUID)?.let { Uuid.parseOrNull(it) } ?: return@collect
+
+                // These receivers are exported and every live session sees every SEND broadcast,
+                // so without this a session would relay messages addressed to a different
+                // watchapp, and two concurrent sessions would each send the same message once.
+                if (uuid != this@PebbleKitClassic.uuid) {
+                    return@collect
+                }
+
                 val dictionary: PebbleClassicDictionary = PebbleClassicDictionary.fromJson(
                     intent.getStringExtra(MSG_DATA)
                 )
@@ -120,9 +150,7 @@ class PebbleKitClassic(
                     putExtra(TRANSACTION_ID, result.transactionId.toInt())
                 }
 
-                // Regular broadcasts are sometimes delayed on Android 14+. Use ordered ones instead.
-                // https://stackoverflow.com/questions/77842817/slow-intent-broadcast-delivery-on-android-14
-                context.sendOrderedBroadcast(intent, null)
+                broadcastToCompanions(intent)
             }
         }
     }
@@ -141,6 +169,15 @@ class PebbleKitClassic(
         runningScope?.cancel()
     }
 }
+
+/**
+ * Android packages the watchapp declares as its companions, deduplicated.
+ *
+ * An empty result means "no declaration to narrow to", which callers treat as the pre-existing
+ * untargeted broadcast rather than as "send to nobody".
+ */
+internal fun PbwAppInfo.androidCompanionPackages(): List<String> =
+    companionApp?.android?.apps.orEmpty().mapNotNull { it.pkg }.distinct()
 
 private fun PebbleClassicDictionary.toAppMessageDict(): AppMessageDictionary {
     return tuples.mapValues {

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitCompanionRegistry.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitCompanionRegistry.kt
@@ -5,11 +5,18 @@ import io.rebble.libpebblecommon.connection.LockerApi
 import io.rebble.libpebblecommon.di.LibPebbleCoroutineScope
 import io.rebble.libpebblecommon.disk.pbw.PbwApp
 import io.rebble.libpebblecommon.locker.LockerPBWCache
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.io.files.Path
+import kotlin.uuid.Uuid
 
 private val logger = Logger.withTag("PebbleKitCompanionRegistry")
 
@@ -27,11 +34,17 @@ private val logger = Logger.withTag("PebbleKitCompanionRegistry")
  * locating a PBW ([LockerPBWCache.getPBWFileForApp]) falls through to a network fetch on a cache
  * miss, which would let an unauthorized caller drive traffic just by querying. Only
  * already-cached PBWs are consulted here.
+ *
+ * The constructor takes the narrow seams (a locker UUID flow, a cached-path lookup, a
+ * cache-change signal) rather than the services that provide them so unit tests can drive
+ * scans directly; [create] does the production wiring.
  */
 class PebbleKitCompanionRegistry(
-    private val locker: LockerApi,
-    private val pbwCache: LockerPBWCache,
-    private val scope: LibPebbleCoroutineScope,
+    private val lockerUuids: Flow<List<Uuid>>,
+    private val cachedPbws: () -> List<Path>,
+    private val pbwFilesChanged: Flow<Unit>,
+    private val scope: CoroutineScope,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     /**
      * Companion packages keyed by the lowercase watchapp UUID that declares them.
@@ -49,10 +62,16 @@ class PebbleKitCompanionRegistry(
 
     fun init() {
         scope.launch(CoroutineName("PebbleKitCompanionRegistry")) {
-            // Rebuild whenever the locker changes: installing or removing a watchapp is exactly
-            // what grants or revokes a companion package's access.
-            locker.getAllLockerUuids().collectLatest {
-                val scanned = withContext(Dispatchers.IO) { scanCachedPbws() }
+            // Rebuild on either signal. The locker flow covers install and removal, which is
+            // what grants or revokes a companion package's access. The cache signal covers a
+            // store install's PBW arriving after its locker row: the download is a file-only
+            // write that no database flow surfaces, and it is the event that makes the
+            // declaration readable at all.
+            combine(
+                lockerUuids,
+                pbwFilesChanged.onStart { emit(Unit) },
+            ) { uuids, _ -> uuids }.collectLatest { uuids ->
+                val scanned = withContext(ioDispatcher) { scanCachedPbws(uuids.toSet()) }
                 companionsByApp = scanned
                 logger.d { "Companion packages across ${scanned.size} watchapps" }
             }
@@ -71,13 +90,19 @@ class PebbleKitCompanionRegistry(
         return companionsByApp?.get(watchappUuid.lowercase())?.contains(callingPackage) == true
     }
 
-    private fun scanCachedPbws(): Map<String, Set<String>> = buildMap {
-        pbwCache.cachedPbwPaths().forEach { path ->
+    private fun scanCachedPbws(installed: Set<Uuid>): Map<String, Set<String>> = buildMap {
+        cachedPbws().forEach { path ->
             // A corrupt or partially written PBW must not take down the whole scan, which would
             // revoke access for every other companion app on the device.
             val info = runCatching { PbwApp(path).info }
                 .onFailure { logger.w(it) { "Skipping unreadable PBW ${path.name}" } }
                 .getOrNull() ?: return@forEach
+
+            // A cached file whose watchapp is not in the locker grants nothing: web-sync
+            // removal marks the row deleted without deleting the file, so membership has to be
+            // enforced here rather than assumed from cache hygiene.
+            val uuid = Uuid.parseOrNull(info.uuid) ?: return@forEach
+            if (uuid !in installed) return@forEach
 
             val packages = info.companionApp?.android?.apps.orEmpty().mapNotNull { it.pkg }.toSet()
             if (packages.isEmpty()) return@forEach
@@ -85,5 +110,18 @@ class PebbleKitCompanionRegistry(
             // The cache can hold several versions of one watchapp, so merge rather than replace.
             merge(info.uuid.lowercase(), packages) { existing, new -> existing + new }
         }
+    }
+
+    companion object {
+        fun create(
+            locker: LockerApi,
+            pbwCache: LockerPBWCache,
+            scope: LibPebbleCoroutineScope,
+        ) = PebbleKitCompanionRegistry(
+            lockerUuids = locker.getAllLockerUuids(),
+            cachedPbws = pbwCache::cachedPbwPaths,
+            pbwFilesChanged = pbwCache.pbwFilesChanged,
+            scope = scope,
+        )
     }
 }

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitCompanionRegistry.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitCompanionRegistry.kt
@@ -34,12 +34,18 @@ class PebbleKitCompanionRegistry(
     private val scope: LibPebbleCoroutineScope,
 ) {
     /**
+     * Companion packages keyed by the lowercase watchapp UUID that declares them.
+     *
      * Null until the first scan completes, which is deliberately distinct from "scanned, found
      * nothing": callers are denied in both cases, so a query arriving before the locker has been
      * read fails closed instead of briefly exposing watch state.
+     *
+     * Keyed by watchapp rather than flattened because the sender surface has to answer "may this
+     * package drive *this* watchapp", and it has to answer it while holding a binder thread, so
+     * the per-watchapp breakdown cannot be recomputed on demand.
      */
     @Volatile
-    private var authorizedPackages: Set<String>? = null
+    private var companionsByApp: Map<String, Set<String>>? = null
 
     fun init() {
         scope.launch(CoroutineName("PebbleKitCompanionRegistry")) {
@@ -47,25 +53,37 @@ class PebbleKitCompanionRegistry(
             // what grants or revokes a companion package's access.
             locker.getAllLockerUuids().collectLatest {
                 val scanned = withContext(Dispatchers.IO) { scanCachedPbws() }
-                authorizedPackages = scanned
-                logger.d { "Authorized PebbleKit companion packages: ${scanned.size}" }
+                companionsByApp = scanned
+                logger.d { "Companion packages across ${scanned.size} watchapps" }
             }
         }
     }
 
+    /** Whether [callingPackage] is a declared companion of any installed watchapp. */
     fun isAuthorized(callingPackage: String?): Boolean {
         if (callingPackage == null) return false
-        return authorizedPackages?.contains(callingPackage) == true
+        return companionsByApp?.values?.any { callingPackage in it } == true
     }
 
-    private fun scanCachedPbws(): Set<String> = buildSet {
+    /** Whether [callingPackage] is a declared companion of the watchapp [watchappUuid]. */
+    fun isAuthorizedFor(callingPackage: String?, watchappUuid: String?): Boolean {
+        if (callingPackage == null || watchappUuid == null) return false
+        return companionsByApp?.get(watchappUuid.lowercase())?.contains(callingPackage) == true
+    }
+
+    private fun scanCachedPbws(): Map<String, Set<String>> = buildMap {
         pbwCache.cachedPbwPaths().forEach { path ->
             // A corrupt or partially written PBW must not take down the whole scan, which would
             // revoke access for every other companion app on the device.
-            runCatching { PbwApp(path).info.companionApp?.android?.apps.orEmpty() }
+            val info = runCatching { PbwApp(path).info }
                 .onFailure { logger.w(it) { "Skipping unreadable PBW ${path.name}" } }
-                .getOrNull()
-                ?.forEach { app -> app.pkg?.let(::add) }
+                .getOrNull() ?: return@forEach
+
+            val packages = info.companionApp?.android?.apps.orEmpty().mapNotNull { it.pkg }.toSet()
+            if (packages.isEmpty()) return@forEach
+
+            // The cache can hold several versions of one watchapp, so merge rather than replace.
+            merge(info.uuid.lowercase(), packages) { existing, new -> existing + new }
         }
     }
 }

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitCompanionRegistry.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitCompanionRegistry.kt
@@ -1,0 +1,71 @@
+package io.rebble.libpebblecommon.pebblekit.two
+
+import co.touchlab.kermit.Logger
+import io.rebble.libpebblecommon.connection.LockerApi
+import io.rebble.libpebblecommon.di.LibPebbleCoroutineScope
+import io.rebble.libpebblecommon.disk.pbw.PbwApp
+import io.rebble.libpebblecommon.locker.LockerPBWCache
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private val logger = Logger.withTag("PebbleKitCompanionRegistry")
+
+/**
+ * Which Android packages are authorized to use the PebbleKit2 API surface.
+ *
+ * A package is authorized when it is named in the `companionApp.android.apps[].pkg` list of a
+ * watchapp the user has actually installed, which is the same relationship
+ * [PebbleSenderReceiver] already requires before it will relay app messages or timeline pins.
+ * Applying it to the read path as well means the authorization is rooted in a deliberate user
+ * action (installing that watchapp) rather than in the caller merely existing on the device.
+ *
+ * The set is precomputed rather than resolved per query for two reasons. Resolving on demand
+ * would mean opening PBW archives while holding a binder thread, and the obvious API for
+ * locating a PBW ([LockerPBWCache.getPBWFileForApp]) falls through to a network fetch on a cache
+ * miss, which would let an unauthorized caller drive traffic just by querying. Only
+ * already-cached PBWs are consulted here.
+ */
+class PebbleKitCompanionRegistry(
+    private val locker: LockerApi,
+    private val pbwCache: LockerPBWCache,
+    private val scope: LibPebbleCoroutineScope,
+) {
+    /**
+     * Null until the first scan completes, which is deliberately distinct from "scanned, found
+     * nothing": callers are denied in both cases, so a query arriving before the locker has been
+     * read fails closed instead of briefly exposing watch state.
+     */
+    @Volatile
+    private var authorizedPackages: Set<String>? = null
+
+    fun init() {
+        scope.launch(CoroutineName("PebbleKitCompanionRegistry")) {
+            // Rebuild whenever the locker changes: installing or removing a watchapp is exactly
+            // what grants or revokes a companion package's access.
+            locker.getAllLockerUuids().collectLatest {
+                val scanned = withContext(Dispatchers.IO) { scanCachedPbws() }
+                authorizedPackages = scanned
+                logger.d { "Authorized PebbleKit companion packages: ${scanned.size}" }
+            }
+        }
+    }
+
+    fun isAuthorized(callingPackage: String?): Boolean {
+        if (callingPackage == null) return false
+        return authorizedPackages?.contains(callingPackage) == true
+    }
+
+    private fun scanCachedPbws(): Set<String> = buildSet {
+        pbwCache.cachedPbwPaths().forEach { path ->
+            // A corrupt or partially written PBW must not take down the whole scan, which would
+            // revoke access for every other companion app on the device.
+            runCatching { PbwApp(path).info.companionApp?.android?.apps.orEmpty() }
+                .onFailure { logger.w(it) { "Skipping unreadable PBW ${path.name}" } }
+                .getOrNull()
+                ?.forEach { app -> app.pkg?.let(::add) }
+        }
+    }
+}

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitProvider.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitProvider.kt
@@ -1,5 +1,8 @@
 package io.rebble.libpebblecommon.pebblekit.two
 
+import android.database.Cursor
+import android.net.Uri
+import co.touchlab.kermit.Logger
 import io.rebble.libpebblecommon.connection.ConnectedPebbleDevice
 import io.rebble.libpebblecommon.connection.LibPebble
 import io.rebble.libpebblecommon.connection.LockerApi
@@ -31,6 +34,32 @@ class PebbleKitProvider : BasePebbleKitProvider(), LibPebbleKoinComponent {
       coroutineScope = getKoin().get()
 
       super.initialize()
+   }
+
+   /**
+    * The provider is exported, so every read is gated on the caller being a companion of an
+    * installed watchapp. Without this any app on the device could read watch state, including
+    * the watch identifier, with no permission and no user-visible prompt.
+    *
+    * Denial returns null rather than an empty cursor because that is already the outcome for an
+    * unrecognised URI, so clients handle it. Failing closed while the registry is still loading
+    * costs a legitimate companion one empty result at cold start; the alternative would leak
+    * watch state during exactly the window before authorization is known.
+    */
+   override fun query(
+      uri: Uri,
+      projection: Array<out String?>?,
+      selection: String?,
+      selectionArgs: Array<out String?>?,
+      sortOrder: String?
+   ): Cursor? {
+      val caller = callingPackage
+      val registry = runCatching { getKoin().getOrNull<PebbleKitCompanionRegistry>() }.getOrNull()
+      if (registry?.isAuthorized(caller) != true) {
+         logger.d { "Denied PebbleKit query from $caller" }
+         return null
+      }
+      return super.query(uri, projection, selection, selectionArgs, sortOrder)
    }
 
    override fun getConnectedWatches(): Flow<List<Map<String, Any?>>> {
@@ -83,5 +112,7 @@ class PebbleKitProvider : BasePebbleKitProvider(), LibPebbleKoinComponent {
 
    companion object {
       var instance: PebbleKitProvider? = null
+
+      private val logger = Logger.withTag("PebbleKitProvider")
    }
 }

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitProvider.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitProvider.kt
@@ -1,6 +1,7 @@
 package io.rebble.libpebblecommon.pebblekit.two
 
 import android.database.Cursor
+import android.database.MatrixCursor
 import android.net.Uri
 import co.touchlab.kermit.Logger
 import io.rebble.libpebblecommon.connection.ConnectedPebbleDevice
@@ -53,13 +54,84 @@ class PebbleKitProvider : BasePebbleKitProvider(), LibPebbleKoinComponent {
       selectionArgs: Array<out String?>?,
       sortOrder: String?
    ): Cursor? {
-      val caller = callingPackage
+      val caller = callingPackage ?: return null
       val registry = runCatching { getKoin().getOrNull<PebbleKitCompanionRegistry>() }.getOrNull()
       if (registry?.isAuthorized(caller) != true) {
          logger.d { "Denied PebbleKit query from $caller" }
          return null
       }
-      return super.query(uri, projection, selection, selectionArgs, sortOrder)
+      val identity = runCatching { getKoin().getOrNull<PebbleKitWatchIdentity>() }.getOrNull()
+         ?: return null
+
+      return when (uri.pathSegments.firstOrNull()) {
+         ConnectedWatch.CONTENT_PATH ->
+            super.query(uri, projection, selection, selectionArgs, sortOrder)
+               ?.let { pseudonymiseWatchIds(it, caller, identity) }
+
+         // The watch is addressed by a path segment, and the caller only ever saw a pseudonym,
+         // so translate it back before the base class tries to match it against a real serial.
+         ActiveApp.CONTENT_PATH -> {
+            val supplied = uri.pathSegments.getOrNull(1) ?: return null
+            val serial = identity.resolveSerial(caller, supplied, connectedSerials())
+               ?: return null
+            val rebuilt = uri.buildUpon()
+               .path(null)
+               .appendPath(ActiveApp.CONTENT_PATH)
+               .appendPath(serial)
+               .build()
+            super.query(rebuilt, projection, selection, selectionArgs, sortOrder)
+         }
+
+         else -> super.query(uri, projection, selection, selectionArgs, sortOrder)
+      }
+   }
+
+   private fun connectedSerials(): List<String> =
+      runCatching {
+         getKoin().getOrNull<LibPebble>()?.watches?.value
+            ?.filterIsInstance<ConnectedPebbleDevice>()
+            ?.map { it.watchInfo.serial }
+      }.getOrNull().orEmpty()
+
+   /**
+    * Rebuilds the connected-watch rows with the serial replaced by this caller's pseudonym.
+    *
+    * A row whose identifier cannot be derived is dropped rather than passed through, so a
+    * failure in the identity layer cannot degrade into disclosing the serial it was meant to
+    * replace.
+    */
+   private fun pseudonymiseWatchIds(
+      cursor: Cursor,
+      callingPackage: String,
+      identity: PebbleKitWatchIdentity,
+   ): Cursor {
+      val columns = cursor.columnNames
+      val idIndex = columns.indexOf(ConnectedWatch.ID)
+      if (idIndex < 0) return cursor
+
+      val out = MatrixCursor(columns, cursor.count)
+      cursor.use { source ->
+         while (source.moveToNext()) {
+            val serial = source.getString(idIndex) ?: continue
+            val pseudonym = identity.pseudonymFor(callingPackage, serial) ?: continue
+            val row = arrayOfNulls<Any>(columns.size)
+            for (index in columns.indices) {
+               row[index] = if (index == idIndex) {
+                  pseudonym
+               } else {
+                  when (source.getType(index)) {
+                     Cursor.FIELD_TYPE_NULL -> null
+                     Cursor.FIELD_TYPE_INTEGER -> source.getLong(index)
+                     Cursor.FIELD_TYPE_FLOAT -> source.getDouble(index)
+                     Cursor.FIELD_TYPE_BLOB -> source.getBlob(index)
+                     else -> source.getString(index)
+                  }
+               }
+            }
+            out.addRow(row)
+         }
+      }
+      return out
    }
 
    override fun getConnectedWatches(): Flow<List<Map<String, Any?>>> {

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitProvider.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitProvider.kt
@@ -82,10 +82,17 @@ class PebbleKitProvider : BasePebbleKitProvider(), LibPebbleKoinComponent {
             super.query(rebuilt, projection, selection, selectionArgs, sortOrder)
          }
 
-         else -> super.query(uri, projection, selection, selectionArgs, sortOrder)
+         // Fail closed on paths this override does not recognise. The base class serves only
+         // the two paths above today, but a library upgrade could add one that carries watch
+         // data, and delegating would hand it to callers unpseudonymised with no diff here to
+         // review.
+         else -> null
       }
    }
 
+   // Deliberately more defensive than the same helper in PebbleSenderReceiver: a provider can
+   // be queried before initialize() has populated the lateinit fields, so this must resolve
+   // Koin per call, whereas the bound service's constructor-resolved field is always safe.
    private fun connectedSerials(): List<String> =
       runCatching {
          getKoin().getOrNull<LibPebble>()?.watches?.value
@@ -143,7 +150,7 @@ class PebbleKitProvider : BasePebbleKitProvider(), LibPebbleKoinComponent {
 
                mapOf(
                   ConnectedWatch.ID to watchInfo.serial,
-                  ConnectedWatch.NAME to watch.displayName(),
+                  ConnectedWatch.NAME to pebbleKitWatchName(watch.name),
                   ConnectedWatch.PLATFORM to watchInfo.platform.watchType.codename,
                   ConnectedWatch.REVISION to watchInfo.platform.revision,
                   ConnectedWatch.FIRMWARE_VERSION_MAJOR to runningFwVersion.major,
@@ -188,3 +195,18 @@ class PebbleKitProvider : BasePebbleKitProvider(), LibPebbleKoinComponent {
       private val logger = Logger.withTag("PebbleKitProvider")
    }
 }
+
+// "Pebble Time 4F2A": the model prefix plus four hex digits unique to the device.
+private val DEVICE_NAME_SUFFIX = Regex(""" [0-9A-Fa-f]{4}$""")
+
+/**
+ * The watch name served to PebbleKit callers: the BLE-advertised name with the device-unique
+ * suffix stripped.
+ *
+ * The full advertised name, and even more so the user's nickname (which `displayName()` would
+ * prefer), is identical for every caller, so serving either would hand two companions the
+ * shared correlator the per-caller pseudonymous IDs exist to remove. The model prefix keeps the
+ * name informative; nothing more specific than the model is served.
+ */
+internal fun pebbleKitWatchName(advertisedName: String): String =
+    advertisedName.replace(DEVICE_NAME_SUFFIX, "")

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitWatchIdentity.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitWatchIdentity.kt
@@ -1,0 +1,83 @@
+package io.rebble.libpebblecommon.pebblekit.two
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import co.touchlab.kermit.Logger
+import java.security.KeyStore
+import javax.crypto.KeyGenerator
+import javax.crypto.Mac
+import javax.crypto.SecretKey
+
+/**
+ * Per-caller pseudonymous identifiers for watches on the PebbleKit 2 surface.
+ *
+ * The watch serial is a permanent hardware identifier. Handing it to every companion app would
+ * give any two of them a shared key to correlate the same user across otherwise unrelated
+ * installs, which is the tracking primitive this fork exists to avoid. Each calling package
+ * instead sees a different, stable identifier for the same watch, so an app can still recognise
+ * "the watch I talked to last time" while two apps comparing notes learn nothing.
+ *
+ * Derived with HMAC-SHA256 under a key that never leaves the Android Keystore, so the mapping is
+ * not reversible by a caller and cannot be recomputed off-device even given a full copy of app
+ * storage.
+ */
+class PebbleKitWatchIdentity {
+
+    private val keyStore: KeyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+    private val keyLock = Any()
+
+    private fun getOrCreateKey(): SecretKey = synchronized(keyLock) {
+        (keyStore.getEntry(KEY_ALIAS, null) as? KeyStore.SecretKeyEntry)?.secretKey
+            ?: KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_HMAC_SHA256, ANDROID_KEYSTORE)
+                .run {
+                    init(
+                        KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_SIGN).build()
+                    )
+                    generateKey()
+                }
+    }
+
+    /**
+     * Returns null rather than falling back to the serial: a caller receiving no identifier is a
+     * degraded response, whereas a caller receiving the real serial is the exact disclosure this
+     * class exists to prevent.
+     */
+    fun pseudonymFor(callingPackage: String, serial: String): String? = runCatching {
+        val mac = Mac.getInstance(MAC_ALGORITHM)
+        mac.init(getOrCreateKey())
+        mac.update(callingPackage.encodeToByteArray())
+        // Domain separator, so ("a.b", "cd") and ("a", "bcd") cannot collide onto one identifier.
+        mac.update(0)
+        mac.update(serial.encodeToByteArray())
+        mac.doFinal().take(ID_BYTES).joinToString("") { byte ->
+            (byte.toInt() and 0xFF).toString(16).padStart(2, '0')
+        }
+    }.onFailure { logger.e(it) { "Could not derive a watch identifier" } }.getOrNull()
+
+    /**
+     * Maps an identifier supplied by [callingPackage] back to a real serial.
+     *
+     * Real serials are also accepted. Emitting them is what leaks, and a caller that already
+     * holds one learns nothing by passing it back, so rejecting them would break existing
+     * integrations for no gain.
+     */
+    fun resolveSerial(
+        callingPackage: String,
+        identifier: String,
+        connectedSerials: List<String>,
+    ): String? {
+        if (identifier in connectedSerials) return identifier
+        return connectedSerials.firstOrNull { pseudonymFor(callingPackage, it) == identifier }
+    }
+
+    private companion object {
+        val logger = Logger.withTag("PebbleKitWatchIdentity")
+
+        const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        const val KEY_ALIAS = "gravel_pebblekit_watch_id_v1"
+        const val MAC_ALGORITHM = "HmacSHA256"
+
+        /** 128 bits of a SHA-256 MAC: collision risk is negligible for a handful of watches. */
+        const val ID_BYTES = 16
+    }
+}

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitWatchIdentity.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitWatchIdentity.kt
@@ -20,10 +20,18 @@ import javax.crypto.SecretKey
  * Derived with HMAC-SHA256 under a key that never leaves the Android Keystore, so the mapping is
  * not reversible by a caller and cannot be recomputed off-device even given a full copy of app
  * storage.
+ *
+ * The Keystore access pattern here has a structural twin in the util module's
+ * KeystoreSecretCipher, which this module cannot depend on. A fix to the Keystore handling in
+ * either file almost certainly applies to both.
  */
 class PebbleKitWatchIdentity {
 
     private val keyStore: KeyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+
+    // Key creation is not atomic, and concurrent binder calls from different companions can
+    // reach it together, which would otherwise race two keys into the same alias and change
+    // every previously issued pseudonym.
     private val keyLock = Any()
 
     private fun getOrCreateKey(): SecretKey = synchronized(keyLock) {

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleSenderReceiver.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleSenderReceiver.kt
@@ -4,8 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.IBinder
 import co.touchlab.kermit.Logger
-import io.rebble.pebblekit2.common.SendDataCallback
-import io.rebble.pebblekit2.common.UniversalRequestResponse
 import io.rebble.libpebblecommon.connection.ConnectedPebbleDevice
 import io.rebble.libpebblecommon.connection.LibPebble
 import io.rebble.libpebblecommon.connection.LockerApi
@@ -19,6 +17,8 @@ import io.rebble.libpebblecommon.js.TimelinePinJson
 import io.rebble.libpebblecommon.locker.Locker
 import io.rebble.libpebblecommon.locker.LockerPBWCache
 import io.rebble.libpebblecommon.services.appmessage.AppMessageResult
+import io.rebble.pebblekit2.common.SendDataCallback
+import io.rebble.pebblekit2.common.UniversalRequestResponse
 import io.rebble.pebblekit2.common.model.PebbleDictionary
 import io.rebble.pebblekit2.common.model.TimelinePin
 import io.rebble.pebblekit2.common.model.TimelineResult
@@ -126,17 +126,20 @@ class PebbleSenderReceiver : BasePebbleSenderReceiver(), LibPebbleKoinComponent 
                         callback.onResult(pseudonymiseResults(result, caller, suppliedBySerial))
                     }
                 })
-            }.onFailure { logger.e(it) { "Failed to dispatch PebbleKit request" } }
+            }.onFailure {
+                logger.e(it) { "Failed to dispatch PebbleKit request" }
+                // Same contract as the rejection paths above: the caller always hears back.
+                // Swallowing the failure without replying would leave it blocked on a callback
+                // that will never fire.
+                callback.replyEmpty()
+            }
         }
     }
 
     /**
      * Rewrites the per-watch result keys, which the base class fills in with real serials.
-     *
-     * An identifier the caller supplied is echoed back verbatim so it can still correlate the
-     * result with its request. Anything else, which is the "all connected watches" case where
-     * the base class generated the keys itself, is replaced with this caller's pseudonym, and
-     * dropped outright if none can be derived.
+     * The key translation itself lives in [pseudonymiseTransmissionKeys]; this method is only
+     * the Bundle plumbing around it.
      */
     private fun pseudonymiseResults(
         result: Bundle,
@@ -144,13 +147,13 @@ class PebbleSenderReceiver : BasePebbleSenderReceiver(), LibPebbleKoinComponent 
         suppliedBySerial: Map<String, String>,
     ): Bundle {
         val results = result.getBundle(KEY_TRANSMISSION_RESULTS) ?: return result
+        val identifierBySerial = pseudonymiseTransmissionKeys(
+            serials = results.keySet(),
+            suppliedBySerial = suppliedBySerial,
+        ) { serial -> watchIdentity.pseudonymFor(callingPackage, serial) }
         val mapped = Bundle()
-        results.keySet().forEach { serial ->
-            val value = results.getBundle(serial) ?: return@forEach
-            val identifier = suppliedBySerial[serial]
-                ?: watchIdentity.pseudonymFor(callingPackage, serial)
-                ?: return@forEach
-            mapped.putBundle(identifier, value)
+        identifierBySerial.forEach { (serial, identifier) ->
+            results.getBundle(serial)?.let { mapped.putBundle(identifier, it) }
         }
         return Bundle(result).apply { putBundle(KEY_TRANSMISSION_RESULTS, mapped) }
     }
@@ -282,6 +285,26 @@ class PebbleSenderReceiver : BasePebbleSenderReceiver(), LibPebbleKoinComponent 
         )
 
         return pbwInfo.info.companionApp?.android?.apps.orEmpty().any { it.pkg == pkg }
+    }
+}
+
+/**
+ * Maps each real serial in a result to the identifier the caller should see.
+ *
+ * An identifier the caller supplied is echoed back verbatim so it can still correlate the
+ * result with its request. Anything else, which is the "all connected watches" case where the
+ * base class generated the keys itself, is replaced with this caller's pseudonym, and dropped
+ * outright if none can be derived: a failure in the identity layer must degrade into a missing
+ * row, never into disclosing the serial it was meant to replace.
+ */
+internal fun pseudonymiseTransmissionKeys(
+    serials: Collection<String>,
+    suppliedBySerial: Map<String, String>,
+    pseudonymFor: (String) -> String?,
+): Map<String, String> = buildMap {
+    serials.forEach { serial ->
+        val identifier = suppliedBySerial[serial] ?: pseudonymFor(serial) ?: return@forEach
+        put(serial, identifier)
     }
 }
 

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleSenderReceiver.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleSenderReceiver.kt
@@ -1,5 +1,11 @@
 package io.rebble.libpebblecommon.pebblekit.two
 
+import android.content.Intent
+import android.os.Bundle
+import android.os.IBinder
+import co.touchlab.kermit.Logger
+import io.rebble.pebblekit2.common.SendDataCallback
+import io.rebble.pebblekit2.common.UniversalRequestResponse
 import io.rebble.libpebblecommon.connection.ConnectedPebbleDevice
 import io.rebble.libpebblecommon.connection.LibPebble
 import io.rebble.libpebblecommon.connection.LockerApi
@@ -35,12 +41,128 @@ import kotlin.uuid.toKotlinUuid
 
 private val WATCH_SENDING_TIMEOUT = 10.seconds
 
+private val logger = Logger.withTag("PebbleSenderReceiver")
+
+// The request protocol is internal to the PebbleKit server library and is not exposed as public
+// API, so these are pinned by PebbleKitRequestProtocolTest rather than by the compiler. If that
+// test starts failing after a library upgrade, the wire keys changed and the checks below are
+// silently inert until they are updated to match.
+private const val KEY_ACTION = "ACTION"
+private const val KEY_WATCHAPP_UUID = "WATCHAPP_UUID"
+private const val KEY_WATCHES_ID = "WATCHES_ID"
+private const val KEY_TRANSMISSION_RESULTS = "TRANSMISSION_RESULTS"
+private const val ACTION_START_APP = "START_APP"
+private const val ACTION_STOP_APP = "STOP_APP"
+
 class PebbleSenderReceiver : BasePebbleSenderReceiver(), LibPebbleKoinComponent {
     private val watchManager: Watches = getKoin().get<LibPebble>()
     private val locker: Locker = getKoin().get()
     private val lockerPBWCache: LockerPBWCache = getKoin().get()
     private val remoteTimelineEmulator: RemoteTimelineEmulator = getKoin().get()
+    private val companionRegistry: PebbleKitCompanionRegistry = getKoin().get()
+    private val watchIdentity: PebbleKitWatchIdentity = getKoin().get()
     override val coroutineScope: LibPebbleCoroutineScope = getKoin().get()
+
+    /**
+     * Wraps the base binder so requests can be inspected while the caller's identity is still
+     * available.
+     *
+     * [startAppOnTheWatch] and [stopAppOnTheWatch] receive no caller identity at all, unlike the
+     * app-message and timeline entry points, so on their own they cannot tell an authorized
+     * companion from any other app that happens to be installed. The library does resolve the
+     * calling package, on the binder thread where it is authoritative, and then discards it
+     * before invoking those two callbacks. Intercepting here is what puts it back.
+     *
+     * Everything is delegated synchronously on that same binder thread on purpose: dispatching
+     * to a coroutine first would make the library's own caller lookup return this app's identity
+     * instead of the client's, silently defeating the checks it already performs.
+     */
+    override fun onBind(intent: Intent?): IBinder? {
+        val delegate = super.onBind(intent) as? UniversalRequestResponse ?: return null
+        return AuthorizingBinder(delegate)
+    }
+
+    private inner class AuthorizingBinder(
+        private val delegate: UniversalRequestResponse,
+    ) : UniversalRequestResponse.Stub() {
+
+        override fun request(request: Bundle, callback: SendDataCallback) {
+            val caller = packageManager.getNameForUid(getCallingUid())
+            if (caller == null) {
+                logger.d { "Rejecting PebbleKit request from an unresolvable caller" }
+                callback.replyEmpty()
+                return
+            }
+
+            val action = request.getString(KEY_ACTION)
+            if (action == ACTION_START_APP || action == ACTION_STOP_APP) {
+                val watchapp = request.getString(KEY_WATCHAPP_UUID)
+                if (!companionRegistry.isAuthorizedFor(caller, watchapp)) {
+                    logger.d { "Denied $action of $watchapp from $caller" }
+                    callback.replyEmpty()
+                    return
+                }
+            }
+
+            // Callers only ever saw pseudonyms, so translate before the base class matches them
+            // against real serials, and remember the mapping to undo it on the way back.
+            val serials = connectedSerials()
+            val supplied = request.getStringArray(KEY_WATCHES_ID)
+            val serialBySupplied = supplied.orEmpty().associateWith { identifier ->
+                watchIdentity.resolveSerial(caller, identifier, serials) ?: identifier
+            }
+            val outbound = if (supplied == null) {
+                request
+            } else {
+                Bundle(request).apply {
+                    putStringArray(KEY_WATCHES_ID, supplied.map { serialBySupplied.getValue(it) }.toTypedArray())
+                }
+            }
+            val suppliedBySerial = serialBySupplied.entries.associate { (k, v) -> v to k }
+
+            runCatching {
+                delegate.request(outbound, object : SendDataCallback.Stub() {
+                    override fun onResult(result: Bundle) {
+                        callback.onResult(pseudonymiseResults(result, caller, suppliedBySerial))
+                    }
+                })
+            }.onFailure { logger.e(it) { "Failed to dispatch PebbleKit request" } }
+        }
+    }
+
+    /**
+     * Rewrites the per-watch result keys, which the base class fills in with real serials.
+     *
+     * An identifier the caller supplied is echoed back verbatim so it can still correlate the
+     * result with its request. Anything else, which is the "all connected watches" case where
+     * the base class generated the keys itself, is replaced with this caller's pseudonym, and
+     * dropped outright if none can be derived.
+     */
+    private fun pseudonymiseResults(
+        result: Bundle,
+        callingPackage: String,
+        suppliedBySerial: Map<String, String>,
+    ): Bundle {
+        val results = result.getBundle(KEY_TRANSMISSION_RESULTS) ?: return result
+        val mapped = Bundle()
+        results.keySet().forEach { serial ->
+            val value = results.getBundle(serial) ?: return@forEach
+            val identifier = suppliedBySerial[serial]
+                ?: watchIdentity.pseudonymFor(callingPackage, serial)
+                ?: return@forEach
+            mapped.putBundle(identifier, value)
+        }
+        return Bundle(result).apply { putBundle(KEY_TRANSMISSION_RESULTS, mapped) }
+    }
+
+    private fun connectedSerials(): List<String> =
+        watchManager.watches.value.filterIsInstance<ConnectedPebbleDevice>()
+            .map { it.watchInfo.serial }
+
+    private fun SendDataCallback.replyEmpty() {
+        runCatching { onResult(Bundle()) }
+            .onFailure { logger.e(it) { "Failed to reply to a rejected PebbleKit request" } }
+    }
 
     override suspend fun sendDataToPebble(
         callingPackage: String?,

--- a/libpebble3/src/androidMain/kotlin/main.kt
+++ b/libpebble3/src/androidMain/kotlin/main.kt
@@ -4,6 +4,7 @@ import io.rebble.libpebblecommon.di.LibPebbleKoinComponent
 import io.rebble.libpebblecommon.packets.PhoneAppVersion
 import io.rebble.libpebblecommon.pebblekit.classic.PebbleKitClassicStartListeners
 import io.rebble.libpebblecommon.pebblekit.classic.PebbleKitProviderNotifier
+import io.rebble.libpebblecommon.pebblekit.two.PebbleKitCompanionRegistry
 import io.rebble.libpebblecommon.pebblekit.two.PebbleKitProvider
 
 actual fun getPlatform(): PhoneAppVersion.OSType = PhoneAppVersion.OSType.Android
@@ -12,6 +13,9 @@ actual fun performPlatformSpecificInit() {
     val koin = object: LibPebbleKoinComponent {}.getKoin()
     koin.get<PebbleKitClassicStartListeners>().init()
     koin.get<PebbleKitProviderNotifier>().init()
+    // Before the provider: it fails closed until the first scan lands, so starting the scan
+    // early keeps the window where a legitimate companion is refused as short as possible.
+    koin.get<PebbleKitCompanionRegistry>().init()
 
     PebbleKitProvider.instance?.initialize()
 }

--- a/libpebble3/src/androidUnitTest/kotlin/io/rebble/libpebblecommon/pebblekit/classic/AndroidCompanionPackagesTest.kt
+++ b/libpebble3/src/androidUnitTest/kotlin/io/rebble/libpebblecommon/pebblekit/classic/AndroidCompanionPackagesTest.kt
@@ -1,0 +1,74 @@
+package io.rebble.libpebblecommon.pebblekit.classic
+
+import io.rebble.libpebblecommon.metadata.pbw.appinfo.AndroidCompanionAppInstance
+import io.rebble.libpebblecommon.metadata.pbw.appinfo.AndroidCompanionAppRoot
+import io.rebble.libpebblecommon.metadata.pbw.appinfo.CompanionApp
+import io.rebble.libpebblecommon.metadata.pbw.appinfo.PbwAppInfo
+import io.rebble.libpebblecommon.metadata.pbw.appinfo.Resources
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Classic PebbleKit broadcasts watch data with no permission, so narrowing delivery to the
+ * watchapp's declared companions is the only thing standing between an app's messages and every
+ * receiver on the device. An empty result is load-bearing in the other direction: it means
+ * "broadcast as before", so a watchapp predating companion declarations keeps working.
+ */
+class AndroidCompanionPackagesTest {
+
+    @Test
+    fun `returns the declared packages`() {
+        val info = appInfo(CompanionApp(android = root("com.example.one", "com.example.two")))
+
+        assertEquals(listOf("com.example.one", "com.example.two"), info.androidCompanionPackages())
+    }
+
+    @Test
+    fun `is empty when no companion is declared`() {
+        assertEquals(emptyList(), appInfo(companion = null).androidCompanionPackages())
+    }
+
+    @Test
+    fun `is empty when the declaration has no android section`() {
+        assertEquals(emptyList(), appInfo(CompanionApp(android = null)).androidCompanionPackages())
+    }
+
+    @Test
+    fun `is empty when the android section declares no apps`() {
+        val info = appInfo(CompanionApp(android = AndroidCompanionAppRoot()))
+
+        assertEquals(emptyList(), info.androidCompanionPackages())
+    }
+
+    @Test
+    fun `skips entries with no package name`() {
+        // appinfo.json can carry a companion entry that only names a store URL.
+        val android = AndroidCompanionAppRoot(
+            apps = listOf(
+                AndroidCompanionAppInstance(pkg = null),
+                AndroidCompanionAppInstance(pkg = "com.example.one"),
+            )
+        )
+
+        assertEquals(listOf("com.example.one"), appInfo(CompanionApp(android)).androidCompanionPackages())
+    }
+
+    @Test
+    fun `deduplicates repeated packages`() {
+        // Otherwise the same companion would receive one copy of every message per entry.
+        val info = appInfo(CompanionApp(android = root("com.example.one", "com.example.one")))
+
+        assertEquals(listOf("com.example.one"), info.androidCompanionPackages())
+    }
+
+    private fun root(vararg packages: String) =
+        AndroidCompanionAppRoot(apps = packages.map { AndroidCompanionAppInstance(pkg = it) })
+
+    private fun appInfo(companion: CompanionApp?) = PbwAppInfo(
+        uuid = "00000000-0000-0000-0000-000000000001",
+        shortName = "test",
+        versionLabel = "1.0",
+        resources = Resources(),
+        companionApp = companion,
+    )
+}

--- a/libpebble3/src/androidUnitTest/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitCompanionRegistryTest.kt
+++ b/libpebble3/src/androidUnitTest/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitCompanionRegistryTest.kt
@@ -1,0 +1,187 @@
+package io.rebble.libpebblecommon.pebblekit.two
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.io.files.Path
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.io.FileOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * The registry is the single authorization oracle for the exported PebbleKit 2 provider and the
+ * sender service, so its decision semantics are pinned here: fail-closed before the first scan,
+ * locker membership as the source of authority (a cached file alone grants nothing), rescans
+ * when a store install's PBW lands after its locker row, and resilience of one watchapp's
+ * grant to another watchapp's corrupt file. A regression in any of these either reopens the
+ * watch-state read path or silently locks every companion out.
+ */
+class PebbleKitCompanionRegistryTest {
+
+    @get:Rule
+    val temp = TemporaryFolder()
+
+    private val watchappUuid = Uuid.parse("864369ab-1f37-4a2e-9243-dd6b21af9c14")
+    private val otherUuid = Uuid.parse("5f2c1e08-9f61-4d3e-8a35-0d2f8e1b7a90")
+
+    @Test
+    fun `denies everything before the first scan completes`() = runTest {
+        writePbw("app.pbw", watchappUuid, "com.example.companion")
+        val registry = startRegistry(MutableStateFlow(listOf(watchappUuid)))
+
+        // The scheduler is deliberately not advanced: the scan has not run yet, and a query in
+        // that window must fail closed rather than expose watch state.
+        assertFalse(registry.isAuthorized("com.example.companion"))
+        assertFalse(registry.isAuthorizedFor("com.example.companion", watchappUuid.toString()))
+    }
+
+    @Test
+    fun `authorizes a declared companion of an installed watchapp`() = runTest {
+        writePbw("app.pbw", watchappUuid, "com.example.companion")
+        val registry = startRegistry(MutableStateFlow(listOf(watchappUuid)))
+        runCurrent()
+
+        assertTrue(registry.isAuthorized("com.example.companion"))
+        assertTrue(registry.isAuthorizedFor("com.example.companion", watchappUuid.toString()))
+        assertFalse(registry.isAuthorized("com.example.uninvolved"))
+        assertFalse(registry.isAuthorizedFor("com.example.companion", otherUuid.toString()))
+    }
+
+    @Test
+    fun `accepts a mixed-case uuid from the caller`() = runTest {
+        writePbw("app.pbw", watchappUuid, "com.example.companion")
+        val registry = startRegistry(MutableStateFlow(listOf(watchappUuid)))
+        runCurrent()
+
+        val uppercase = watchappUuid.toString().uppercase()
+        assertTrue(registry.isAuthorizedFor("com.example.companion", uppercase))
+    }
+
+    @Test
+    fun `denies a null caller and a null watchapp`() = runTest {
+        writePbw("app.pbw", watchappUuid, "com.example.companion")
+        val registry = startRegistry(MutableStateFlow(listOf(watchappUuid)))
+        runCurrent()
+
+        assertFalse(registry.isAuthorized(null))
+        assertFalse(registry.isAuthorizedFor(null, watchappUuid.toString()))
+        assertFalse(registry.isAuthorizedFor("com.example.companion", null))
+    }
+
+    @Test
+    fun `merges packages across cached versions of one watchapp`() = runTest {
+        writePbw("app_1.0.pbw", watchappUuid, "com.example.old")
+        writePbw("app_1.1.pbw", watchappUuid, "com.example.new")
+        val registry = startRegistry(MutableStateFlow(listOf(watchappUuid)))
+        runCurrent()
+
+        assertTrue(registry.isAuthorizedFor("com.example.old", watchappUuid.toString()))
+        assertTrue(registry.isAuthorizedFor("com.example.new", watchappUuid.toString()))
+    }
+
+    @Test
+    fun `skips a corrupt pbw without revoking other companions`() = runTest {
+        File(temp.root, "corrupt.pbw").writeBytes(byteArrayOf(0x50, 0x4B, 0x00, 0x01))
+        writePbw("app.pbw", watchappUuid, "com.example.companion")
+        val registry = startRegistry(MutableStateFlow(listOf(watchappUuid)))
+        runCurrent()
+
+        assertTrue(registry.isAuthorized("com.example.companion"))
+    }
+
+    @Test
+    fun `contributes nothing for a watchapp with no companion declaration`() = runTest {
+        writePbw("app.pbw", watchappUuid)
+        val registry = startRegistry(MutableStateFlow(listOf(watchappUuid)))
+        runCurrent()
+
+        assertFalse(registry.isAuthorizedFor("com.example.companion", watchappUuid.toString()))
+    }
+
+    @Test
+    fun `a cached pbw grants nothing when its watchapp is not in the locker`() = runTest {
+        writePbw("app.pbw", watchappUuid, "com.example.companion")
+        val registry = startRegistry(MutableStateFlow(emptyList()))
+        runCurrent()
+
+        assertFalse(registry.isAuthorized("com.example.companion"))
+    }
+
+    @Test
+    fun `revokes when the watchapp leaves the locker even if its file remains`() = runTest {
+        // A web-sync removal marks the locker row deleted without deleting the cached file, so
+        // revocation must come from locker membership, not from the file disappearing.
+        writePbw("app.pbw", watchappUuid, "com.example.companion")
+        val uuids = MutableStateFlow(listOf(watchappUuid))
+        val registry = startRegistry(uuids)
+        runCurrent()
+        assertTrue(registry.isAuthorized("com.example.companion"))
+
+        uuids.value = emptyList()
+        runCurrent()
+
+        assertFalse(registry.isAuthorized("com.example.companion"))
+    }
+
+    @Test
+    fun `rescans when a pbw lands in the cache after its locker row`() = runTest {
+        // The store-install order: the locker row is inserted first and the PBW is downloaded
+        // later as a file-only write, so the scan triggered by the row insert finds nothing.
+        val uuids = MutableStateFlow(listOf(watchappUuid))
+        val changes = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+        val registry = startRegistry(uuids, changes)
+        runCurrent()
+        assertFalse(registry.isAuthorized("com.example.companion"))
+
+        writePbw("app.pbw", watchappUuid, "com.example.companion")
+        changes.tryEmit(Unit)
+        runCurrent()
+
+        assertTrue(registry.isAuthorized("com.example.companion"))
+    }
+
+    private fun TestScope.startRegistry(
+        uuids: Flow<List<Uuid>>,
+        changes: Flow<Unit> = MutableSharedFlow(),
+    ): PebbleKitCompanionRegistry {
+        val registry = PebbleKitCompanionRegistry(
+            lockerUuids = uuids,
+            cachedPbws = ::cachedPbws,
+            pbwFilesChanged = changes,
+            scope = backgroundScope,
+            ioDispatcher = StandardTestDispatcher(testScheduler),
+        )
+        registry.init()
+        return registry
+    }
+
+    private fun cachedPbws(): List<Path> = temp.root.listFiles().orEmpty()
+        .filter { it.name.endsWith(".pbw") }
+        .map { Path(it.absolutePath) }
+
+    /** A minimal but genuinely parseable PBW: a zip holding only appinfo.json. */
+    private fun writePbw(name: String, uuid: Uuid, vararg packages: String) {
+        val companion = if (packages.isEmpty()) "" else {
+            val apps = packages.joinToString(",") { """{"package":"$it"}""" }
+            ""","companionApp":{"android":{"apps":[$apps]}}"""
+        }
+        val json =
+            """{"uuid":"$uuid","shortName":"test","versionLabel":"1.0","resources":{"media":[]}$companion}"""
+        ZipOutputStream(FileOutputStream(File(temp.root, name))).use { zip ->
+            zip.putNextEntry(ZipEntry("appinfo.json"))
+            zip.write(json.encodeToByteArray())
+            zip.closeEntry()
+        }
+    }
+}

--- a/libpebble3/src/androidUnitTest/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitRequestProtocolTest.kt
+++ b/libpebble3/src/androidUnitTest/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitRequestProtocolTest.kt
@@ -1,6 +1,7 @@
 package io.rebble.libpebblecommon.pebblekit.two
 
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -13,15 +14,18 @@ import kotlin.test.assertTrue
  * The failure mode matters: the interception would stop recognising start and stop requests and
  * would wave them through unauthorized, silently, while everything still built and ran.
  *
- * This inspects the library's own compiled dispatch class for the literals it encodes. That
- * proves the strings still exist there, not that they still mean the same thing, so treat a
- * failure as "read the library's dispatch code again" rather than "adjust the constant".
+ * This inspects the library's own compiled dispatch class for the constant-pool entries it
+ * encodes. Entries are matched exactly (tag, length prefix, bytes), not as substrings, so a
+ * rename that extends a key (ACTION to REQUEST_ACTION, say) fails the pin instead of slipping
+ * past on the embedded old literal. That proves the strings still exist there, not that they
+ * still mean the same thing, so treat a failure as "read the library's dispatch code again"
+ * rather than "adjust the constant".
  */
 class PebbleKitRequestProtocolTest {
 
     @Test
     fun `library dispatch still encodes the request keys we depend on`() {
-        val constantPool = binderClassBytes()
+        val classBytes = binderClassBytes()
 
         listOf(
             "ACTION",
@@ -32,30 +36,62 @@ class PebbleKitRequestProtocolTest {
             "STOP_APP",
         ).forEach { literal ->
             assertTrue(
-                constantPool.contains(literal),
-                "PebbleKit request protocol changed: '$literal' is no longer present in " +
-                    "$BINDER_CLASS. The start/stop authorization in PebbleSenderReceiver keys " +
-                    "off these literals and is inert until they are corrected.",
+                classBytes.containsUtf8Entry(literal),
+                "PebbleKit request protocol changed: '$literal' is no longer a constant-pool " +
+                    "entry of $BINDER_CLASS. The start/stop authorization in " +
+                    "PebbleSenderReceiver keys off these literals and is inert until they are " +
+                    "corrected.",
             )
         }
     }
 
     @Test
     fun `the pin can actually fail`() {
-        // Without this, a broken resource load or a botched decode would make every assertion
+        // Without this, a broken resource load or a botched search would make every assertion
         // above pass vacuously, and the tripwire would look green while guarding nothing.
-        assertTrue(
-            !binderClassBytes().contains("NOT_A_PEBBLEKIT_PROTOCOL_KEY"),
+        assertFalse(
+            binderClassBytes().containsUtf8Entry("NOT_A_PEBBLEKIT_PROTOCOL_KEY"),
             "control string was found, so the constant-pool search is not discriminating",
         )
     }
 
-    private fun binderClassBytes(): String {
+    @Test
+    fun `the pin distinguishes an entry from its substrings`() {
+        // "ACTIO" occurs inside the ACTION entry's bytes; only the length prefix tells them
+        // apart. If this matches, the exact-entry search has regressed to substring matching,
+        // which is blind to exactly the extension renames the pin exists to catch.
+        assertFalse(
+            binderClassBytes().containsUtf8Entry("ACTIO"),
+            "a strict substring of a real key matched, so entry lengths are not being checked",
+        )
+    }
+
+    private fun binderClassBytes(): ByteArray {
         val stream = javaClass.classLoader?.getResourceAsStream(BINDER_CLASS)
         assertNotNull(stream, "could not load $BINDER_CLASS from the test classpath")
-        // Latin-1 keeps every byte a distinct character, so constant-pool UTF-8 entries survive
-        // the decode intact and can be searched as plain substrings.
-        return stream.use { it.readBytes().toString(Charsets.ISO_8859_1) }
+        return stream.use { it.readBytes() }
+    }
+
+    /**
+     * Whether the class bytes contain a CONSTANT_Utf8 constant-pool entry that is exactly
+     * [literal]: tag byte 1, two-byte big-endian length equal to the literal's length, then the
+     * literal's bytes. The length check is what rejects superstring entries.
+     */
+    private fun ByteArray.containsUtf8Entry(literal: String): Boolean {
+        val bytes = literal.encodeToByteArray()
+        val target = ByteArray(3 + bytes.size)
+        target[0] = 1
+        target[1] = (bytes.size ushr 8).toByte()
+        target[2] = bytes.size.toByte()
+        bytes.copyInto(target, 3)
+
+        outer@ for (start in 0..(size - target.size)) {
+            for (offset in target.indices) {
+                if (this[start + offset] != target[offset]) continue@outer
+            }
+            return true
+        }
+        return false
     }
 
     private companion object {

--- a/libpebble3/src/androidUnitTest/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitRequestProtocolTest.kt
+++ b/libpebble3/src/androidUnitTest/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitRequestProtocolTest.kt
@@ -1,0 +1,65 @@
+package io.rebble.libpebblecommon.pebblekit.two
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Pins the PebbleKit server library's request protocol.
+ *
+ * [PebbleSenderReceiver] authorizes start and stop requests, and translates watch identifiers, by
+ * reading keys out of the request Bundle. Those keys are internal to the library and are not
+ * exposed as public API, so nothing at compile time notices if a library upgrade renames them.
+ * The failure mode matters: the interception would stop recognising start and stop requests and
+ * would wave them through unauthorized, silently, while everything still built and ran.
+ *
+ * This inspects the library's own compiled dispatch class for the literals it encodes. That
+ * proves the strings still exist there, not that they still mean the same thing, so treat a
+ * failure as "read the library's dispatch code again" rather than "adjust the constant".
+ */
+class PebbleKitRequestProtocolTest {
+
+    @Test
+    fun `library dispatch still encodes the request keys we depend on`() {
+        val constantPool = binderClassBytes()
+
+        listOf(
+            "ACTION",
+            "WATCHAPP_UUID",
+            "WATCHES_ID",
+            "TRANSMISSION_RESULTS",
+            "START_APP",
+            "STOP_APP",
+        ).forEach { literal ->
+            assertTrue(
+                constantPool.contains(literal),
+                "PebbleKit request protocol changed: '$literal' is no longer present in " +
+                    "$BINDER_CLASS. The start/stop authorization in PebbleSenderReceiver keys " +
+                    "off these literals and is inert until they are corrected.",
+            )
+        }
+    }
+
+    @Test
+    fun `the pin can actually fail`() {
+        // Without this, a broken resource load or a botched decode would make every assertion
+        // above pass vacuously, and the tripwire would look green while guarding nothing.
+        assertTrue(
+            !binderClassBytes().contains("NOT_A_PEBBLEKIT_PROTOCOL_KEY"),
+            "control string was found, so the constant-pool search is not discriminating",
+        )
+    }
+
+    private fun binderClassBytes(): String {
+        val stream = javaClass.classLoader?.getResourceAsStream(BINDER_CLASS)
+        assertNotNull(stream, "could not load $BINDER_CLASS from the test classpath")
+        // Latin-1 keeps every byte a distinct character, so constant-pool UTF-8 entries survive
+        // the decode intact and can be searched as plain substrings.
+        return stream.use { it.readBytes().toString(Charsets.ISO_8859_1) }
+    }
+
+    private companion object {
+        const val BINDER_CLASS =
+            "io/rebble/pebblekit2/server/BasePebbleSenderReceiver\$Binder.class"
+    }
+}

--- a/libpebble3/src/androidUnitTest/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitWatchNameTest.kt
+++ b/libpebble3/src/androidUnitTest/kotlin/io/rebble/libpebblecommon/pebblekit/two/PebbleKitWatchNameTest.kt
@@ -1,0 +1,38 @@
+package io.rebble.libpebblecommon.pebblekit.two
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The NAME column is served to every authorized companion, so it must carry nothing more
+ * specific than the watch model: the advertised name's device-unique suffix (or a user
+ * nickname) is identical for every caller and would hand two companions the shared correlator
+ * the per-caller pseudonymous identifiers exist to remove.
+ */
+class PebbleKitWatchNameTest {
+
+    @Test
+    fun `strips the device-unique suffix from advertised names`() {
+        assertEquals("Pebble", pebbleKitWatchName("Pebble 4F2A"))
+        assertEquals("Pebble Time", pebbleKitWatchName("Pebble Time 807A"))
+        assertEquals("Pebble Time Le", pebbleKitWatchName("Pebble Time Le 12ab"))
+    }
+
+    @Test
+    fun `strips the suffix from unrecognised model prefixes too`() {
+        // A future device following the same suffix convention gets the same treatment.
+        assertEquals("Core Time 2", pebbleKitWatchName("Core Time 2 B3C4"))
+    }
+
+    @Test
+    fun `keeps model names that end in a short numeral`() {
+        // "2" is a hex digit, but the device suffix is always four; the model name survives.
+        assertEquals("Pebble 2", pebbleKitWatchName("Pebble 2"))
+        assertEquals("Core Time 2", pebbleKitWatchName("Core Time 2"))
+    }
+
+    @Test
+    fun `keeps names with a non-hex final word`() {
+        assertEquals("Pebble Steel", pebbleKitWatchName("Pebble Steel"))
+    }
+}

--- a/libpebble3/src/androidUnitTest/kotlin/io/rebble/libpebblecommon/pebblekit/two/PseudonymiseTransmissionKeysTest.kt
+++ b/libpebble3/src/androidUnitTest/kotlin/io/rebble/libpebblecommon/pebblekit/two/PseudonymiseTransmissionKeysTest.kt
@@ -1,0 +1,65 @@
+package io.rebble.libpebblecommon.pebblekit.two
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins the outbound half of the identifier translation in [PebbleSenderReceiver]: results keyed
+ * by real serial must reach the caller keyed by what it is allowed to see. The drop case is the
+ * security-relevant branch: when no pseudonym can be derived, the row disappears rather than
+ * falling back to the serial, so an identity-layer failure cannot disclose the identifier the
+ * whole scheme exists to hide.
+ */
+class PseudonymiseTransmissionKeysTest {
+
+    @Test
+    fun `echoes an identifier the caller supplied`() {
+        // The caller addressed the watch by pseudonym (or legacy serial); echoing exactly what
+        // it sent is what lets it correlate the result with its request.
+        val mapped = pseudonymiseTransmissionKeys(
+            serials = listOf("SERIAL-1"),
+            suppliedBySerial = mapOf("SERIAL-1" to "supplied-id"),
+            pseudonymFor = { "derived-id" },
+        )
+
+        assertEquals(mapOf("SERIAL-1" to "supplied-id"), mapped)
+    }
+
+    @Test
+    fun `pseudonymises a key the base class generated`() {
+        // The "all connected watches" case: the caller supplied nothing, so the serials came
+        // from the base class and must be replaced before they leave the process.
+        val mapped = pseudonymiseTransmissionKeys(
+            serials = listOf("SERIAL-1"),
+            suppliedBySerial = emptyMap(),
+            pseudonymFor = { serial -> "pseudonym-of-$serial" },
+        )
+
+        assertEquals(mapOf("SERIAL-1" to "pseudonym-of-SERIAL-1"), mapped)
+    }
+
+    @Test
+    fun `drops a serial with no derivable pseudonym`() {
+        val mapped = pseudonymiseTransmissionKeys(
+            serials = listOf("SERIAL-1"),
+            suppliedBySerial = emptyMap(),
+            pseudonymFor = { null },
+        )
+
+        assertEquals(emptyMap(), mapped)
+    }
+
+    @Test
+    fun `handles the mixed case independently per serial`() {
+        val mapped = pseudonymiseTransmissionKeys(
+            serials = listOf("SUPPLIED", "GENERATED", "UNDERIVABLE"),
+            suppliedBySerial = mapOf("SUPPLIED" to "as-sent"),
+            pseudonymFor = { serial -> "pseudonym-of-$serial".takeIf { serial == "GENERATED" } },
+        )
+
+        assertEquals(
+            mapOf("SUPPLIED" to "as-sent", "GENERATED" to "pseudonym-of-GENERATED"),
+            mapped,
+        )
+    }
+}

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/locker/Locker.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/locker/Locker.kt
@@ -635,6 +635,19 @@ abstract class LockerPBWCache(private val context: AppContext) {
         return Path(cacheDir, "${appId}_${version}.pbw")
     }
 
+    /**
+     * PBWs already on disk. Unlike [getPBWFileForApp] this never falls through to
+     * [handleCacheMiss], so it is safe to call from a binder/IPC entry point where an
+     * untrusted caller must not be able to induce a network fetch.
+     */
+    fun cachedPbwPaths(): List<Path> {
+        if (!SystemFileSystem.exists(cacheDir)) return emptyList()
+        return SystemFileSystem.list(cacheDir).filter { path ->
+            path.name.endsWith(".pbw") &&
+                SystemFileSystem.metadataOrNull(path)?.isRegularFile == true
+        }
+    }
+
     protected fun pkjsPathForApp(appId: Uuid): Path {
         SystemFileSystem.createDirectories(pkjsCacheDir, false)
         return Path(pkjsCacheDir, "$appId.js")

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/locker/Locker.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/locker/Locker.kt
@@ -35,7 +35,9 @@ import io.rebble.libpebblecommon.web.WebSyncManager
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -554,6 +556,17 @@ abstract class LockerPBWCache(private val context: AppContext) {
     private val cacheDir = getLockerPBWCacheDirectory(context)
     private val pkjsCacheDir = Path(cacheDir, "pkjs")
 
+    // A store install writes its locker row first and the PBW arrives later as a file-only
+    // write, which no database flow ever surfaces, so consumers of the cached PBWs (the
+    // PebbleKit companion registry) need this signal to know the set of files changed.
+    private val _pbwFilesChanged = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    /** Emits after a PBW file is added to or removed from the cache. */
+    val pbwFilesChanged: Flow<Unit> = _pbwFilesChanged
+
     fun init() {
         migrateFromLegacyIfNeeded(context)
     }
@@ -662,7 +675,10 @@ abstract class LockerPBWCache(private val context: AppContext) {
         } else {
             // Delete any other cached versions for this app
             deleteApp(appId)
-            handleCacheMiss(appId, version, locker) ?: error("Failed to find PBW file for app $appId")
+            val fetched = handleCacheMiss(appId, version, locker)
+                ?: error("Failed to find PBW file for app $appId")
+            _pbwFilesChanged.tryEmit(Unit)
+            fetched
         }
     }
 
@@ -671,6 +687,7 @@ abstract class LockerPBWCache(private val context: AppContext) {
         SystemFileSystem.sink(targetPath).use { sink ->
             source.transferTo(sink)
         }
+        _pbwFilesChanged.tryEmit(Unit)
     }
 
     private fun sanitizeJS(js: String): String {
@@ -716,6 +733,7 @@ abstract class LockerPBWCache(private val context: AppContext) {
                 }
             }
         }
+        _pbwFilesChanged.tryEmit(Unit)
     }
 }
 

--- a/pebble/build.gradle.kts
+++ b/pebble/build.gradle.kts
@@ -151,7 +151,6 @@ kotlin {
                 // Add Android-specific dependencies here. Note that this source set depends on
                 // commonMain by default and will correctly pull the Android artifacts of any KMP
                 // dependencies declared in commonMain.
-                implementation(compose.uiTooling)
             }
         }
 
@@ -166,6 +165,13 @@ kotlin {
         }
     }
 
+}
+
+dependencies {
+    // Debug-only: compose.uiTooling contributes an exported
+    // androidx.compose.ui.tooling.PreviewActivity to the merged manifest, which must not
+    // reach a release APK. Declaring it in androidMain put it in every variant.
+    debugImplementation(compose.uiTooling)
 }
 
 compose.resources {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/account/PebbleAccount.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/account/PebbleAccount.kt
@@ -35,8 +35,14 @@ class RealPebbleAccount(
     // the app encrypts anything at rest, so it would otherwise sit in plaintext SharedPreferences
     // and travel in every backup and device transfer.
     private val tokenSetting = EncryptedStringSetting(settings, secretCipher, TOKEN_KEY)
-    private val _loggedIn = MutableStateFlow(getToken())
-    override val loggedIn = _loggedIn.asStateFlow()
+
+    // Lazy because getToken() now performs Keystore IPC (decrypting the token), and this class
+    // is constructed on the main thread during DI graph init in Application.onCreate; eager
+    // seeding would block startup on the keystore daemon. Laziness moves that one-time cost to
+    // the first consumer that actually reads the flow, while keeping the value synchronously
+    // available from then on, so no consumer ever observes a transient signed-out state.
+    private val _loggedIn by lazy { MutableStateFlow(getToken()) }
+    override val loggedIn: StateFlow<String?> by lazy { _loggedIn.asStateFlow() }
     private val _devToken = MutableStateFlow(getDevPortalId())
     override val devToken = _devToken.asStateFlow()
 

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/account/PebbleAccount.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/account/PebbleAccount.kt
@@ -4,6 +4,8 @@ import co.touchlab.kermit.Logger
 import com.russhwolf.settings.Settings
 import coredevices.firestore.UsersDao
 import coredevices.pebble.services.PebbleWebServices
+import coredevices.util.security.EncryptedStringSetting
+import coredevices.util.security.SecretCipher
 import io.rebble.libpebblecommon.connection.TokenProvider
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -25,8 +27,14 @@ class RealPebbleAccount(
     private val pebbleWebServices: PebbleWebServices,
     private val bootConfigProvider: BootConfigProvider,
     private val usersDao: UsersDao,
+    secretCipher: SecretCipher,
 ) : PebbleAccount {
     private val logger = Logger.withTag("PebbleAccount")
+
+    // The account bearer token is the highest-value secret the app persists, and nothing else in
+    // the app encrypts anything at rest, so it would otherwise sit in plaintext SharedPreferences
+    // and travel in every backup and device transfer.
+    private val tokenSetting = EncryptedStringSetting(settings, secretCipher, TOKEN_KEY)
     private val _loggedIn = MutableStateFlow(getToken())
     override val loggedIn = _loggedIn.asStateFlow()
     private val _devToken = MutableStateFlow(getDevPortalId())
@@ -34,11 +42,7 @@ class RealPebbleAccount(
 
     override suspend fun setToken(token: String?, bootUrl: String?) {
         logger.d("setToken")
-        if (token != null) {
-            settings.putString(TOKEN_KEY, token)
-        } else {
-            settings.remove(TOKEN_KEY)
-        }
+        tokenSetting.set(token)
         _loggedIn.value = token
         bootConfigProvider.setUrl(bootUrl)
         setDevPortalId()
@@ -55,7 +59,7 @@ class RealPebbleAccount(
         _devToken.value = devPortalId
     }
 
-    private fun getToken(): String? = settings.getStringOrNull(TOKEN_KEY)
+    private fun getToken(): String? = tokenSetting.get()
     private fun getDevPortalId(): String? = settings.getStringOrNull(DEV_KEY)
 
     companion object {

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/account/RealPebbleAccountTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/account/RealPebbleAccountTest.kt
@@ -1,0 +1,127 @@
+package coredevices.pebble.account
+
+import com.russhwolf.settings.MapSettings
+import coredevices.database.AppstoreSource
+import coredevices.firestore.PebbleUser
+import coredevices.firestore.UsersDao
+import coredevices.pebble.services.AppStoreHomeResult
+import coredevices.pebble.services.CoreUsersMe
+import coredevices.pebble.services.PebbleWebServices
+import coredevices.pebble.services.StoreSearchResult
+import coredevices.pebble.ui.CommonAppType
+import coredevices.pebble.weather.WeatherResponse
+import coredevices.util.WeatherUnit
+import coredevices.util.security.DecryptResult
+import coredevices.util.security.SecretCipher
+import io.rebble.libpebblecommon.locker.AppType
+import io.rebble.libpebblecommon.metadata.WatchType
+import io.rebble.libpebblecommon.web.LockerAddResponse
+import io.rebble.libpebblecommon.web.LockerModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+/**
+ * Pins that constructing the account performs no cryptography. The class is built on the main
+ * thread during DI graph init in Application.onCreate, and the stored token is encrypted, so an
+ * eager read would block startup on Keystore IPC; the read must happen on first use instead,
+ * while staying synchronously available so no consumer sees a transient signed-out state.
+ */
+class RealPebbleAccountTest {
+
+    @Test
+    fun `construction does not decrypt the stored token`() {
+        val cipher = CountingCipher()
+        val settings = MapSettings().apply { putString("account_token_key", "enc1:nekot") }
+
+        buildAccount(settings, cipher)
+
+        assertEquals(0, cipher.decrypts, "construction must not perform Keystore work")
+    }
+
+    @Test
+    fun `the token is synchronously available on first read and cached after`() {
+        val cipher = CountingCipher()
+        val settings = MapSettings().apply { putString("account_token_key", "enc1:nekot") }
+        val account = buildAccount(settings, cipher)
+
+        assertEquals("token", account.loggedIn.value)
+        assertEquals("token", account.loggedIn.value)
+        assertEquals(1, cipher.decrypts, "the stored token is decrypted once, not per read")
+    }
+
+    private fun buildAccount(settings: MapSettings, cipher: SecretCipher) = RealPebbleAccount(
+        settings = settings,
+        pebbleWebServices = FakeWebServices,
+        bootConfigProvider = FakeBootConfig,
+        usersDao = FakeUsersDao,
+        secretCipher = cipher,
+    )
+
+    /** Reverses strings, like the storage-wrapper tests' fake, and counts decrypts. */
+    private class CountingCipher : SecretCipher {
+        var decrypts = 0
+
+        override fun encrypt(plaintext: String): String = plaintext.reversed()
+
+        override fun decrypt(stored: String): DecryptResult {
+            decrypts++
+            return DecryptResult.Success(stored.reversed())
+        }
+    }
+
+    private object FakeBootConfig : BootConfigProvider {
+        override suspend fun setUrl(url: String?) {}
+        override fun getUrl(): String? = null
+        override suspend fun getBootConfig(): BootConfig? = null
+    }
+
+    private object FakeUsersDao : UsersDao {
+        override val user: Flow<PebbleUser?> = flow { emit(null) }
+        override val loginEvents: Flow<PebbleUser> = flow {}
+        override suspend fun updateTodoBlockId(todoBlockId: String) {}
+        override suspend fun initUserDevToken(rebbleUserToken: String?) {}
+        override suspend fun updateLastConnectedWatch(serial: String) {}
+        override suspend fun updateRingLifetimeCollectionCount(serial: String, count: Int) {}
+        override fun init() {}
+    }
+
+    private object FakeWebServices : PebbleWebServices {
+        override suspend fun fetchUsersMePebble(): UsersMeResponse? = null
+        override suspend fun fetchUsersMeCore(): CoreUsersMe? = null
+        override suspend fun fetchPebbleLocker(): LockerModel? = null
+        override suspend fun addToLegacyLocker(uuid: String): Boolean = false
+        override suspend fun fetchAppStoreHome(
+            type: AppType,
+            hardwarePlatform: WatchType?,
+            enabledOnly: Boolean,
+            useCache: Boolean,
+        ): List<AppStoreHomeResult> = emptyList()
+
+        override suspend fun fetchPebbleAppStoreHomes(
+            hardwarePlatform: WatchType?,
+            useCache: Boolean,
+        ): Map<AppType, AppStoreHomeResult?> = emptyMap()
+
+        override suspend fun searchAppStore(
+            search: String,
+            appType: AppType,
+            watchType: WatchType,
+            page: Int,
+            pageSize: Int,
+        ): List<Pair<AppstoreSource, StoreSearchResult>> = emptyList()
+
+        override suspend fun addToLegacyLockerWithResponse(uuid: String): LockerAddResponse? = null
+        override suspend fun addToLocker(entry: CommonAppType.Store, timelineToken: String?): Boolean = false
+        override suspend fun removeFromLegacyLocker(id: Uuid): Boolean = false
+        override suspend fun fetchUserHearts() {}
+        override suspend fun getWeather(
+            latitude: Double,
+            longitude: Double,
+            units: WeatherUnit,
+            language: String,
+        ): WeatherResponse? = null
+    }
+}

--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -156,6 +156,9 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(libs.kotlin.test)
+                // MapSettings, so the encrypted-setting storage contract can be tested without
+                // a device. Same artifact family and version as the Settings dep already used.
+                implementation(libs.settings.test)
             }
         }
 

--- a/util/build.gradle.kts
+++ b/util/build.gradle.kts
@@ -163,7 +163,6 @@ kotlin {
             dependencies {
                 implementation(libs.androidx.activity.compose)
                 implementation(libs.ktor.client.okhttp)
-                implementation(compose.uiTooling)
             }
         }
 
@@ -180,6 +179,11 @@ dependencies {
     add("kspAndroid", libs.room.compiler)
     add("kspIosArm64", libs.room.compiler)
     add("kspIosSimulatorArm64", libs.room.compiler)
+
+    // Debug-only: compose.uiTooling contributes an exported
+    // androidx.compose.ui.tooling.PreviewActivity to the merged manifest, which must not
+    // reach a release APK. Declaring it in androidMain put it in every variant.
+    debugImplementation(compose.uiTooling)
 }
 
 val headSha by lazy {

--- a/util/src/androidMain/kotlin/coredevices/util/security/KeystoreSecretCipher.kt
+++ b/util/src/androidMain/kotlin/coredevices/util/security/KeystoreSecretCipher.kt
@@ -5,6 +5,7 @@ import android.security.keystore.KeyProperties
 import android.util.Base64
 import co.touchlab.kermit.Logger
 import java.security.KeyStore
+import javax.crypto.AEADBadTagException
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
@@ -16,6 +17,10 @@ import javax.crypto.spec.GCMParameterSpec
  * Uses the platform Keystore and javax.crypto directly rather than
  * androidx.security:security-crypto, whose entire API surface was deprecated in favour of
  * exactly this.
+ *
+ * The Keystore access pattern here (keystore init, key lock, get-or-generate under its own
+ * alias) has a structural twin in libpebble3's PebbleKitWatchIdentity, which cannot depend on
+ * this module. A fix to the Keystore handling in either file almost certainly applies to both.
  */
 class KeystoreSecretCipher : SecretCipher {
 
@@ -31,7 +36,7 @@ class KeystoreSecretCipher : SecretCipher {
     }
 
     private fun getOrCreateKey(): SecretKey = synchronized(keyLock) {
-        (keyStore.getEntry(KEY_ALIAS, null) as? KeyStore.SecretKeyEntry)?.secretKey
+        existingKey()
             ?: KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE).run {
                 init(
                     KeyGenParameterSpec.Builder(
@@ -61,19 +66,50 @@ class KeystoreSecretCipher : SecretCipher {
         Base64.encodeToString(combined, Base64.NO_WRAP)
     }.onFailure { logger.e(it) { "Encryption failed" } }.getOrNull()
 
-    override fun decrypt(stored: String): String? = runCatching {
+    override fun decrypt(stored: String): DecryptResult {
         // Never create a key here: on a device that has never encrypted anything, or after the
         // key was cleared, generating a fresh one would turn "cannot decrypt" into a confusing
-        // authentication failure further down.
-        val key = existingKey() ?: return null
-        val combined = Base64.decode(stored, Base64.NO_WRAP)
-        val ivSize = combined[0].toInt() and 0xFF
-        val iv = combined.copyOfRange(1, 1 + ivSize)
-        val ciphertext = combined.copyOfRange(1 + ivSize, combined.size)
-        val cipher = Cipher.getInstance(TRANSFORMATION)
-        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
-        cipher.doFinal(ciphertext).decodeToString()
-    }.onFailure { logger.w(it) { "Decryption failed" } }.getOrNull()
+        // authentication failure further down. The lookup itself failing is a different case
+        // from the key being absent: the keystore daemon can die or reject calls under load,
+        // and classifying that as unrecoverable would let a hiccup destroy the stored value.
+        val key = try {
+            existingKey() ?: return DecryptResult.Unrecoverable
+        } catch (e: Exception) {
+            logger.w(e) { "Keystore unavailable while looking up the key" }
+            return DecryptResult.TransientFailure
+        }
+
+        // Malformed input can only ever be malformed: no retry changes what the bytes are.
+        val combined = try {
+            Base64.decode(stored, Base64.NO_WRAP)
+        } catch (e: IllegalArgumentException) {
+            logger.w { "Stored value is not valid Base64" }
+            return DecryptResult.Unrecoverable
+        }
+
+        return try {
+            val ivSize = combined[0].toInt() and 0xFF
+            val iv = combined.copyOfRange(1, 1 + ivSize)
+            val ciphertext = combined.copyOfRange(1 + ivSize, combined.size)
+            val cipher = Cipher.getInstance(TRANSFORMATION)
+            cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+            DecryptResult.Success(cipher.doFinal(ciphertext).decodeToString())
+        } catch (e: AEADBadTagException) {
+            // Deterministic: this key did not write this ciphertext (restored from another
+            // device, or the value was tampered with). Retrying cannot change the outcome.
+            logger.w(e) { "Decryption failed authentication" }
+            DecryptResult.Unrecoverable
+        } catch (e: IndexOutOfBoundsException) {
+            logger.w { "Stored value has malformed framing" }
+            DecryptResult.Unrecoverable
+        } catch (e: Exception) {
+            // Everything else is presumed transient (keystore/provider errors). The cost of
+            // being wrong is one failed read per launch; the cost of the opposite mistake is
+            // deleting a recoverable secret.
+            logger.w(e) { "Decryption failed, treating as transient" }
+            DecryptResult.TransientFailure
+        }
+    }
 
     private companion object {
         val logger = Logger.withTag("KeystoreSecretCipher")

--- a/util/src/androidMain/kotlin/coredevices/util/security/KeystoreSecretCipher.kt
+++ b/util/src/androidMain/kotlin/coredevices/util/security/KeystoreSecretCipher.kt
@@ -1,0 +1,86 @@
+package coredevices.util.security
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import co.touchlab.kermit.Logger
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * [SecretCipher] backed by AES-256-GCM with the key held in the Android Keystore.
+ *
+ * Uses the platform Keystore and javax.crypto directly rather than
+ * androidx.security:security-crypto, whose entire API surface was deprecated in favour of
+ * exactly this.
+ */
+class KeystoreSecretCipher : SecretCipher {
+
+    private val keyStore: KeyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+
+    // Key creation is not atomic, and both the account token read at startup and a concurrent
+    // sign-in can reach it, which would otherwise race two keys into the same alias and leave
+    // whichever value was written first undecryptable.
+    private val keyLock = Any()
+
+    private fun existingKey(): SecretKey? = synchronized(keyLock) {
+        (keyStore.getEntry(KEY_ALIAS, null) as? KeyStore.SecretKeyEntry)?.secretKey
+    }
+
+    private fun getOrCreateKey(): SecretKey = synchronized(keyLock) {
+        (keyStore.getEntry(KEY_ALIAS, null) as? KeyStore.SecretKeyEntry)?.secretKey
+            ?: KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE).run {
+                init(
+                    KeyGenParameterSpec.Builder(
+                        KEY_ALIAS,
+                        KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+                    )
+                        .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                        .setKeySize(256)
+                        .build()
+                )
+                generateKey()
+            }
+    }
+
+    override fun encrypt(plaintext: String): String? = runCatching {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, getOrCreateKey())
+        // GCM is catastrophically broken by IV reuse, so take the one the provider generated per
+        // operation and carry it alongside the ciphertext instead of choosing one here.
+        val iv = cipher.iv
+        val ciphertext = cipher.doFinal(plaintext.encodeToByteArray())
+        val combined = ByteArray(1 + iv.size + ciphertext.size)
+        combined[0] = iv.size.toByte()
+        iv.copyInto(combined, 1)
+        ciphertext.copyInto(combined, 1 + iv.size)
+        Base64.encodeToString(combined, Base64.NO_WRAP)
+    }.onFailure { logger.e(it) { "Encryption failed" } }.getOrNull()
+
+    override fun decrypt(stored: String): String? = runCatching {
+        // Never create a key here: on a device that has never encrypted anything, or after the
+        // key was cleared, generating a fresh one would turn "cannot decrypt" into a confusing
+        // authentication failure further down.
+        val key = existingKey() ?: return null
+        val combined = Base64.decode(stored, Base64.NO_WRAP)
+        val ivSize = combined[0].toInt() and 0xFF
+        val iv = combined.copyOfRange(1, 1 + ivSize)
+        val ciphertext = combined.copyOfRange(1 + ivSize, combined.size)
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+        cipher.doFinal(ciphertext).decodeToString()
+    }.onFailure { logger.w(it) { "Decryption failed" } }.getOrNull()
+
+    private companion object {
+        val logger = Logger.withTag("KeystoreSecretCipher")
+
+        const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        const val KEY_ALIAS = "gravel_secret_v1"
+        const val TRANSFORMATION = "AES/GCM/NoPadding"
+        const val GCM_TAG_BITS = 128
+    }
+}

--- a/util/src/commonMain/kotlin/coredevices/util/security/EncryptedStringSetting.kt
+++ b/util/src/commonMain/kotlin/coredevices/util/security/EncryptedStringSetting.kt
@@ -33,14 +33,25 @@ class EncryptedStringSetting(
             return stored
         }
 
-        val plaintext = cipher.decrypt(stored.removePrefix(PREFIX))
-        if (plaintext == null) {
-            // Undecryptable almost always means this value arrived from another device via
-            // backup or transfer. Drop it so it does not sit at rest forever being retried.
-            logger.w { "Discarding undecryptable '$key'" }
-            settings.remove(key)
+        return when (val result = cipher.decrypt(stored.removePrefix(PREFIX))) {
+            is DecryptResult.Success -> result.plaintext
+
+            DecryptResult.Unrecoverable -> {
+                // Undecryptable almost always means this value arrived from another device via
+                // backup or transfer. Drop it so it does not sit at rest forever being retried.
+                logger.w { "Discarding undecryptable '$key'" }
+                settings.remove(key)
+                null
+            }
+
+            DecryptResult.TransientFailure -> {
+                // The ciphertext may be perfectly recoverable, so removing it here would turn
+                // a keystore hiccup into a permanently lost secret (a forced re-login, for the
+                // account token). Keep it and let a later read try again.
+                logger.w { "Temporarily failed to decrypt '$key'; keeping it" }
+                null
+            }
         }
-        return plaintext
     }
 
     fun set(value: String?) {

--- a/util/src/commonMain/kotlin/coredevices/util/security/EncryptedStringSetting.kt
+++ b/util/src/commonMain/kotlin/coredevices/util/security/EncryptedStringSetting.kt
@@ -1,0 +1,71 @@
+package coredevices.util.security
+
+import co.touchlab.kermit.Logger
+import com.russhwolf.settings.Settings
+
+private val logger = Logger.withTag("EncryptedStringSetting")
+
+/**
+ * A single string setting that is encrypted at rest via [SecretCipher].
+ *
+ * Values are tagged with [PREFIX] so a value written by an older build, before this class
+ * existed, is distinguishable from a ciphertext and can be upgraded in place on first read
+ * instead of silently logging the user out.
+ */
+class EncryptedStringSetting(
+    private val settings: Settings,
+    private val cipher: SecretCipher,
+    private val key: String,
+) {
+    fun get(): String? {
+        val stored = settings.getStringOrNull(key) ?: return null
+
+        if (!stored.startsWith(PREFIX)) {
+            // Written in the clear by a pre-encryption build. Re-write it encrypted now; if that
+            // fails, leave the plaintext alone rather than destroying a working session, since
+            // that is no worse than the state we just found.
+            val upgraded = cipher.encrypt(stored)
+            if (upgraded != null) {
+                settings.putString(key, PREFIX + upgraded)
+            } else {
+                logger.e { "Could not upgrade plaintext '$key' to encrypted storage" }
+            }
+            return stored
+        }
+
+        val plaintext = cipher.decrypt(stored.removePrefix(PREFIX))
+        if (plaintext == null) {
+            // Undecryptable almost always means this value arrived from another device via
+            // backup or transfer. Drop it so it does not sit at rest forever being retried.
+            logger.w { "Discarding undecryptable '$key'" }
+            settings.remove(key)
+        }
+        return plaintext
+    }
+
+    fun set(value: String?) {
+        if (value == null) {
+            settings.remove(key)
+            return
+        }
+
+        val encrypted = cipher.encrypt(value)
+        if (encrypted == null) {
+            // Falling back to plaintext would quietly reintroduce the exposure this class exists
+            // to close, so store nothing. The caller keeps the value in memory, so the current
+            // session still works and only persistence across restart is lost.
+            logger.e { "Could not encrypt '$key'; refusing to store it in the clear" }
+            settings.remove(key)
+            return
+        }
+        settings.putString(key, PREFIX + encrypted)
+    }
+
+    private companion object {
+        /**
+         * Marks a value as ciphertext. Includes a version so the encoding can change later
+         * without another round of "is this plaintext?" guesswork.
+         */
+        const val PREFIX = "enc1:"
+    }
+}

--- a/util/src/commonMain/kotlin/coredevices/util/security/SecretCipher.kt
+++ b/util/src/commonMain/kotlin/coredevices/util/security/SecretCipher.kt
@@ -14,14 +14,31 @@ package coredevices.util.security
  * with no user present, so the key is not authentication-bound. Claiming otherwise would be the
  * kind of control that looks protective without being so.
  *
- * Both methods return null rather than throwing. A secret that cannot be decrypted (wrong
- * device, key destroyed, corrupt value) is indistinguishable from having no secret, and callers
- * should treat it as absent and re-acquire it.
+ * Neither method throws. Decryption failures are classified rather than collapsed to one
+ * value because callers act on the difference: a value that can never be decrypted here
+ * (wrong device, key destroyed, corrupt value) is safe to discard, while a value the
+ * keystore merely failed to decrypt right now must be kept, since deleting it would turn a
+ * transient provider error into permanent loss of the secret.
  */
 interface SecretCipher {
     /** Returns an opaque encoded ciphertext, or null if the secret could not be encrypted. */
     fun encrypt(plaintext: String): String?
 
-    /** Returns the original plaintext, or null if [stored] could not be decrypted. */
-    fun decrypt(stored: String): String?
+    fun decrypt(stored: String): DecryptResult
+}
+
+sealed interface DecryptResult {
+    data class Success(val plaintext: String) : DecryptResult
+
+    /**
+     * [stored] can never be decrypted here: the key is absent, authentication failed (a
+     * ciphertext written under a different device's key), or the value is malformed.
+     */
+    data object Unrecoverable : DecryptResult
+
+    /**
+     * The keystore failed right now; the same value may decrypt fine on a later attempt, so
+     * the caller must not destroy it.
+     */
+    data object TransientFailure : DecryptResult
 }

--- a/util/src/commonMain/kotlin/coredevices/util/security/SecretCipher.kt
+++ b/util/src/commonMain/kotlin/coredevices/util/security/SecretCipher.kt
@@ -1,0 +1,27 @@
+package coredevices.util.security
+
+/**
+ * Encrypts short secrets so they are not written to app storage in the clear.
+ *
+ * What this defends against is off-device exposure: a copy of the app's data that has left the
+ * running device, such as an Auto Backup or device-transfer blob, a backup restored onto
+ * different hardware, or the private data directory read out of a pulled image. The key is
+ * device-bound and non-exportable, so none of those copies decrypt.
+ *
+ * What it deliberately does not defend against is code already running as this app on an
+ * unlocked device: that code can simply ask the cipher to decrypt. Binding the key to user
+ * authentication would raise that bar, but the app needs its account token in background sync
+ * with no user present, so the key is not authentication-bound. Claiming otherwise would be the
+ * kind of control that looks protective without being so.
+ *
+ * Both methods return null rather than throwing. A secret that cannot be decrypted (wrong
+ * device, key destroyed, corrupt value) is indistinguishable from having no secret, and callers
+ * should treat it as absent and re-acquire it.
+ */
+interface SecretCipher {
+    /** Returns an opaque encoded ciphertext, or null if the secret could not be encrypted. */
+    fun encrypt(plaintext: String): String?
+
+    /** Returns the original plaintext, or null if [stored] could not be decrypted. */
+    fun decrypt(stored: String): String?
+}

--- a/util/src/commonTest/kotlin/coredevices/util/security/EncryptedStringSettingTest.kt
+++ b/util/src/commonTest/kotlin/coredevices/util/security/EncryptedStringSettingTest.kt
@@ -4,6 +4,7 @@ import com.russhwolf.settings.MapSettings
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -12,13 +13,13 @@ private const val KEY = "account_token_key"
 /** Reversible stand-in for the Keystore so the storage contract can be tested off-device. */
 private class FakeCipher(
     var failEncrypt: Boolean = false,
-    var failDecrypt: Boolean = false,
+    var decryptFailure: DecryptResult? = null,
 ) : SecretCipher {
     override fun encrypt(plaintext: String): String? =
         if (failEncrypt) null else plaintext.reversed()
 
-    override fun decrypt(stored: String): String? =
-        if (failDecrypt) null else stored.reversed()
+    override fun decrypt(stored: String): DecryptResult =
+        decryptFailure ?: DecryptResult.Success(stored.reversed())
 }
 
 class EncryptedStringSettingTest {
@@ -81,15 +82,35 @@ class EncryptedStringSettingTest {
     }
 
     @Test
-    fun `discards a value it cannot decrypt`() {
+    fun `discards a value it can never decrypt`() {
         // Stands in for a ciphertext restored from a backup onto different hardware.
         val settings = MapSettings()
         EncryptedStringSetting(settings, FakeCipher(), KEY).set("secret-token")
 
-        val onNewDevice = EncryptedStringSetting(settings, FakeCipher(failDecrypt = true), KEY)
+        val onNewDevice = EncryptedStringSetting(
+            settings, FakeCipher(decryptFailure = DecryptResult.Unrecoverable), KEY,
+        )
 
         assertNull(onNewDevice.get())
         assertNull(settings.getStringOrNull(KEY), "undecryptable value was left at rest")
+    }
+
+    @Test
+    fun `keeps a value through a transient decryption failure`() {
+        // A keystore hiccup at startup must cost one read, not the stored secret: deleting
+        // here is what would turn a transient provider error into a forced re-login.
+        val settings = MapSettings()
+        val cipher = FakeCipher()
+        val setting = EncryptedStringSetting(settings, cipher, KEY)
+        setting.set("secret-token")
+
+        cipher.decryptFailure = DecryptResult.TransientFailure
+        assertNull(setting.get())
+        assertNotNull(settings.getStringOrNull(KEY), "recoverable value was destroyed")
+
+        // The next attempt (in production, the next launch) succeeds against the kept value.
+        cipher.decryptFailure = null
+        assertEquals("secret-token", setting.get())
     }
 
     @Test

--- a/util/src/commonTest/kotlin/coredevices/util/security/EncryptedStringSettingTest.kt
+++ b/util/src/commonTest/kotlin/coredevices/util/security/EncryptedStringSettingTest.kt
@@ -1,0 +1,106 @@
+package coredevices.util.security
+
+import com.russhwolf.settings.MapSettings
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val KEY = "account_token_key"
+
+/** Reversible stand-in for the Keystore so the storage contract can be tested off-device. */
+private class FakeCipher(
+    var failEncrypt: Boolean = false,
+    var failDecrypt: Boolean = false,
+) : SecretCipher {
+    override fun encrypt(plaintext: String): String? =
+        if (failEncrypt) null else plaintext.reversed()
+
+    override fun decrypt(stored: String): String? =
+        if (failDecrypt) null else stored.reversed()
+}
+
+class EncryptedStringSettingTest {
+
+    @Test
+    fun `round trips a value`() {
+        val settings = MapSettings()
+        val setting = EncryptedStringSetting(settings, FakeCipher(), KEY)
+
+        setting.set("secret-token")
+
+        assertEquals("secret-token", setting.get())
+    }
+
+    @Test
+    fun `does not store the plaintext`() {
+        val settings = MapSettings()
+        val setting = EncryptedStringSetting(settings, FakeCipher(), KEY)
+
+        setting.set("secret-token")
+
+        val raw = settings.getStringOrNull(KEY)
+        assertFalse(raw!!.contains("secret-token"), "raw stored value leaked the plaintext: $raw")
+        assertTrue(raw.startsWith("enc1:"))
+    }
+
+    @Test
+    fun `upgrades a legacy plaintext value in place`() {
+        // What an install written by a pre-encryption build looks like on disk.
+        val settings = MapSettings().apply { putString(KEY, "legacy-token") }
+        val setting = EncryptedStringSetting(settings, FakeCipher(), KEY)
+
+        // The user must stay signed in across the upgrade.
+        assertEquals("legacy-token", setting.get())
+
+        val raw = settings.getStringOrNull(KEY)
+        assertTrue(raw!!.startsWith("enc1:"), "legacy value was not upgraded: $raw")
+        assertFalse(raw.contains("legacy-token"))
+        assertEquals("legacy-token", setting.get())
+    }
+
+    @Test
+    fun `keeps a legacy value when encryption is unavailable`() {
+        val settings = MapSettings().apply { putString(KEY, "legacy-token") }
+        val setting = EncryptedStringSetting(settings, FakeCipher(failEncrypt = true), KEY)
+
+        // Losing the session would be worse than leaving it exactly as it already was.
+        assertEquals("legacy-token", setting.get())
+        assertEquals("legacy-token", settings.getStringOrNull(KEY))
+    }
+
+    @Test
+    fun `refuses to store plaintext when encryption fails`() {
+        val settings = MapSettings()
+        val setting = EncryptedStringSetting(settings, FakeCipher(failEncrypt = true), KEY)
+
+        setting.set("secret-token")
+
+        assertNull(settings.getStringOrNull(KEY))
+    }
+
+    @Test
+    fun `discards a value it cannot decrypt`() {
+        // Stands in for a ciphertext restored from a backup onto different hardware.
+        val settings = MapSettings()
+        EncryptedStringSetting(settings, FakeCipher(), KEY).set("secret-token")
+
+        val onNewDevice = EncryptedStringSetting(settings, FakeCipher(failDecrypt = true), KEY)
+
+        assertNull(onNewDevice.get())
+        assertNull(settings.getStringOrNull(KEY), "undecryptable value was left at rest")
+    }
+
+    @Test
+    fun `clears the stored value on null`() {
+        val settings = MapSettings()
+        val setting = EncryptedStringSetting(settings, FakeCipher(), KEY)
+        setting.set("secret-token")
+
+        setting.set(null)
+
+        assertNull(setting.get())
+        assertNull(settings.getStringOrNull(KEY))
+    }
+}


### PR DESCRIPTION
Any installed application could read a stable watch hardware identifier
through the exported PebbleKit 2 content provider and drive watchapp
start and stop; the account bearer token sat in plaintext
SharedPreferences and travelled in every backup; classic PebbleKit
broadcast watch data to every app on the device; and a Compose tooling
preview activity was exported in release builds by a library manifest.

PebbleKit 2 is now authorization-gated end to end. Every entry point
requires the caller to be a declared Android companion of an installed
watchapp, decided by a registry scanned from cached PBWs that rebuilds
on locker and cache changes and fails closed before its first scan.
Authorized callers see per-caller pseudonymous watch identifiers
(HMAC-SHA256 under a Keystore key) instead of the serial, and a
model-level watch name with the device-unique suffix stripped and the
user nickname never served. Unrecognised provider paths, rows whose
pseudonym cannot be derived, and failed dispatches all fail closed.

Classic PebbleKit delivery is narrowed to the watchapp's declared
companions where a declaration exists, and a message send is relayed
only when it addresses the session's own watchapp. The parts of the
classic surface that cannot be gated (broadcasts carry no sender
identity, and a normal-protection permission is granted to anything
that asks) are recorded in KNOWN_ISSUES.md with their bounds, as is the
classic provider's compatibility-driven open export.

The account token is encrypted at rest with AES-256-GCM under a
non-exportable Keystore key, plaintext values upgrade in place on first
read, keystore failures are classified so a transient daemon error
cannot destroy a recoverable token, and the decrypt runs on first use
rather than inside Application.onCreate. Backups are gated on
client-side encryption on every API level that can express the
condition and deliberately back up nothing on Android 8.x, which
cannot. Release builds fail on any exported component missing from a
pinned allowlist, checked on every packaging path (assemble, bundle,
install) with a task-graph assertion against the check silently
detaching.

Verification record:

- Tests: 40 unit tests and 29 instrumented tests added, covering the
  registry decision semantics (fail-closed first scan, locker
  membership, cache-write rescan, corrupt-PBW isolation), the identity
  primitives and identifier translation including the
  drop-rather-than-disclose branch, the cipher storage contract with
  transient-failure survival, the backup rule pins, protocol and
  companion-extraction tripwires, and on-device: querying the exported
  provider and driving the sender binder as a non-companion (both
  denied), classic session routing against a fake watch, and the real
  Keystore cipher suite including the decrypt-never-creates-a-key
  invariant.
- Release artifact: assembleRelease green with the exported-component
  check reporting 12 components, all allowlisted; the check confirmed
  scheduled in the task graphs of assembleRelease, bundleRelease, and
  installRelease; minified build runs on a Pixel running GrapheneOS
  with no fatals.
- The pre-merge review's 32 confirmed findings were resolved in the
  seven review-fix commits; the deliberately accepted residuals
  (classic broadcast injection and forgery, the ungated classic
  provider, model-level metadata columns, no backup on Android 8.x)
  are each recorded in KNOWN_ISSUES.md with rationale.
