### PR TITLE
Gate watchapp network and location behind deny-by-default per-app permissions

### DIFF
--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -55,6 +55,91 @@ either registers a device token with Google or does not exist, so
 rather than no-opped. That deletion is not precedent for other strips; the
 seam rule stands everywhere else.
 
+## Watchapp permissions (phone-side network and location)
+
+Third-party watchapps and watchfaces ship companion JavaScript (PebbleKit
+JS) that upstream runs on the phone inside a per-app `WebView`
+(`WebViewJsRunner`, one at a time, started when the watch launches that
+app). Through it the app's JS gets `navigator.geolocation` (bridged to real
+phone GPS) and unrestricted network (XHR/fetch/WebSocket go straight out
+Chromium's stack; the phone-side weather interceptors also egress on the
+app's behalf). Upstream gated none of this and disclosed none of it: the
+appstore capability vocabulary (`location`/`health`/`timeline`) has no
+"network" entry, so an app that used location to call a weather API only
+ever showed "location". This fork adds a per-app, tri-state permission
+system over those two capabilities, denied by default.
+
+**Decision authority.** `WatchappPermissionResolver`
+(`locker/WatchappPermissions.kt`) is the single place that resolves a
+grant. A capability is stored per app in the existing
+`LockerAppPermission` Room table as tri-state: no row = FollowGlobal
+(inherit the global default), `granted=true` = Allow, `granted=false` =
+Deny. Per-app rows win over the global default in either direction.
+"Reset to default" is a row delete, not a third stored state. The global
+defaults are `WatchConfig.watchappDefaultNetworkAllowed` /
+`watchappDefaultLocationAllowed`, both shipping `false`. An upgrading
+install inherits deny because the fields deserialize to their defaults;
+a fresh install is offered the choice during onboarding. The resolver is
+exposed on `LibPebble` via the `WatchappPermissions` interface for the UI.
+
+**Location enforcement** is a single deterministic gate:
+`GeolocationInterface.geolocationPermissionGranted()` now asks the
+resolver (upstream read a row nothing ever wrote and defaulted to
+"granted", so the gate was inert). Denial is reported to the JS callback
+as a geolocation error.
+
+**Network enforcement is layered** (three independent layers, per the
+defence-in-depth rule, with at least one deterministic cover for every
+socket type):
+
+1. `WebViewJsRunner.shouldInterceptRequest` returns a 403 for every
+   non-`file://` request when the app is network-denied. Deterministic for
+   http/https (XHR, fetch, subresources, navigations). WebSocket
+   handshakes do not pass through this callback (a documented WebView
+   limitation), which is why layer 3 exists.
+2. `startup.js` replaces `XMLHttpRequest`/`fetch`/`WebSocket`/
+   `EventSource`/`sendBeacon` with failing stubs before the app bundle
+   loads, gated on a synchronous `_Pebble.isNetworkAllowed()` bridge call.
+   Best-effort (same-realm JS a hostile bundle could try to work around),
+   so it never stands alone.
+3. `ProxyController` (androidx.webkit) sets a process-wide WebView proxy
+   override that black-holes all egress (every scheme, including ws/wss)
+   to an unroutable address while a network-denied app runs, and clears it
+   otherwise. Applied and awaited before the app page loads, kept in sync
+   with live toggles, and cleared on stop. Process-global is inherent to
+   the API, but only one PKJS WebView runs at a time and the config page
+   (below) is gated for denied apps, so nothing legitimate needs the
+   network while it is set. Requires the `PROXY_OVERRIDE` feature; the
+   degraded case is in `KNOWN_ISSUES.md`.
+
+The phone-side interceptor path (`PrivatePKJSInterface.onIntercepted`,
+which the weather interceptors use to fetch on the app's behalf) is gated
+separately and deterministically: it is exposed directly on the `_Pebble`
+bridge, so a hostile bundle could call it without going through the XHR
+shim, and gating it in Kotlin, not only in JS, is what actually closes
+the egress-on-behalf vector.
+
+**Config page.** A `configurable` app's developer settings page URL is
+built by the app's own JS and loaded in a WebView, so opening it is an
+app-controlled network request to a developer-chosen server that can carry
+anything the app gathered (location included). `CommonApp.showSettings`
+therefore refuses to open it when the app is network-denied and points the
+user at the settings screen, rather than leaving a hole the size of the
+control.
+
+**Surfaces.** Settings > Apps > Watch App Permissions
+(`WatchappPermissionsScreen`) holds the global defaults and an app list;
+the per-app tri-state controls live on each app's detail page
+(`WatchappPermissionControls`, reused by the list). Store listings gain an
+honest disclosure that phone-side code can reach the internet, and the
+location capability description states the real "may send it to outside
+servers" flow. A one-time "What's New" dialog announces the deny-by-default
+change to existing users (`WhatsNewDialog`).
+
+**Dependency.** `androidx.webkit` (1.16.0) is added for `ProxyController`
+only: current stable, Apache-2.0, on Google's Maven (F-Droid
+deliverable), no known advisories, non-deprecated API surface.
+
 ## Branding assets
 
 applicationId is `com.anopticlabs.gravel`; the Kotlin `namespace` and

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -82,11 +82,15 @@ install inherits deny because the fields deserialize to their defaults;
 a fresh install is offered the choice during onboarding. The resolver is
 exposed on `LibPebble` via the `WatchappPermissions` interface for the UI.
 
-**Location enforcement** is a single deterministic gate:
-`GeolocationInterface.geolocationPermissionGranted()` now asks the
-resolver (upstream read a row nothing ever wrote and defaulted to
-"granted", so the gate was inert). Denial is reported to the JS callback
-as a geolocation error.
+**Location enforcement** is a single deterministic gate resolved through
+the resolver (upstream read a row nothing ever wrote and defaulted to
+"granted", so the gate was inert). One-shot requests
+(`getCurrentPosition`) check the grant per call; continuous
+subscriptions (`watchPosition`) collect the resolved grant as a live
+flow, so revoking Location mid-session cancels the running GPS stream
+immediately (a watchface can hold a watch for days) and re-granting
+restarts it. Denial is reported to the JS callback as a geolocation
+error in both cases.
 
 **Network enforcement is layered** (three independent layers, per the
 defence-in-depth rule, with at least one deterministic cover for every

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -97,20 +97,39 @@ socket type):
    http/https (XHR, fetch, subresources, navigations). WebSocket
    handshakes do not pass through this callback (a documented WebView
    limitation), which is why layer 3 exists.
-2. `startup.js` replaces `XMLHttpRequest`/`fetch`/`WebSocket`/
-   `EventSource`/`sendBeacon` with failing stubs before the app bundle
-   loads, gated on a synchronous `_Pebble.isNetworkAllowed()` bridge call.
-   Best-effort (same-realm JS a hostile bundle could try to work around),
-   so it never stands alone.
+2. `startup.js` wraps `XMLHttpRequest`/`fetch`/`WebSocket`/
+   `EventSource`/`sendBeacon` in failing guards when the app loads while
+   denied, gated on a synchronous `_Pebble.isNetworkAllowed()` bridge
+   call. The guards re-read the live grant on every use and restore the
+   original entry points the moment access is granted, so granting a
+   running app takes effect without a session restart (the page loads
+   only once per session, so a load-time-only stub would freeze the deny
+   until the app restarts). They do not reinstall on a later revoke; the
+   native layers enforce that direction live. Best-effort (same-realm JS
+   a hostile bundle could try to work around), so it never stands alone.
 3. `ProxyController` (androidx.webkit) sets a process-wide WebView proxy
    override that black-holes all egress (every scheme, including ws/wss)
    to an unroutable address while a network-denied app runs, and clears it
-   otherwise. Applied and awaited before the app page loads, kept in sync
-   with live toggles, and cleared on stop. Process-global is inherent to
-   the API, but only one PKJS WebView runs at a time and the config page
-   (below) is gated for denied apps, so nothing legitimate needs the
-   network while it is set. Requires the `PROXY_OVERRIDE` feature; the
-   degraded case is in `KNOWN_ISSUES.md`.
+   otherwise. Chromium's implicit proxy-bypass rules are removed so
+   localhost and link-local destinations are black-holed too; both are
+   real egress (other apps' local socket servers, hosts on the same
+   network segment). Applied and awaited before the app page loads and
+   kept in sync with live toggles; on stop, the live-toggle collector is
+   cancelled first and the override is cleared only after the WebView is
+   destroyed, so a denied app's scripts never run without the black-hole
+   and nothing can re-install it once teardown has cleared it.
+   Process-global is inherent to the API, but only one PKJS WebView runs
+   at a time and the config page (below) is gated for denied apps, so
+   nothing legitimate needs the network while it is set. Requires the
+   `PROXY_OVERRIDE` feature; the degraded case is in `KNOWN_ISSUES.md`.
+
+A deny-to-allow flip while the app is running also restarts its PKJS
+session (`CompanionAppLifecycleManager` funnels the restart through the
+same serially processed stream as watch-side app switches): an app that
+fetches only at launch never touches the network again after its first
+attempt fails, so without the restart a mid-session grant would take
+visible effect only at the next app switch. Allow-to-deny needs no
+restart; the enforcement layers apply it live.
 
 The phone-side interceptor path (`PrivatePKJSInterface.onIntercepted`,
 which the weather interceptors use to fetch on the app's behalf) is gated

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -148,6 +148,29 @@ transfer path, and `adb backup` alike on those devices. `BackupRulesTest`
 pins the shape of all three rule files. This entry leaves the file when
 minSdk reaches 28.
 
+## Watchapp WebSocket deny is best-effort on WebViews without proxy override
+
+**Status: accepted; degrades safely and is rare in practice.**
+
+The watchapp network gate (see `DESIGN_NOTES.md`) enforces a denied app's
+network block in three layers. Two of them, the `shouldInterceptRequest`
+403 and the `startup.js` API stubs, always apply, but only the third, the
+`ProxyController` black-hole, deterministically covers WebSocket, because
+`ws`/`wss` handshakes never reach `shouldInterceptRequest` (a documented
+WebView limitation) and the JS stub is same-realm best-effort a hostile
+bundle could try to bypass. `ProxyController` needs the `PROXY_OVERRIDE`
+WebView feature, which is present on the updatable WebView shipped by every
+current Android version but can be absent on very old or stripped WebView
+builds. Where it is absent, a network-denied app's http/https egress is
+still deterministically blocked (layer 1) and its JS network APIs are
+stubbed (layer 2), but a hostile bundle that recovers a fresh `WebSocket`
+constructor could open a WebSocket. The exposure is narrow: it needs a
+`PROXY_OVERRIDE`-less WebView and a deliberately hostile watchapp, and it
+is limited to WebSocket only. `WebViewJsRunner.applyNetworkProxy` logs a
+warning when the feature is unavailable. This entry leaves the file if
+minSdk/WebView baseline guarantees `PROXY_OVERRIDE`, or if a WebView-level
+WebSocket intercept becomes available.
+
 ## The bundled speech stack blocks F-Droid inclusion
 
 **Status: open; which way to resolve it is not yet decided.**

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -171,6 +171,37 @@ warning when the feature is unavailable. This entry leaves the file if
 minSdk/WebView baseline guarantees `PROXY_OVERRIDE`, or if a WebView-level
 WebSocket intercept becomes available.
 
+## Cleartext HTTP is blocked app-wide, breaking http-only watchapps
+
+**Status: deliberate; a guarded per-app opt-in may lift it later.**
+
+Watchapps whose developer config pages or PebbleKit JS requests use plain
+`http://` fail even when the app's Network permission is granted: the
+config page shows a load error and JS requests fail with
+`ERR_CLEARTEXT_NOT_PERMITTED`. `https://` is unaffected.
+
+The block began as an upstream accident this fork keeps on purpose.
+Upstream's manifest declares `android:usesCleartextTraffic="true"`, but
+Android ignores that attribute whenever an `android:networkSecurityConfig`
+is declared, which upstream later added to trust user-installed CAs
+(upstream commit `7549c661`, "Android: trust user-installed CA certs via
+Network Security Config"), and with targetSdk 28+ the config's base
+default is cleartext off. The
+fork keeps the block because a config page is remote code executed in a
+WebView on the phone: fetched over cleartext, it hands any
+network-position attacker script injection into that WebView, plus
+whatever app state rides in the config URL. Legacy http-only watchapps
+break, and that is the accepted cost.
+
+A possible future resolution is a per-app "allow insecure HTTP" toggle in
+the watchapp permission controls, default off and gated behind an
+explicit warning, enforced through the same layered gate as the Network
+permission: the request interceptor and the config-page WebView can
+refuse the scheme per app, and the proxy layer supports scheme-filtered
+rules that would keep insecure WebSocket covered deterministically. This
+entry leaves the file if that ships, or if the ecosystem's http-only
+apps age out.
+
 ## The bundled speech stack blocks F-Droid inclusion
 
 **Status: open; which way to resolve it is not yet decided.**

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ it cannot be mistaken for the official app.
 
 The goal is a companion app for Pebble watches that runs fully featured
 without Google Play services or Firebase, for GrapheneOS, LineageOS, and
-similar phones with as little telemetry as technically possible.
+similar phones with as little telemetry as technically possible, and with
+a security posture tightened beyond upstream's defaults.
 
 ## Fork goals
 
@@ -19,6 +20,13 @@ similar phones with as little telemetry as technically possible.
   screen is a server-rendered page fed by that relay, so it has no data
   source in this fork and its entry points are disabled; usable battery
   analytics would need a local, on-device reimplementation.
+- **Hardening beyond the de-Googling.** The app's own attack surface is in
+  scope, not just its Google dependencies. Landed so far: third-party
+  watchapps' phone-side code gets no internet or location access unless
+  granted (deny by default, per-app controls, revocation applies to running
+  apps), the app's exported Android interfaces are authorization-gated or
+  removed, and plain-HTTP (cleartext) traffic is blocked app-wide
+  ([KNOWN_ISSUES.md](KNOWN_ISSUES.md) records the trade-offs).
 - **Weather without Play services.** Manual latitude/longitude entry, since
   the stock place search relies on the GMS-backed platform geocoder.
 - **A watch microphone API for third-party applications** documented and
@@ -45,6 +53,7 @@ lands piece by piece:
 - [x] Telemetry strip (Crashlytics, analytics, firmware-diagnostics relay)
 - [x] Google Play services / Firebase removal
 - [x] Core watch firmware updates from the public PebbleOS GitHub releases
+- [x] Per-app watchapp permissions (internet + location, deny by default)
 - [ ] Third-party microphone API
 - [ ] Local on-device battery analytics (secondary goal, feasibility open)
 - [ ] F-Droid inclusion (blockers tracked in KNOWN_ISSUES.md)

--- a/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/App.kt
+++ b/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/App.kt
@@ -12,6 +12,7 @@ import co.touchlab.kermit.Logger
 import com.russhwolf.settings.Settings
 import coredevices.coreapp.ui.navigation.AppNavHost
 import coredevices.coreapp.ui.screens.SHOWN_ONBOARDING
+import coredevices.coreapp.ui.screens.WhatsNewDialog
 import coredevices.pebble.ui.PebbleRoutes
 import coredevices.ui.dismissKeyboardOnTapOutside
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -42,6 +43,9 @@ fun App() {
         Box(Modifier.fillMaxSize().dismissKeyboardOnTapOutside()) {
             AppNavHost(navHostController, startDestination)
             SttModelUpdatePrompt()
+            // Fork: one-time update notice (currently: watchapp permissions). Self-gates
+            // to onboarded installs whose last-seen revision is behind the current one.
+            WhatsNewDialog()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/OnboardingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/OnboardingScreen.kt
@@ -21,18 +21,23 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Devices
 import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material.icons.filled.Watch
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
@@ -51,6 +56,7 @@ import com.russhwolf.settings.Settings
 import com.russhwolf.settings.set
 import coreapp.composeapp.generated.resources.Res
 import coreapp.composeapp.generated.resources.gravel_logo
+import io.rebble.libpebblecommon.connection.LibPebble
 import coredevices.pebble.ui.PebbleRoutes
 import coredevices.pebble.ui.PreviewWrapper
 import coredevices.ui.PebbleElevatedButton
@@ -77,6 +83,11 @@ enum class OnboardingStage {
     Welcome,
     DeviceSelection,
     Permissions,
+    // Fork: the user's one-time choice for whether watchfaces/apps may reach the
+    // internet and location by default. Placed just before Done so it is the last
+    // thing set during onboarding; existing installs (which never re-run onboarding)
+    // keep the deny-by-default baseline.
+    WatchappPrivacy,
     SignIn,
     Done,
 }
@@ -94,6 +105,13 @@ class OnboardingViewModel(private val config: CoreConfigHolder) : ViewModel() {
     val coreConfig = config.config
     fun setIndexEnabled(enabled: Boolean) {
         config.update(config.config.value.copy(enableIndex = enabled))
+    }
+
+    // Fork: stamp the current changelog revision as seen (see WhatsNewDialog). Called on
+    // onboarding exit so a fresh install is not shown the update dialog for changes it was
+    // just walked through during setup.
+    fun markWhatsNewSeen() {
+        config.update(config.config.value.copy(lastSeenWhatsNewVersion = WHATS_NEW_VERSION))
     }
 }
 
@@ -127,6 +145,10 @@ fun OnboardingScreen(
     fun exitOnboarding() {
         logger.v { "exitOnboarding" }
         settings[SHOWN_ONBOARDING] = true
+        // Fork: a fresh install has just made its watchapp privacy choice during
+        // onboarding, so mark the current "What's New" as seen, otherwise the update
+        // dialog would immediately re-announce what the user just set.
+        viewModel.markWhatsNewSeen()
         doneInitialOnboarding.onDoneInitialOnboarding()
         coreNav.navigateTo(PebbleRoutes.WatchHomeRoute)
     }
@@ -232,8 +254,9 @@ fun OnboardingScreen(
                             // Fork: Core-account sign-in is removed with the
                             // Firebase strip, so onboarding skips the SignIn
                             // stage; the stage and its UI stay compiled for
-                            // cheap upstream merges.
-                            viewModel.stage.value = OnboardingStage.Done
+                            // cheap upstream merges. Route through the watchapp
+                            // privacy choice before finishing.
+                            viewModel.stage.value = OnboardingStage.WatchappPrivacy
                         } else {
                             val warnBeforeFullScreenRequest = permissionToRequest.requestIsFullScreen()
                             LaunchedEffect(permissionToRequest) {
@@ -279,6 +302,12 @@ fun OnboardingScreen(
                             }
                         }
                     }
+                }
+
+                OnboardingStage.WatchappPrivacy -> {
+                    WatchappPrivacyStage(
+                        onDone = { viewModel.stage.value = OnboardingStage.Done },
+                    )
                 }
 
                 OnboardingStage.SignIn -> {
@@ -330,6 +359,130 @@ fun OnboardingScreen(
     }
     }
 }
+
+/**
+ * Fork: one-time onboarding choice for the global watchapp/watchface phone-side
+ * permission defaults (internet + location). Both default to off (deny) here: the user
+ * opts in rather than out. The choice is confirmed via a dialog, then written to
+ * WatchConfig, then acknowledged with a note pointing at the settings screen where it can
+ * be changed later, per David's requested flow.
+ */
+@Composable
+private fun WatchappPrivacyStage(onDone: () -> Unit) {
+    val libPebble: LibPebble = koinInject()
+    var allowInternet by remember { mutableStateOf(false) }
+    var allowLocation by remember { mutableStateOf(false) }
+    var showConfirm by remember { mutableStateOf(false) }
+    var saved by remember { mutableStateOf(false) }
+
+    if (saved) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Text(
+                text = "You're all set",
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = "Watchfaces and apps will have internet ${onOff(allowInternet)} and " +
+                    "location ${onOff(allowLocation)} by default. You can change this any time, " +
+                    "for all apps or one at a time, in Settings > Apps > Watch App Permissions.",
+                textAlign = TextAlign.Center,
+            )
+            Spacer(modifier = Modifier.height(20.dp))
+            PebbleElevatedButton(
+                text = "Continue",
+                onClick = onDone,
+                primaryColor = true,
+            )
+        }
+        return
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = "Privacy",
+            fontSize = 28.sp,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(
+            text = "Some watchfaces and apps run code on your phone to fetch things like " +
+                "weather, which can use your internet connection and location. Choose what " +
+                "they're allowed to do by default. Off is the safer choice, but can stop " +
+                "features that need it, such as third-party weather, from working; you can " +
+                "allow individual apps later.",
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(20.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text("Allow internet access", modifier = Modifier.weight(1f))
+            Switch(checked = allowInternet, onCheckedChange = { allowInternet = it })
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text("Allow location", modifier = Modifier.weight(1f))
+            Switch(checked = allowLocation, onCheckedChange = { allowLocation = it })
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        PebbleElevatedButton(
+            text = "Finish setup",
+            onClick = { showConfirm = true },
+            primaryColor = true,
+        )
+    }
+
+    if (showConfirm) {
+        AlertDialog(
+            onDismissRequest = { showConfirm = false },
+            title = { Text("Confirm your choice") },
+            text = {
+                Text(
+                    "By default, watchfaces and apps will have:\n\n" +
+                        "Internet: ${allowedBlocked(allowInternet)}\n" +
+                        "Location: ${allowedBlocked(allowLocation)}\n\n" +
+                        "You can change this any time in Settings.",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    val cfg = libPebble.config.value
+                    libPebble.updateConfig(
+                        cfg.copy(
+                            watchConfig = cfg.watchConfig.copy(
+                                watchappDefaultNetworkAllowed = allowInternet,
+                                watchappDefaultLocationAllowed = allowLocation,
+                            ),
+                        ),
+                    )
+                    showConfirm = false
+                    saved = true
+                }) { Text("Confirm") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showConfirm = false }) { Text("Back") }
+            },
+        )
+    }
+}
+
+private fun onOff(value: Boolean): String = if (value) "on" else "off"
+
+private fun allowedBlocked(value: Boolean): String = if (value) "Allowed" else "Blocked"
 
 @Composable
 private fun DeviceChoiceCard(

--- a/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/OnboardingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/OnboardingScreen.kt
@@ -84,9 +84,11 @@ enum class OnboardingStage {
     DeviceSelection,
     Permissions,
     // Fork: the user's one-time choice for whether watchfaces/apps may reach the
-    // internet and location by default. Placed just before Done so it is the last
-    // thing set during onboarding; existing installs (which never re-run onboarding)
-    // keep the deny-by-default baseline.
+    // internet and location by default. Runs as the last stage of the fork's flow:
+    // Permissions routes here and onDone goes straight to Done, skipping the SignIn
+    // stage that sits between them in this enum (kept compiled for cheap upstream
+    // merges). Existing installs, which never re-run onboarding, keep the
+    // deny-by-default baseline.
     WatchappPrivacy,
     SignIn,
     Done,
@@ -364,8 +366,8 @@ fun OnboardingScreen(
  * Fork: one-time onboarding choice for the global watchapp/watchface phone-side
  * permission defaults (internet + location). Both default to off (deny) here: the user
  * opts in rather than out. The choice is confirmed via a dialog, then written to
- * WatchConfig, then acknowledged with a note pointing at the settings screen where it can
- * be changed later, per David's requested flow.
+ * WatchConfig, then acknowledged with a note pointing at the settings screen where it
+ * can be changed later.
  */
 @Composable
 private fun WatchappPrivacyStage(onDone: () -> Unit) {

--- a/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/WhatsNewDialog.kt
+++ b/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/WhatsNewDialog.kt
@@ -1,0 +1,89 @@
+package coredevices.coreapp.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.russhwolf.settings.Settings
+import coredevices.util.CoreConfigHolder
+import org.koin.compose.koinInject
+
+/**
+ * Fork: the current "What's New" changelog revision. Bump this by one, and prepend an
+ * entry to [whatsNewEntries], whenever there is something worth announcing to existing
+ * users on update. The dialog shows once per user per bump (see [WhatsNewDialog]).
+ */
+const val WHATS_NEW_VERSION = 1
+
+/** A single announced change: a short heading and a sentence or two of body. */
+data class WhatsNewEntry(val title: String, val body: String)
+
+/**
+ * Newest first. Kept deliberately small: this is a "what changed for you" notice, not a
+ * full changelog (that lives in git history and the repo docs).
+ */
+val whatsNewEntries: List<WhatsNewEntry> = listOf(
+    WhatsNewEntry(
+        title = "Control what watchfaces and apps can reach",
+        body = "Watchfaces and apps can run code on your phone that uses the internet and " +
+            "your location. You can now turn that off, for everything or per app, in " +
+            "Settings > Apps > Watch App Permissions. It starts off for apps you already " +
+            "had installed; turn it on for the ones you trust.",
+    ),
+)
+
+/**
+ * One-time update notice, shown over the home screen. Only fires when onboarding has
+ * already happened (so it never overlaps the onboarding privacy choice) and the user's
+ * last-seen revision is behind [WHATS_NEW_VERSION]. Dismissing stamps the current version
+ * so it does not reappear.
+ */
+@Composable
+fun WhatsNewDialog() {
+    val settings: Settings = koinInject()
+    val configHolder: CoreConfigHolder = koinInject()
+    val config by configHolder.config.collectAsState()
+
+    // Guard: only for installs that finished onboarding in a previous version. A fresh
+    // install stamps lastSeenWhatsNewVersion at the end of onboarding, so this is false
+    // for it and the dialog stays hidden.
+    val onboarded = settings.getBoolean(SHOWN_ONBOARDING, false)
+    if (!onboarded || config.lastSeenWhatsNewVersion >= WHATS_NEW_VERSION) {
+        return
+    }
+
+    AlertDialog(
+        onDismissRequest = { /* require an explicit acknowledge so it isn't missed */ },
+        title = { Text("What's new") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                whatsNewEntries.forEach { entry ->
+                    Column {
+                        Text(
+                            entry.title,
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Spacer(Modifier.height(2.dp))
+                        Text(entry.body, style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                configHolder.update(config.copy(lastSeenWhatsNewVersion = WHATS_NEW_VERSION))
+            }) { Text("Got it") }
+        },
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,13 @@ settings = "1.3.0"
 kable = "0.42.0"
 kmpio = "0.3.0"
 androidx-core = "1.17.0"
+# Fork: androidx.webkit provides ProxyController, the process-wide WebView proxy
+# override used to black-hole a network-denied watchapp's PebbleKit JS (incl. the
+# WebSocket handshakes that shouldInterceptRequest cannot see). Current stable at
+# time of adding (released 2026-05-06); Apache-2.0; on Google's Maven, so F-Droid
+# deliverable; no known advisories; ProxyController / WebViewFeature.PROXY_OVERRIDE
+# are stable (non-deprecated, non-experimental) API in this version.
+androidx-webkit = "1.16.0"
 monitorVersion = "1.8.0"
 androidXTestVersion = "1.7.0"
 androidXRulesVersion = "1.7.0"
@@ -113,6 +120,7 @@ settings-serialization = { group = "com.russhwolf", name = "multiplatform-settin
 kable = { group = "com.juul.kable", name = "kable-core", version.ref = "kable" }
 kmpio = { module = "io.github.skolson:kmp-io", version.ref = "kmpio" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-webkit = { module = "androidx.webkit:webkit", version.ref = "androidx-webkit" }
 androidx-monitor = { group = "androidx.test", name = "monitor", version.ref = "monitorVersion" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidXTestVersion" }
 androidx-test-rules = { group = "androidx.test", name = "rules", version.ref = "androidXRulesVersion" }

--- a/libpebble3/build.gradle.kts
+++ b/libpebble3/build.gradle.kts
@@ -184,6 +184,8 @@ kotlin {
         androidMain.dependencies {
             implementation(libs.androidx.core.ktx)
             implementation(libs.pebblekit)
+            // Fork: ProxyController for the watchapp network black-hole (layer 3).
+            implementation(libs.androidx.webkit)
         }
 
         iosMain.dependencies {

--- a/libpebble3/src/androidMain/assets/startup.js
+++ b/libpebble3/src/androidMain/assets/startup.js
@@ -487,5 +487,42 @@ navigator.geolocation.clearWatch = (id) => {
         xhr.originalSend(body);
     };
 
+    // Fork network gate (JS-shim layer). When this app's Network permission is denied,
+    // replace the network entry points with failing stubs before the app bundle loads.
+    // This is best-effort defence in depth layered on top of the native
+    // shouldInterceptRequest and proxy-override layers: it gives a well-behaved app a
+    // clean, synchronous failure instead of a hung request, but a hostile bundle could
+    // try to recover fresh natives (e.g. from an about:blank iframe), which is exactly
+    // why the deterministic native layers below it exist. Installed last so it wins over
+    // the interception overrides above. Wrapped in try/catch because the bridge method
+    // only exists on Android; iOS falls through and leaves the network APIs intact.
+    try {
+        if (_Pebble.isNetworkAllowed && _Pebble.isNetworkAllowed() === false) {
+            const denyNetwork = (what) => {
+                throw new Error("Network access denied for this watchapp (" + what + ")");
+            };
+            // Fail XHR at open(), so neither the real request nor the interception path runs.
+            XMLHttpRequest.prototype.open = function() { denyNetwork("XMLHttpRequest"); };
+            XMLHttpRequest.prototype.send = function() { denyNetwork("XMLHttpRequest"); };
+            if (typeof global.fetch !== 'undefined') {
+                global.fetch = () => Promise.reject(
+                    new Error("Network access denied for this watchapp (fetch)")
+                );
+            }
+            if (typeof global.WebSocket !== 'undefined') {
+                global.WebSocket = function() { denyNetwork("WebSocket"); };
+            }
+            if (typeof global.EventSource !== 'undefined') {
+                global.EventSource = function() { denyNetwork("EventSource"); };
+            }
+            if (global.navigator && typeof global.navigator.sendBeacon !== 'undefined') {
+                global.navigator.sendBeacon = () => false;
+            }
+            console.warn("Pebble JS Bridge: network access is denied for this app; network APIs are disabled.");
+        }
+    } catch (e) {
+        // No _Pebble.isNetworkAllowed (iOS): leave the network APIs untouched.
+    }
+
     console.log("Pebble JS Bridge initialized.");
 })(_global);

--- a/libpebble3/src/androidMain/assets/startup.js
+++ b/libpebble3/src/androidMain/assets/startup.js
@@ -487,36 +487,96 @@ navigator.geolocation.clearWatch = (id) => {
         xhr.originalSend(body);
     };
 
-    // Fork network gate (JS-shim layer). When this app's Network permission is denied,
-    // replace the network entry points with failing stubs before the app bundle loads.
-    // This is best-effort defence in depth layered on top of the native
-    // shouldInterceptRequest and proxy-override layers: it gives a well-behaved app a
-    // clean, synchronous failure instead of a hung request, but a hostile bundle could
-    // try to recover fresh natives (e.g. from an about:blank iframe), which is exactly
-    // why the deterministic native layers below it exist. Installed last so it wins over
-    // the interception overrides above. Wrapped in try/catch because the bridge method
+    // Fork network gate (JS-shim layer). When this app's Network permission is denied
+    // at page load, wrap the network entry points in guards that fail cleanly. This is
+    // best-effort defence in depth layered on top of the native shouldInterceptRequest
+    // and proxy-override layers: it gives a well-behaved app a clean, synchronous
+    // failure instead of a hung request, but a hostile bundle could try to recover
+    // fresh natives (e.g. from an about:blank iframe), which is exactly why the
+    // deterministic native layers below it exist. Installed last so it wins over the
+    // interception overrides above. Wrapped in try/catch because the bridge method
     // only exists on Android; iOS falls through and leaves the network APIs intact.
+    //
+    // The guards re-read the live grant (a synchronous bridge call into the runner's
+    // cached permission state) on every use: the page loads exactly once per session,
+    // so a load-time-only check would freeze the deny for the whole session and a
+    // user granting access to a running app (the normal "watchface weather is broken,
+    // let me allow it" flow, and watchfaces run indefinitely) would see no effect
+    // until the app restarts. Once the grant is seen, the guards restore the saved
+    // originals and get out of the way entirely; they do not reinstall on a later
+    // revoke. Revoking mid-session is enforced by the native layers, which act on the
+    // live value: the shim only exists to make load-time denial fail cleanly.
     try {
         if (_Pebble.isNetworkAllowed && _Pebble.isNetworkAllowed() === false) {
+            // Saved AFTER the interception wrappers above are installed, so restoring
+            // puts back the interception-aware versions, not the raw natives.
+            const original = {
+                xhrOpen: XMLHttpRequest.prototype.open,
+                xhrSend: XMLHttpRequest.prototype.send,
+                fetch: typeof global.fetch !== 'undefined' ? global.fetch : undefined,
+                webSocket: typeof global.WebSocket !== 'undefined' ? global.WebSocket : undefined,
+                eventSource: typeof global.EventSource !== 'undefined' ? global.EventSource : undefined,
+                sendBeacon: (global.navigator && typeof global.navigator.sendBeacon !== 'undefined')
+                    ? global.navigator.sendBeacon.bind(global.navigator) : undefined,
+            };
+            const restoreNetworkApis = () => {
+                XMLHttpRequest.prototype.open = original.xhrOpen;
+                XMLHttpRequest.prototype.send = original.xhrSend;
+                if (original.fetch) global.fetch = original.fetch;
+                if (original.webSocket) global.WebSocket = original.webSocket;
+                if (original.eventSource) global.EventSource = original.eventSource;
+                if (original.sendBeacon) global.navigator.sendBeacon = original.sendBeacon;
+                console.warn("Pebble JS Bridge: network access granted; network APIs restored.");
+            };
+            // Returns true while the app is still denied; on the first call after a
+            // grant it restores the originals (all of them, so later calls skip the
+            // guards completely) and returns false.
+            const stillDenied = () => {
+                if (_Pebble.isNetworkAllowed() === true) {
+                    restoreNetworkApis();
+                    return false;
+                }
+                return true;
+            };
             const denyNetwork = (what) => {
                 throw new Error("Network access denied for this watchapp (" + what + ")");
             };
             // Fail XHR at open(), so neither the real request nor the interception path runs.
-            XMLHttpRequest.prototype.open = function() { denyNetwork("XMLHttpRequest"); };
-            XMLHttpRequest.prototype.send = function() { denyNetwork("XMLHttpRequest"); };
-            if (typeof global.fetch !== 'undefined') {
-                global.fetch = () => Promise.reject(
-                    new Error("Network access denied for this watchapp (fetch)")
-                );
+            XMLHttpRequest.prototype.open = function() {
+                if (stillDenied()) denyNetwork("XMLHttpRequest");
+                return original.xhrOpen.apply(this, arguments);
+            };
+            XMLHttpRequest.prototype.send = function() {
+                if (stillDenied()) denyNetwork("XMLHttpRequest");
+                return original.xhrSend.apply(this, arguments);
+            };
+            if (original.fetch) {
+                global.fetch = function() {
+                    if (stillDenied()) {
+                        return Promise.reject(
+                            new Error("Network access denied for this watchapp (fetch)")
+                        );
+                    }
+                    return original.fetch.apply(global, arguments);
+                };
             }
-            if (typeof global.WebSocket !== 'undefined') {
-                global.WebSocket = function() { denyNetwork("WebSocket"); };
+            if (original.webSocket) {
+                global.WebSocket = function() {
+                    if (stillDenied()) denyNetwork("WebSocket");
+                    return new original.webSocket(...arguments);
+                };
             }
-            if (typeof global.EventSource !== 'undefined') {
-                global.EventSource = function() { denyNetwork("EventSource"); };
+            if (original.eventSource) {
+                global.EventSource = function() {
+                    if (stillDenied()) denyNetwork("EventSource");
+                    return new original.eventSource(...arguments);
+                };
             }
-            if (global.navigator && typeof global.navigator.sendBeacon !== 'undefined') {
-                global.navigator.sendBeacon = () => false;
+            if (original.sendBeacon) {
+                global.navigator.sendBeacon = function() {
+                    if (stillDenied()) return false;
+                    return original.sendBeacon.apply(global.navigator, arguments);
+                };
             }
             console.warn("Pebble JS Bridge: network access is denied for this app; network APIs are disabled.");
         }

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/di/PKJSModule.android.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/di/PKJSModule.android.kt
@@ -23,6 +23,7 @@ actual val pkjsPlatformModule: Module = module {
             remoteTimelineEmulator = get(),
             httpInterceptorManager = get(),
             notificationConfigFlow = get(),
+            watchappPermissions = get(),
         )
     } bind JsRunner::class
 }

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/js/WebViewJsRunner.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/js/WebViewJsRunner.kt
@@ -37,7 +37,9 @@ import io.rebble.libpebblecommon.locker.WatchappPermissionResolver
 import io.rebble.libpebblecommon.metadata.pbw.appinfo.PbwAppInfo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -93,6 +95,10 @@ class WebViewJsRunner(
     }
 
     private var webView: WebView? = null
+
+    // The live-toggle collector launched in start(); stop() cancels it before any
+    // proxy teardown so the two can never interleave on the process-global override.
+    private var networkPermissionCollector: Job? = null
     private var restoreCompleted: Boolean = false
     private val initializedLock = Object()
     private val publicJsInterface = WebViewPKJSInterface(this, device, context, libPebble, jsTokenUtil)
@@ -319,8 +325,12 @@ class WebViewJsRunner(
         applyNetworkProxy(networkAllowed)
         // Track live toggles: a change in the resolved grant (per-app override or the
         // global default) re-caches the value and re-applies/clears the proxy while the
-        // app keeps running. Runs on the runner scope so it dies with the session.
-        scope.launch {
+        // app keeps running. The job is kept so stop() can cancel it FIRST, before it
+        // touches the proxy itself: the runner scope outlives stop()'s suspension
+        // points (PKJSApp cancels it only after stop() returns), so an emission landing
+        // mid-teardown would otherwise re-install the process-wide black-hole after
+        // stop() cleared it, with nothing left alive to ever clear it again.
+        networkPermissionCollector = scope.launch {
             watchappPermissions.watchappPermissionGranted(uuid, LockerAppPermissionType.Network)
                 .collect { allowed ->
                     if (allowed != networkAllowed) {
@@ -358,10 +368,17 @@ class WebViewJsRunner(
             if (allowed) {
                 controller.clearProxyOverride(executor) { if (cont.isActive) cont.resume(Unit) }
             } else {
-                // Route everything to an unroutable address (RFC 5737 TEST-NET-1) with
-                // no bypass rules, so every connection attempt fails fast.
+                // Route everything to an unroutable address (RFC 5737 TEST-NET-1), so
+                // every connection attempt fails fast. removeImplicitRules() matters:
+                // without it Chromium exempts localhost and link-local destinations
+                // from any proxy override, which would leave a denied app's WebSocket
+                // reachable to other apps' local socket servers and to link-local
+                // hosts on the same network segment. Those destinations are egress
+                // too; the black-hole has to cover them for this layer to be the
+                // deterministic WebSocket cover it claims to be.
                 val config = ProxyConfig.Builder()
                     .addProxyRule("192.0.2.1:1")
+                    .removeImplicitRules()
                     .build()
                 controller.setProxyOverride(config, executor) { if (cont.isActive) cont.resume(Unit) }
             }
@@ -395,11 +412,15 @@ class WebViewJsRunner(
         // connection scope — e.g. on watch disconnect.
         withContext(NonCancellable + Dispatchers.Main) {
             try {
-                // Clear any black-hole proxy this app set, so the process-global override
-                // never outlives the session and starves a later WebView (config page or
-                // the next app). No-op if this app was network-allowed.
-                runCatching { applyNetworkProxy(allowed = true) }
-                    .onFailure { logger.w(it) { "Failed to clear network proxy on stop" } }
+                // Stop the live-toggle collector before anything else so a grant-flow
+                // emission (the combined flow re-emits on any permission-table or
+                // config write) cannot re-install the process-global black-hole while
+                // teardown is mid-flight; the clear at the end of this block must be
+                // the last word on the override. cancelAndJoin, not just cancel: the
+                // collector may be suspended inside a proxy call of its own, and it
+                // must have fully wound down before the teardown sequence proceeds.
+                networkPermissionCollector?.cancelAndJoin()
+                networkPermissionCollector = null
                 // Save final state of localStorage to our scoped storage, to catch any
                 // property-accessor changes (not caught by our shim).
                 // Skip if restoreLocalStorage() never completed: window.localStorage is
@@ -423,6 +444,16 @@ class WebViewJsRunner(
             } finally {
                 // destroy() must always run, even if the pre-destroy teardown fails
                 webView?.destroy()
+                // Clear any black-hole proxy this app set, so the process-global
+                // override never outlives the session and starves a later WebView
+                // (config page or the next app). Deliberately the LAST teardown step,
+                // after destroy(): the page's JS stays live through the earlier steps
+                // (persistLocalStorage even evaluates into it), and clearing the
+                // proxy any sooner would hand a denied app's still-running scripts a
+                // WebSocket-egress window on every stop. No-op if this app was
+                // network-allowed.
+                runCatching { applyNetworkProxy(allowed = true) }
+                    .onFailure { logger.w(it) { "Failed to clear network proxy on stop" } }
             }
         }
         synchronized(initializedLock) {

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/js/WebViewJsRunner.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/js/WebViewJsRunner.kt
@@ -21,24 +21,32 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.core.net.toUri
+import androidx.webkit.ProxyConfig
+import androidx.webkit.ProxyController
+import androidx.webkit.WebViewFeature
 import co.touchlab.kermit.Logger
 import io.rebble.libpebblecommon.NotificationConfigFlow
 import io.rebble.libpebblecommon.connection.AppContext
 import io.rebble.libpebblecommon.connection.LibPebble
+import io.rebble.libpebblecommon.database.entity.LockerAppPermissionType
 import io.rebble.libpebblecommon.database.entity.LockerEntry
 import io.rebble.libpebblecommon.di.LibPebbleKoinComponent
 import io.rebble.libpebblecommon.io.rebble.libpebblecommon.js.WebViewGeolocationInterface
 import io.rebble.libpebblecommon.io.rebble.libpebblecommon.js.WebViewJSLocalStorageInterface
+import io.rebble.libpebblecommon.locker.WatchappPermissionResolver
 import io.rebble.libpebblecommon.metadata.pbw.appinfo.PbwAppInfo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import kotlinx.io.files.Path
+import java.util.concurrent.Executor
+import kotlin.uuid.Uuid
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -62,8 +70,21 @@ class WebViewJsRunner(
     remoteTimelineEmulator: RemoteTimelineEmulator,
     httpInterceptorManager: HttpInterceptorManager,
     notificationConfigFlow: NotificationConfigFlow,
+    private val watchappPermissions: WatchappPermissionResolver,
 ): JsRunner(appInfo, lockerEntry, jsPath, device, urlOpenRequests), LibPebbleKoinComponent {
     private val context = appContext.context
+
+    // Fork network gate, cached snapshot. Defaults to false so that during the brief
+    // window between WebView creation and the first permission resolve, requests are
+    // blocked rather than leaked. Updated synchronously in start() before any app code
+    // runs, then kept live by a collector on the resolved grant flow. Read from the
+    // WebView client thread (shouldInterceptRequest) and the JS bridge thread, hence
+    // @Volatile.
+    @Volatile
+    private var networkAllowed: Boolean = false
+
+    // Read by startup.js (via the _Pebble bridge) to install the JS-shim layer.
+    fun isNetworkAllowedForJs(): Boolean = networkAllowed
     companion object {
         const val API_NAMESPACE = "Pebble"
         const val PRIVATE_API_NAMESPACE = "_$API_NAMESPACE"
@@ -75,7 +96,7 @@ class WebViewJsRunner(
     private var restoreCompleted: Boolean = false
     private val initializedLock = Object()
     private val publicJsInterface = WebViewPKJSInterface(this, device, context, libPebble, jsTokenUtil)
-    private val privateJsInterface = WebViewPrivatePKJSInterface(this, device, scope, _outgoingAppMessages, logMessages, jsTokenUtil, remoteTimelineEmulator, httpInterceptorManager, notificationConfigFlow)
+    private val privateJsInterface = WebViewPrivatePKJSInterface(this, device, scope, _outgoingAppMessages, logMessages, jsTokenUtil, remoteTimelineEmulator, httpInterceptorManager, notificationConfigFlow, watchappPermissions)
     private val localStorageInterface = WebViewJSLocalStorageInterface(appInfo.uuid, appContext) {
         runBlocking(Dispatchers.Main) {
             webView?.evaluateJavascript(
@@ -124,21 +145,28 @@ class WebViewJsRunner(
         }
 
         override fun shouldInterceptRequest(view: WebView?, request: WebResourceRequest?): WebResourceResponse? {
-            if (isForbidden(request?.url)) {
-                return object : WebResourceResponse("text/plain", "utf-8", null) {
-                    override fun getStatusCode(): Int {
-                        return 403
-                    }
-
-                    override fun getReasonPhrase(): String {
-                        return "Forbidden"
-                    }
-                }
-            } else {
-                return super.shouldInterceptRequest(view, request)
+            val url = request?.url
+            if (isForbidden(url)) {
+                return blockedResponse("Forbidden")
             }
+            // Fork network gate (layer 1, deterministic for http/https). When the app's
+            // Network permission is denied, refuse every non-file request so no XHR,
+            // fetch, page subresource or navigation reaches the network. WebSocket
+            // handshakes do NOT pass through this callback (a documented WebView
+            // limitation); the proxy override layer is what covers those.
+            if (!networkAllowed && url != null && url.scheme?.uppercase() != "FILE") {
+                logger.d { "Network denied; blocking ${url.scheme} request to ${url.host}" }
+                return blockedResponse("Network access denied for this app")
+            }
+            return super.shouldInterceptRequest(view, request)
         }
     }
+
+    private fun blockedResponse(reason: String): WebResourceResponse =
+        object : WebResourceResponse("text/plain", "utf-8", null) {
+            override fun getStatusCode(): Int = 403
+            override fun getReasonPhrase(): String = reason
+        }
 
     private fun isForbidden(url: Uri?): Boolean {
         return if (url == null) {
@@ -281,7 +309,63 @@ class WebViewJsRunner(
         }
         check(webView != null) { "WebView not initialized" }
         logger.d { "WebView initialized" }
+
+        // Resolve the app's Network grant and put the enforcement layers in place
+        // BEFORE any app page/script loads, so there is no window in which a denied
+        // app can reach the network. The initial value gates layers 1 (intercept) and
+        // 2 (JS shim); the proxy (layer 3) is applied and awaited here too.
+        val uuid = Uuid.parse(appInfo.uuid)
+        networkAllowed = watchappPermissions.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network)
+        applyNetworkProxy(networkAllowed)
+        // Track live toggles: a change in the resolved grant (per-app override or the
+        // global default) re-caches the value and re-applies/clears the proxy while the
+        // app keeps running. Runs on the runner scope so it dies with the session.
+        scope.launch {
+            watchappPermissions.watchappPermissionGranted(uuid, LockerAppPermissionType.Network)
+                .collect { allowed ->
+                    if (allowed != networkAllowed) {
+                        logger.d { "Network grant for $uuid changed -> $allowed" }
+                    }
+                    networkAllowed = allowed
+                    applyNetworkProxy(allowed)
+                }
+        }
+
         loadApp(jsPath.toString())
+    }
+
+    /**
+     * Layer 3 of the network gate: a process-wide WebView proxy override that
+     * black-holes all egress (every scheme, including ws/wss that shouldInterceptRequest
+     * cannot see) when the running app's network is denied, and is cleared when allowed.
+     *
+     * Process-global is inherent to the ProxyController API, but only one PKJS WebView
+     * runs at a time and the developer config page is gated for network-denied apps, so
+     * nothing legitimate needs the network while the black-hole is active. Requires the
+     * PROXY_OVERRIDE WebView feature; when unsupported, layers 1 and 2 still apply and
+     * only the WebSocket-deny corner degrades to best-effort (recorded in KNOWN_ISSUES).
+     */
+    private suspend fun applyNetworkProxy(allowed: Boolean) {
+        if (!WebViewFeature.isFeatureSupported(WebViewFeature.PROXY_OVERRIDE)) {
+            if (!allowed) {
+                logger.w { "PROXY_OVERRIDE unsupported; WebSocket deny is best-effort for this app" }
+            }
+            return
+        }
+        val controller = ProxyController.getInstance()
+        val executor = Executor { it.run() }
+        suspendCancellableCoroutine { cont ->
+            if (allowed) {
+                controller.clearProxyOverride(executor) { if (cont.isActive) cont.resume(Unit) }
+            } else {
+                // Route everything to an unroutable address (RFC 5737 TEST-NET-1) with
+                // no bypass rules, so every connection attempt fails fast.
+                val config = ProxyConfig.Builder()
+                    .addProxyRule("192.0.2.1:1")
+                    .build()
+                controller.setProxyOverride(config, executor) { if (cont.isActive) cont.resume(Unit) }
+            }
+        }
     }
 
     private suspend fun persistLocalStorage() {
@@ -311,6 +395,11 @@ class WebViewJsRunner(
         // connection scope — e.g. on watch disconnect.
         withContext(NonCancellable + Dispatchers.Main) {
             try {
+                // Clear any black-hole proxy this app set, so the process-global override
+                // never outlives the session and starves a later WebView (config page or
+                // the next app). No-op if this app was network-allowed.
+                runCatching { applyNetworkProxy(allowed = true) }
+                    .onFailure { logger.w(it) { "Failed to clear network proxy on stop" } }
                 // Save final state of localStorage to our scoped storage, to catch any
                 // property-accessor changes (not caught by our shim).
                 // Skip if restoreLocalStorage() never completed: window.localStorage is

--- a/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/js/WebViewPrivatePKJSInterface.kt
+++ b/libpebble3/src/androidMain/kotlin/io/rebble/libpebblecommon/js/WebViewPrivatePKJSInterface.kt
@@ -5,6 +5,7 @@ import android.webkit.JavascriptInterface
 import androidx.core.net.toUri
 import co.touchlab.kermit.Logger
 import io.rebble.libpebblecommon.NotificationConfigFlow
+import io.rebble.libpebblecommon.locker.WatchappPermissionResolver
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -12,7 +13,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 
 class WebViewPrivatePKJSInterface(
-    jsRunner: WebViewJsRunner,
+    private val webViewJsRunner: WebViewJsRunner,
     device: CompanionAppDevice,
     scope: CoroutineScope,
     outgoingAppMessages: MutableSharedFlow<AppMessageRequest>,
@@ -21,11 +22,20 @@ class WebViewPrivatePKJSInterface(
     remoteTimelineEmulator: RemoteTimelineEmulator,
     httpInterceptorManager: HttpInterceptorManager,
     notificationConfigFlow: NotificationConfigFlow,
-): PrivatePKJSInterface(jsRunner, device, scope, outgoingAppMessages, logMessages, jsTokenUtil, remoteTimelineEmulator, httpInterceptorManager, notificationConfigFlow) {
+    watchappPermissions: WatchappPermissionResolver,
+): PrivatePKJSInterface(webViewJsRunner, device, scope, outgoingAppMessages, logMessages, jsTokenUtil, remoteTimelineEmulator, httpInterceptorManager, notificationConfigFlow, watchappPermissions) {
 
     companion object {
         private val logger = Logger.withTag(WebViewPrivatePKJSInterface::class.simpleName!!)
     }
+
+    // Fork network gate (JS-shim layer). startup.js reads this synchronously before
+    // the app bundle loads and, when denied, replaces XHR/fetch/WebSocket/etc with
+    // failing stubs. Best-effort by nature (same-realm JS the app could try to work
+    // around), so it sits on top of the deterministic shouldInterceptRequest + proxy
+    // layers, never alone. Cached boolean lives on the runner (see its collector).
+    @JavascriptInterface
+    fun isNetworkAllowed(): Boolean = webViewJsRunner.isNetworkAllowedForJs()
 
     @JavascriptInterface
     fun startupScriptHasLoaded(data: String?) {

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/LibPebbleConfig.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/LibPebbleConfig.kt
@@ -91,6 +91,27 @@ data class WatchConfig(
      * Intended to be a debug option to dsiable watch settings sync.
      */
     val enableWatchSettingsSync: Boolean = true,
+    /**
+     * Fork: global default grant for a watchapp/watchface's phone-side PebbleKit JS
+     * network access (XHR/fetch/WebSocket and the phone-side weather interceptors).
+     *
+     * This is the value applied to any app that has no explicit per-app override in
+     * the LockerAppPermission table. It ships DENY (false) on purpose: upstream let
+     * third-party watchface JS reach arbitrary servers with zero disclosure or
+     * control, so the fork's baseline is no access until the user opts in. Onboarding
+     * lets a new user flip this to allow; an upgrading user keeps the deny baseline
+     * (the field simply deserializes to its default for configs written before it
+     * existed). Per-app grants override this in either direction.
+     */
+    val watchappDefaultNetworkAllowed: Boolean = false,
+    /**
+     * Fork: global default grant for a watchapp/watchface's phone-side geolocation
+     * (navigator.geolocation, bridged to real phone GPS). Same deny-by-default
+     * rationale and override semantics as [watchappDefaultNetworkAllowed]. Upstream
+     * modelled a per-app Location permission but never wrote it, so the gate was
+     * inert and everything was effectively allowed; this restores a real default.
+     */
+    val watchappDefaultLocationAllowed: Boolean = false,
 )
 
 class WatchConfigFlow(val flow: StateFlow<LibPebbleConfig>) {

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeLibPebble.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeLibPebble.kt
@@ -29,6 +29,7 @@ import io.rebble.libpebblecommon.database.entity.HRMonitoringInterval
 import io.rebble.libpebblecommon.database.entity.HealthDataEntity
 import io.rebble.libpebblecommon.database.entity.HealthGender
 import io.rebble.libpebblecommon.database.entity.MuteState
+import io.rebble.libpebblecommon.database.entity.LockerAppPermissionType
 import io.rebble.libpebblecommon.database.entity.NotificationAppItem
 import io.rebble.libpebblecommon.database.entity.NotificationEntity
 import io.rebble.libpebblecommon.database.entity.NotificationRuleEntity
@@ -44,6 +45,7 @@ import io.rebble.libpebblecommon.locker.AppPlatform
 import io.rebble.libpebblecommon.locker.AppProperties
 import io.rebble.libpebblecommon.locker.AppType
 import io.rebble.libpebblecommon.locker.LockerWrapper
+import io.rebble.libpebblecommon.locker.PermissionSetting
 import io.rebble.libpebblecommon.metadata.WatchColor
 import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
 import io.rebble.libpebblecommon.metadata.WatchType
@@ -65,6 +67,7 @@ import io.rebble.libpebblecommon.web.LockerEntry
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -214,6 +217,32 @@ class FakeLibPebble : LibPebble {
 
     override fun notificationApps(): Flow<List<AppWithCount>> =
         _notificationApps.map { it.map { AppWithCount(it, 44) } }
+
+    // Fork: previews/tests report every watchapp permission as denied by default,
+    // matching the shipped deny-by-default global defaults.
+    override fun watchappPermissionSetting(
+        uuid: Uuid,
+        type: LockerAppPermissionType,
+    ): Flow<PermissionSetting> = flowOf(PermissionSetting.FollowGlobal)
+
+    override fun watchappPermissionGranted(
+        uuid: Uuid,
+        type: LockerAppPermissionType,
+    ): Flow<Boolean> = flowOf(false)
+
+    override suspend fun isWatchappPermissionGranted(
+        uuid: Uuid,
+        type: LockerAppPermissionType,
+    ): Boolean = false
+
+    override fun globalDefault(type: LockerAppPermissionType): Boolean = false
+
+    override suspend fun setWatchappPermission(
+        uuid: Uuid,
+        type: LockerAppPermissionType,
+        setting: PermissionSetting,
+    ) {
+    }
 
     override fun notificationAppChannelCounts(packageName: String): Flow<List<ChannelAndCount>> =
         MutableStateFlow(emptyList())

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeLibPebble.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeLibPebble.kt
@@ -235,7 +235,7 @@ class FakeLibPebble : LibPebble {
         type: LockerAppPermissionType,
     ): Boolean = false
 
-    override fun globalDefault(type: LockerAppPermissionType): Boolean = false
+    override fun globalDefault(type: LockerAppPermissionType): Flow<Boolean> = flowOf(false)
 
     override suspend fun setWatchappPermission(
         uuid: Uuid,

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeLibPebble.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeLibPebble.kt
@@ -88,7 +88,9 @@ class FakeLibPebble : LibPebble {
         // No-op
     }
 
-    override val watches: PebbleDevices = MutableStateFlow(fakeWatches())
+    // Declared as the mutable type so tests can install a deterministic watch list
+    // instead of the random preview population.
+    override val watches: MutableStateFlow<List<PebbleDevice>> = MutableStateFlow(fakeWatches())
     override val connectionEvents: Flow<PebbleConnectionEvent> = MutableSharedFlow()
 
     override fun watchesDebugState(): String {
@@ -218,22 +220,33 @@ class FakeLibPebble : LibPebble {
     override fun notificationApps(): Flow<List<AppWithCount>> =
         _notificationApps.map { it.map { AppWithCount(it, 44) } }
 
-    // Fork: previews/tests report every watchapp permission as denied by default,
-    // matching the shipped deny-by-default global defaults.
+    // Fork: in-memory per-app permission rows (null entry = FollowGlobal), with the
+    // global default pinned to deny. An untouched fake therefore resolves everything
+    // to denied, matching the shipped deny-by-default baseline for previews, while
+    // tests can grant or deny through setWatchappPermission exactly like the UI does.
+    val watchappPermissionRows =
+        MutableStateFlow<Map<Pair<Uuid, LockerAppPermissionType>, Boolean>>(emptyMap())
+
     override fun watchappPermissionSetting(
         uuid: Uuid,
         type: LockerAppPermissionType,
-    ): Flow<PermissionSetting> = flowOf(PermissionSetting.FollowGlobal)
+    ): Flow<PermissionSetting> = watchappPermissionRows.map { rows ->
+        when (rows[uuid to type]) {
+            null -> PermissionSetting.FollowGlobal
+            true -> PermissionSetting.Allow
+            false -> PermissionSetting.Deny
+        }
+    }
 
     override fun watchappPermissionGranted(
         uuid: Uuid,
         type: LockerAppPermissionType,
-    ): Flow<Boolean> = flowOf(false)
+    ): Flow<Boolean> = watchappPermissionRows.map { it[uuid to type] ?: false }
 
     override suspend fun isWatchappPermissionGranted(
         uuid: Uuid,
         type: LockerAppPermissionType,
-    ): Boolean = false
+    ): Boolean = watchappPermissionRows.value[uuid to type] ?: false
 
     override fun globalDefault(type: LockerAppPermissionType): Flow<Boolean> = flowOf(false)
 
@@ -242,6 +255,11 @@ class FakeLibPebble : LibPebble {
         type: LockerAppPermissionType,
         setting: PermissionSetting,
     ) {
+        watchappPermissionRows.value = when (setting) {
+            PermissionSetting.FollowGlobal -> watchappPermissionRows.value - (uuid to type)
+            PermissionSetting.Allow -> watchappPermissionRows.value + ((uuid to type) to true)
+            PermissionSetting.Deny -> watchappPermissionRows.value + ((uuid to type) to false)
+        }
     }
 
     override fun notificationAppChannelCounts(packageName: String): Flow<List<ChannelAndCount>> =

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeLibPebble.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/FakeLibPebble.kt
@@ -67,7 +67,7 @@ import io.rebble.libpebblecommon.web.LockerEntry
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -221,11 +221,20 @@ class FakeLibPebble : LibPebble {
         _notificationApps.map { it.map { AppWithCount(it, 44) } }
 
     // Fork: in-memory per-app permission rows (null entry = FollowGlobal), with the
-    // global default pinned to deny. An untouched fake therefore resolves everything
-    // to denied, matching the shipped deny-by-default baseline for previews, while
-    // tests can grant or deny through setWatchappPermission exactly like the UI does.
+    // global defaults starting at deny. An untouched fake therefore resolves
+    // everything to denied, matching the shipped deny-by-default baseline for
+    // previews, while tests can grant or deny through setWatchappPermission exactly
+    // like the UI does.
     val watchappPermissionRows =
         MutableStateFlow<Map<Pair<Uuid, LockerAppPermissionType>, Boolean>>(emptyMap())
+
+    // The globalDefault contract is a live flow (the per-app selector labels its
+    // "Default" choice from it and tracks toggles while visible), so the fake backs
+    // it with state instead of a one-shot value, and FollowGlobal rows resolve
+    // against the same state so the fake cannot contradict itself. A missing entry
+    // is deny, keeping untouched fakes on the shipped baseline.
+    val watchappGlobalDefaults =
+        MutableStateFlow<Map<LockerAppPermissionType, Boolean>>(emptyMap())
 
     override fun watchappPermissionSetting(
         uuid: Uuid,
@@ -241,14 +250,19 @@ class FakeLibPebble : LibPebble {
     override fun watchappPermissionGranted(
         uuid: Uuid,
         type: LockerAppPermissionType,
-    ): Flow<Boolean> = watchappPermissionRows.map { it[uuid to type] ?: false }
+    ): Flow<Boolean> =
+        combine(watchappPermissionRows, watchappGlobalDefaults) { rows, defaults ->
+            rows[uuid to type] ?: defaults[type] ?: false
+        }
 
     override suspend fun isWatchappPermissionGranted(
         uuid: Uuid,
         type: LockerAppPermissionType,
-    ): Boolean = watchappPermissionRows.value[uuid to type] ?: false
+    ): Boolean = watchappPermissionRows.value[uuid to type]
+        ?: watchappGlobalDefaults.value[type] ?: false
 
-    override fun globalDefault(type: LockerAppPermissionType): Flow<Boolean> = flowOf(false)
+    override fun globalDefault(type: LockerAppPermissionType): Flow<Boolean> =
+        watchappGlobalDefaults.map { it[type] ?: false }
 
     override suspend fun setWatchappPermission(
         uuid: Uuid,

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/LibPebble.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/LibPebble.kt
@@ -46,6 +46,7 @@ import io.rebble.libpebblecommon.locker.AppBasicProperties
 import io.rebble.libpebblecommon.locker.AppType
 import io.rebble.libpebblecommon.locker.Locker
 import io.rebble.libpebblecommon.locker.LockerWrapper
+import io.rebble.libpebblecommon.locker.WatchappPermissions
 import io.rebble.libpebblecommon.metadata.WatchHardwarePlatform
 import io.rebble.libpebblecommon.notification.NotificationApi
 import io.rebble.libpebblecommon.notification.NotificationListenerConnection
@@ -86,7 +87,7 @@ sealed class PebbleConnectionEvent {
 }
 
 @Stable
-interface LibPebble : Scanning, RequestSync, LockerApi, NotificationApps, CallManagement, Calendar,
+interface LibPebble : Scanning, RequestSync, LockerApi, NotificationApps, WatchappPermissions, CallManagement, Calendar,
     OtherPebbleApps, PKJSToken, Watches, Errors, Contacts, AnalyticsEvents, HealthApi, WatchPrefs,
     SystemGeolocation, Timeline, Vibrations, Weather, HealthDataApi {
     fun init()
@@ -398,8 +399,10 @@ class LibPebble3(
     private val vibePatternDao: VibePatternDao,
     private val watchPreferences: WatchPrefs,
     private val weatherManager: WeatherManager,
+    private val watchappPermissions: WatchappPermissions,
 ) : LibPebble, Scanning by scanning, RequestSync by webSyncManager, LockerApi by locker,
-    NotificationApps by notificationApi, Calendar by phoneCalendarSyncer,
+    NotificationApps by notificationApi, WatchappPermissions by watchappPermissions,
+    Calendar by phoneCalendarSyncer,
     OtherPebbleApps by otherPebbleApps, PKJSToken by jsTokenUtil, Watches by watchManager,
     Errors by errorTracker, Contacts by contacts, AnalyticsEvents by analytics,
     HealthApi by health, SystemGeolocation by systemGeolocation, Timeline by timeline,

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/CompanionAppLifecycleManager.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/CompanionAppLifecycleManager.kt
@@ -10,10 +10,12 @@ import io.rebble.libpebblecommon.database.entity.LockerEntry
 import io.rebble.libpebblecommon.di.ConnectionCoroutineScope
 import io.rebble.libpebblecommon.di.LibPebbleCoroutineScope
 import io.rebble.libpebblecommon.disk.pbw.PbwApp
+import io.rebble.libpebblecommon.database.entity.LockerAppPermissionType
 import io.rebble.libpebblecommon.js.CompanionAppDevice
 import io.rebble.libpebblecommon.js.PKJSApp
 import io.rebble.libpebblecommon.locker.Locker
 import io.rebble.libpebblecommon.locker.LockerPBWCache
+import io.rebble.libpebblecommon.locker.WatchappPermissionResolver
 import io.rebble.libpebblecommon.metadata.pbw.appinfo.PbwAppInfo
 import io.rebble.libpebblecommon.services.WatchInfo
 import io.rebble.libpebblecommon.services.app.AppRunStateService
@@ -25,19 +27,24 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.uuid.Uuid
 
 class CompanionAppLifecycleManager(
     private val lockerPBWCache: LockerPBWCache,
@@ -47,7 +54,8 @@ class CompanionAppLifecycleManager(
     private val locker: Locker,
     private val connectionScope: ConnectionCoroutineScope,
     private val libPebbleConfigFlow: LibPebbleConfigFlow,
-    private val libpebbleCoroutineScope: LibPebbleCoroutineScope
+    private val libpebbleCoroutineScope: LibPebbleCoroutineScope,
+    private val watchappPermissions: WatchappPermissionResolver,
 ): ConnectedPebble.PKJS, ConnectedPebble.CompanionAppControl {
     companion object {
         private val logger = Logger.withTag(CompanionAppLifecycleManager::class.simpleName!!)
@@ -56,6 +64,20 @@ class CompanionAppLifecycleManager(
     private lateinit var device: CompanionAppDevice
 
     private var activeAppScope: CoroutineScope = CoroutineScope(Job().also { it.cancel() })
+
+    // Fork: the locker entry whose companion apps are currently running, kept so a
+    // permission-triggered restart can verify the request still targets the live
+    // session before acting on it.
+    private var currentEntry: LockerEntry? = null
+
+    // Fork: restart requests raised by the network-grant watcher. Funnelled through
+    // the same serially processed event stream as watch-side app changes (see init),
+    // so a restart can never interleave with a genuine app switch; both mutate the
+    // same session state. DROP_OLDEST because restart requests are idempotent.
+    private val restartRequests = MutableSharedFlow<Uuid>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
 
     private val runningApps: MutableStateFlow<List<CompanionApp>> = MutableStateFlow(emptyList())
     @Deprecated("Use more generic currentCompanionAppSession instead and cast if necessary")
@@ -66,6 +88,7 @@ class CompanionAppLifecycleManager(
 
     private suspend fun handleAppStop() {
         activeAppScope.cancel()
+        currentEntry = null
         runningApps.value.forEach { app ->
             // Don't error out if one app fails to stop
             try {
@@ -79,6 +102,7 @@ class CompanionAppLifecycleManager(
 
     private suspend fun handleNewRunningApp(lockerEntry: LockerEntry) {
         try {
+            currentEntry = lockerEntry
             val exceptionHandler = CoroutineExceptionHandler { _, throwable ->
                 logger.e(throwable) { "Unhandled exception in CompanionAppLifecycleManager-${lockerEntry.id}: ${throwable.message}" }
             }
@@ -107,6 +131,33 @@ class CompanionAppLifecycleManager(
                     for (channel in appIncomingChannels) {
                         channel.trySend(message)
                     }
+                }
+            }
+
+            // Fork: restart the session when the app's Network grant flips from deny
+            // to allow. A PKJS session that loaded while denied had its JS network
+            // entry points guarded from page load, and an app that only fetches at
+            // launch never touches the network again after that first attempt throws,
+            // so a mid-session grant would otherwise take visible effect only at the
+            // next app switch. Restarting re-runs the app's JS with the grant in
+            // place, which is the same transition apps already handle when the watch
+            // switches away and back. The allow-to-deny direction needs no restart:
+            // the enforcement layers apply it live. The watcher dies with
+            // activeAppScope, and a fresh session's watcher starts with a clean
+            // transition history, so a restart cannot retrigger itself.
+            if (newApps.any { it is PKJSApp }) {
+                activeAppScope.launch {
+                    var previous: Boolean? = null
+                    watchappPermissions
+                        .watchappPermissionGranted(lockerEntry.id, LockerAppPermissionType.Network)
+                        .distinctUntilChanged()
+                        .collect { allowed ->
+                            if (previous == false && allowed) {
+                                logger.d { "Network grant for ${lockerEntry.id} allowed mid-session; requesting restart" }
+                                restartRequests.tryEmit(lockerEntry.id)
+                            }
+                            previous = allowed
+                        }
                 }
             }
         } catch (e: CancellationException) {
@@ -154,13 +205,35 @@ class CompanionAppLifecycleManager(
             watchInfo,
             appMessagesService
         )
-        appRunStateService.runningApp.onEach {
-            handleAppStop()
-            if (it != null) {
-                val lockerEntry = lockerEntryDao.getEntry(it)
-                lockerEntry?.let {
-                    if (!it.systemApp) {
-                        handleNewRunningApp(lockerEntry)
+        // Fork: watch-side app changes and permission-triggered restart requests are
+        // merged into one serially collected stream, so the two kinds of event can
+        // never interleave; both tear down and rebuild the same session state. A
+        // restart request is only honoured if it still targets the entry that is
+        // currently running (the running app may have changed between the request
+        // being raised and processed).
+        merge(
+            appRunStateService.runningApp.map { SessionEvent.AppChanged(it) },
+            restartRequests.map { SessionEvent.RestartRequested(it) },
+        ).onEach { event ->
+            when (event) {
+                is SessionEvent.AppChanged -> {
+                    handleAppStop()
+                    if (event.uuid != null) {
+                        val lockerEntry = lockerEntryDao.getEntry(event.uuid)
+                        lockerEntry?.let {
+                            if (!it.systemApp) {
+                                handleNewRunningApp(lockerEntry)
+                            }
+                        }
+                    }
+                }
+
+                is SessionEvent.RestartRequested -> {
+                    val entry = currentEntry
+                    if (entry != null && entry.id == event.uuid) {
+                        logger.d { "Restarting companion apps for ${event.uuid} after network grant" }
+                        handleAppStop()
+                        handleNewRunningApp(entry)
                     }
                 }
             }
@@ -169,6 +242,13 @@ class CompanionAppLifecycleManager(
             handleAppStop()
         }.launchIn(connectionScope)
     }
+}
+
+// Fork: event vocabulary for the serialized session stream in
+// CompanionAppLifecycleManager.init.
+private sealed class SessionEvent {
+    data class AppChanged(val uuid: Uuid?) : SessionEvent()
+    data class RestartRequested(val uuid: Uuid) : SessionEvent()
 }
 
 /**

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/CompanionAppLifecycleManager.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/CompanionAppLifecycleManager.kt
@@ -27,19 +27,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.FlowCollector
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
@@ -70,13 +63,22 @@ class CompanionAppLifecycleManager(
     // session before acting on it.
     private var currentEntry: LockerEntry? = null
 
-    // Fork: restart requests raised by the network-grant watcher. Funnelled through
-    // the same serially processed event stream as watch-side app changes (see init),
-    // so a restart can never interleave with a genuine app switch; both mutate the
-    // same session state. DROP_OLDEST because restart requests are idempotent.
-    private val restartRequests = MutableSharedFlow<Uuid>(
-        extraBufferCapacity = 1,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    // Fork: every decision about when sessions stop, start, and restart lives in
+    // the coordinator (see its KDoc for the model); this class only supplies the
+    // effects, which need the locker DAO, PBW cache, and WebView machinery that
+    // unit tests cannot construct.
+    private val sessionCoordinator = CompanionSessionCoordinator(
+        latestRunningApp = { appRunStateService.runningApp.value },
+        currentSessionApp = { currentEntry?.id },
+        stopSession = { handleAppStop() },
+        startSession = { uuid ->
+            // Fresh lookup on every start so a permission restart also picks up the
+            // newest locker entry for the app.
+            val lockerEntry = lockerEntryDao.getEntry(uuid)
+            if (lockerEntry != null && !lockerEntry.systemApp) {
+                handleNewRunningApp(lockerEntry)
+            }
+        },
     )
 
     private val runningApps: MutableStateFlow<List<CompanionApp>> = MutableStateFlow(emptyList())
@@ -146,17 +148,18 @@ class CompanionAppLifecycleManager(
             // activeAppScope, and a fresh session's watcher starts with a clean
             // transition history, so a restart cannot retrigger itself.
             if (newApps.any { it is PKJSApp }) {
+                // Read here, where the coordinator has already counted this
+                // session's start, so the request stays pinned to THIS session; a
+                // read at emission time could adopt a successor session's
+                // generation and defeat the coordinator's staleness check.
+                val sessionGeneration = sessionCoordinator.currentGeneration
                 activeAppScope.launch {
-                    var previous: Boolean? = null
                     watchappPermissions
                         .watchappPermissionGranted(lockerEntry.id, LockerAppPermissionType.Network)
-                        .distinctUntilChanged()
-                        .collect { allowed ->
-                            if (previous == false && allowed) {
-                                logger.d { "Network grant for ${lockerEntry.id} allowed mid-session; requesting restart" }
-                                restartRequests.tryEmit(lockerEntry.id)
-                            }
-                            previous = allowed
+                        .denyToAllowTransitions()
+                        .collect {
+                            logger.d { "Network grant for ${lockerEntry.id} allowed mid-session; requesting restart" }
+                            sessionCoordinator.requestRestart(lockerEntry.id, sessionGeneration)
                         }
                 }
             }
@@ -205,50 +208,12 @@ class CompanionAppLifecycleManager(
             watchInfo,
             appMessagesService
         )
-        // Fork: watch-side app changes and permission-triggered restart requests are
-        // merged into one serially collected stream, so the two kinds of event can
-        // never interleave; both tear down and rebuild the same session state. A
-        // restart request is only honoured if it still targets the entry that is
-        // currently running (the running app may have changed between the request
-        // being raised and processed).
-        merge(
-            appRunStateService.runningApp.map { SessionEvent.AppChanged(it) },
-            restartRequests.map { SessionEvent.RestartRequested(it) },
-        ).onEach { event ->
-            when (event) {
-                is SessionEvent.AppChanged -> {
-                    handleAppStop()
-                    if (event.uuid != null) {
-                        val lockerEntry = lockerEntryDao.getEntry(event.uuid)
-                        lockerEntry?.let {
-                            if (!it.systemApp) {
-                                handleNewRunningApp(lockerEntry)
-                            }
-                        }
-                    }
-                }
-
-                is SessionEvent.RestartRequested -> {
-                    val entry = currentEntry
-                    if (entry != null && entry.id == event.uuid) {
-                        logger.d { "Restarting companion apps for ${event.uuid} after network grant" }
-                        handleAppStop()
-                        handleNewRunningApp(entry)
-                    }
-                }
-            }
-        }.onCompletion {
-            // Unsure if this is needed
-            handleAppStop()
-        }.launchIn(connectionScope)
+        // Fork: session decisions live in CompanionSessionCoordinator; this wiring
+        // stays thin so upstream merges only touch the effect lambdas above.
+        connectionScope.launch {
+            sessionCoordinator.run(appRunStateService.runningApp)
+        }
     }
-}
-
-// Fork: event vocabulary for the serialized session stream in
-// CompanionAppLifecycleManager.init.
-private sealed class SessionEvent {
-    data class AppChanged(val uuid: Uuid?) : SessionEvent()
-    data class RestartRequested(val uuid: Uuid) : SessionEvent()
 }
 
 /**

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/CompanionSessionCoordinator.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/CompanionSessionCoordinator.kt
@@ -1,0 +1,135 @@
+package io.rebble.libpebblecommon.connection.endpointmanager
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+import kotlin.uuid.Uuid
+
+// Fork: event vocabulary for the serialized companion session stream.
+internal sealed class SessionEvent {
+    data class AppChanged(val uuid: Uuid?) : SessionEvent()
+    data class RestartRequested(val uuid: Uuid, val generation: Long) : SessionEvent()
+}
+
+/**
+ * Fork: the decision layer for companion app session lifecycle. Watch-side app
+ * changes and permission-triggered restart requests are merged into one serially
+ * collected stream: both kinds of event tear down and rebuild the same session
+ * state, so they must never interleave. The effects (stopping and starting real
+ * sessions) are injected, because they live in CompanionAppLifecycleManager among
+ * Room- and WebView-backed machinery a unit test cannot construct; every decision
+ * about when they run lives here, pinned by CompanionSessionCoordinatorTest.
+ *
+ * Decision model:
+ *  - [SessionEvent.AppChanged] is conflated to the newest watch state: an event is
+ *    skipped when it equals the last processed value (a brief switch away and back
+ *    must not restart a surviving session) or when it no longer matches the latest
+ *    running app (each stale app would otherwise get a full session build and
+ *    teardown, PBW download and WebView included, delaying the app actually in the
+ *    foreground).
+ *  - [SessionEvent.RestartRequested] is honoured only when it still targets the
+ *    live session, checked as app uuid AND session generation: a dying session's
+ *    watcher can race its request past teardown, and by the time the request is
+ *    processed a fresh session of the same app may already be running with the
+ *    grant in place, which the uuid alone cannot detect.
+ */
+internal class CompanionSessionCoordinator(
+    private val latestRunningApp: () -> Uuid?,
+    private val currentSessionApp: () -> Uuid?,
+    private val stopSession: suspend () -> Unit,
+    private val startSession: suspend (Uuid) -> Unit,
+) {
+    private val logger = Logger.withTag("CompanionSessionCoordinator")
+
+    // Restart requests raised by session-bound permission watchers. DROP_OLDEST
+    // because restart requests are idempotent for the session they target.
+    private val restartRequests = MutableSharedFlow<SessionEvent.RestartRequested>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    /**
+     * Identifies the session most recently started, so a restart request can be
+     * pinned to the session that raised it. Read it when launching a session-bound
+     * watcher and pass that value to [requestRestart]; reading it any later (in
+     * particular inside the watcher's emission handler) could adopt a successor
+     * session's generation and defeat the staleness check.
+     */
+    var currentGeneration: Long = 0L
+        private set
+
+    // Last AppChanged value that passed the skip checks. Deliberately tracks what
+    // was processed, not what is running: a value must be considered handled even
+    // if the session it started later failed, matching how a conflating collector
+    // treats a delivered value.
+    private var lastProcessedApp: Uuid? = null
+
+    fun requestRestart(uuid: Uuid, generation: Long) {
+        restartRequests.tryEmit(SessionEvent.RestartRequested(uuid, generation))
+    }
+
+    /** Collects the merged event stream until the caller's scope dies. */
+    suspend fun run(runningApp: Flow<Uuid?>) {
+        merge(
+            runningApp.map { SessionEvent.AppChanged(it) },
+            restartRequests,
+        )
+            .onEach { process(it) }
+            .onCompletion {
+                // Unsure if this is needed
+                stopSession()
+            }
+            .collect()
+    }
+
+    // Called only from the single collector in [run]; the decision state above is
+    // confined to that collector.
+    internal suspend fun process(event: SessionEvent) {
+        when (event) {
+            is SessionEvent.AppChanged -> {
+                if (event.uuid == lastProcessedApp) return
+                if (event.uuid != latestRunningApp()) {
+                    logger.d { "Skipping stale app change to ${event.uuid}" }
+                    return
+                }
+                lastProcessedApp = event.uuid
+                stopSession()
+                if (event.uuid != null) {
+                    currentGeneration++
+                    startSession(event.uuid)
+                }
+            }
+
+            is SessionEvent.RestartRequested -> {
+                if (currentSessionApp() != event.uuid) return
+                if (currentGeneration != event.generation) return
+                logger.d { "Restarting companion apps for ${event.uuid} after permission grant" }
+                stopSession()
+                currentGeneration++
+                startSession(event.uuid)
+            }
+        }
+    }
+}
+
+/**
+ * Emits once each time the upstream grant flips from denied to allowed. The initial
+ * value never emits (a session that loads with the grant already in place needs no
+ * restart), and repeated equal values are ignored.
+ */
+internal fun Flow<Boolean>.denyToAllowTransitions(): Flow<Unit> = flow {
+    var previous: Boolean? = null
+    collect { allowed ->
+        if (previous == false && allowed) {
+            emit(Unit)
+        }
+        previous = allowed
+    }
+}

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/dao/LockerAppPermissionDao.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/dao/LockerAppPermissionDao.kt
@@ -20,8 +20,6 @@ interface LockerAppPermissionDao {
     // Fork: needed for the tri-state per-app model. Removing the (app, permission)
     // row is how "follow the global default" is represented: absence of a row
     // means the app has no explicit override, so the global default applies.
-    // deleteByAppUuid above would wipe every permission type for the app, which is
-    // not what a single-toggle "reset to default" should do.
     @Query("DELETE FROM LockerAppPermission WHERE appUuid = :appUuid AND permission = :permission")
     suspend fun deleteByAppUuidAndPermission(appUuid: Uuid, permission: LockerAppPermissionType)
 

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/dao/LockerAppPermissionDao.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/dao/LockerAppPermissionDao.kt
@@ -6,6 +6,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import io.rebble.libpebblecommon.database.entity.LockerAppPermission
 import io.rebble.libpebblecommon.database.entity.LockerAppPermissionType
+import kotlinx.coroutines.flow.Flow
 import kotlin.uuid.Uuid
 
 @Dao
@@ -16,9 +17,22 @@ interface LockerAppPermissionDao {
     @Query("DELETE FROM LockerAppPermission WHERE appUuid = :appUuid")
     suspend fun deleteByAppUuid(appUuid: Uuid)
 
+    // Fork: needed for the tri-state per-app model. Removing the (app, permission)
+    // row is how "follow the global default" is represented: absence of a row
+    // means the app has no explicit override, so the global default applies.
+    // deleteByAppUuid above would wipe every permission type for the app, which is
+    // not what a single-toggle "reset to default" should do.
+    @Query("DELETE FROM LockerAppPermission WHERE appUuid = :appUuid AND permission = :permission")
+    suspend fun deleteByAppUuidAndPermission(appUuid: Uuid, permission: LockerAppPermissionType)
+
     @Query("SELECT * FROM LockerAppPermission WHERE appUuid = :appUuid")
     suspend fun getByAppUuid(appUuid: Uuid): List<LockerAppPermission>
 
     @Query("SELECT * FROM LockerAppPermission WHERE appUuid = :appUuid AND permission = :permission")
     suspend fun getByAppUuidAndPermission(appUuid: Uuid, permission: LockerAppPermissionType): LockerAppPermission?
+
+    // Fork: reactive variant so settings/detail UI reflects toggles live and the
+    // per-app WebView enforcement can re-evaluate without polling.
+    @Query("SELECT * FROM LockerAppPermission WHERE appUuid = :appUuid AND permission = :permission")
+    fun getByAppUuidAndPermissionFlow(appUuid: Uuid, permission: LockerAppPermissionType): Flow<LockerAppPermission?>
 }

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/LockerAppPermission.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/database/entity/LockerAppPermission.kt
@@ -12,6 +12,16 @@ data class LockerAppPermission(
     val granted: Boolean = true,
 )
 
+// Persisted as TEXT by name (see the Room schema: `permission` column is TEXT),
+// so entries may be reordered freely, but never rename an existing constant
+// without a migration: a rename orphans every stored row for that permission.
 enum class LockerAppPermissionType {
-    Location
+    Location,
+
+    // Fork: governs whether a watchapp/watchface's phone-side PebbleKit JS may
+    // reach the network at all (XHR/fetch/WebSocket, plus the phone-side weather
+    // interceptors that egress on the app's behalf). Upstream only ever modelled
+    // Location here and left even that ungated; Network is new to the fork's
+    // watchapp-permission system.
+    Network,
 }

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/di/LibPebbleModule.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/di/LibPebbleModule.kt
@@ -115,6 +115,8 @@ import io.rebble.libpebblecommon.js.RemoteTimelineEmulator
 import io.rebble.libpebblecommon.locker.Locker
 import io.rebble.libpebblecommon.locker.LockerPBWCache
 import io.rebble.libpebblecommon.locker.StaticLockerPBWCache
+import io.rebble.libpebblecommon.locker.WatchappPermissionResolver
+import io.rebble.libpebblecommon.locker.WatchappPermissions
 import io.rebble.libpebblecommon.locker.WebSyncManagerProvider
 import io.rebble.libpebblecommon.metadata.WatchColor
 import io.rebble.libpebblecommon.notification.ContactsApi
@@ -370,6 +372,11 @@ fun initKoin(
                 singleOf(::RemoteTimelineEmulator)
                 singleOf(::WeatherManager)
                 singleOf(::HttpInterceptorManager)
+                // Fork: owns the tri-state per-app watchapp permission resolution.
+                // Bound to the interface for LibPebble/UI, and also resolvable as the
+                // concrete type for the JS enforcement sites that inject it directly.
+                single { WatchappPermissionResolver(get(), get()) } binds
+                        arrayOf(WatchappPermissionResolver::class, WatchappPermissions::class)
                 singleOf(::RealWatchPrefs) bind WatchPrefs::class
                 singleOf(::WebSyncManager) bind RequestSync::class
                 singleOf(::TimelineApi) bind Timeline::class
@@ -405,6 +412,8 @@ fun initKoin(
                         get(),
                         get(),
                         get(),
+                        get(),
+                        // watchappPermissions
                         get(),
                     )
                 } bind LibPebble::class

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/js/GeolocationInterface.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/js/GeolocationInterface.kt
@@ -10,6 +10,8 @@ import io.rebble.libpebblecommon.util.SystemGeolocation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import org.koin.core.component.inject
 import kotlin.time.Duration
@@ -109,13 +111,29 @@ abstract class GeolocationInterface(
         logger.d { "watchPosition(highAccuracy=$highAccuracy)" }
         val highAccuracyBool = highAccuracy > 0
         val job = scope.launch {
-            if (!geolocationPermissionGranted()) {
-                triggerPositionResultWatch(id.toInt(), GeolocationPositionResult.Error("Location permission not granted"))
-                return@launch
-            }
-            systemGeolocation.watchPosition(interval.coerceAtLeast(200.0).milliseconds, highAccuracyBool).collect { result ->
-                triggerPositionResultWatch(id.toInt(), result)
-            }
+            // The grant is enforced for the life of the watch, not only at
+            // subscription time: a watchface can hold a subscription for days, so a
+            // one-shot check would keep streaming phone GPS long after the user
+            // revoked access. collectLatest on the resolved grant cancels the
+            // in-flight GPS stream the moment the grant flips to deny (per-app
+            // override or global default) and restarts it if the grant returns.
+            // Denial is reported to the JS callback each time it takes effect; the
+            // watch itself stays registered until the app clears it, matching
+            // geolocation-spec behaviour for a watch awaiting permission.
+            watchappPermissions.watchappPermissionGranted(
+                Uuid.parse(jsRunner.appInfo.uuid),
+                LockerAppPermissionType.Location,
+            )
+                .distinctUntilChanged()
+                .collectLatest { granted ->
+                    if (!granted) {
+                        triggerPositionResultWatch(id.toInt(), GeolocationPositionResult.Error("Location permission not granted"))
+                    } else {
+                        systemGeolocation.watchPosition(interval.coerceAtLeast(200.0).milliseconds, highAccuracyBool).collect { result ->
+                            triggerPositionResultWatch(id.toInt(), result)
+                        }
+                    }
+                }
         }
         watchJobs[id.toInt()] = job
         return id.toInt()

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/js/GeolocationInterface.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/js/GeolocationInterface.kt
@@ -2,9 +2,9 @@ package io.rebble.libpebblecommon.js
 
 import co.touchlab.kermit.Logger
 import io.ktor.http.quote
-import io.rebble.libpebblecommon.database.dao.LockerAppPermissionDao
 import io.rebble.libpebblecommon.database.entity.LockerAppPermissionType
 import io.rebble.libpebblecommon.di.LibPebbleKoinComponent
+import io.rebble.libpebblecommon.locker.WatchappPermissionResolver
 import io.rebble.libpebblecommon.util.GeolocationPositionResult
 import io.rebble.libpebblecommon.util.SystemGeolocation
 import kotlinx.coroutines.CoroutineScope
@@ -21,7 +21,7 @@ abstract class GeolocationInterface(
     private val jsRunner: JsRunner,
 ): LibPebbleKoinComponent {
     private val logger = Logger.withTag("GeolocationInterface")
-    private val permissionDao: LockerAppPermissionDao by inject()
+    private val watchappPermissions: WatchappPermissionResolver by inject()
     private val systemGeolocation: SystemGeolocation by inject()
     private var requestIDs = (1..Int.MAX_VALUE).iterator()
     private var watchIDs = (1..Int.MAX_VALUE).iterator()
@@ -69,11 +69,17 @@ abstract class GeolocationInterface(
         }
     }
 
+    // Fork: resolve the app's Location grant through the tri-state model (per-app
+    // override, else the global default). Upstream read a per-app row that nothing
+    // ever wrote and treated a missing row as "granted", so the gate was inert and
+    // every watchapp got phone GPS silently. Now a missing/FollowGlobal app inherits
+    // the deny-by-default global, and denial is reported back to the JS callback as a
+    // geolocation error rather than being swallowed.
     private suspend fun geolocationPermissionGranted(): Boolean =
-        permissionDao.getByAppUuidAndPermission(
+        watchappPermissions.isWatchappPermissionGranted(
             Uuid.parse(jsRunner.appInfo.uuid),
-            LockerAppPermissionType.Location
-        )?.granted != false //TODO: deny by default?
+            LockerAppPermissionType.Location,
+        )
 
     open fun getRequestCallbackID() = getNextRequestID()
     open fun getWatchCallbackID() = getNextWatchID()

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/js/GeolocationInterface.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/js/GeolocationInterface.kt
@@ -135,12 +135,39 @@ abstract class GeolocationInterface(
                     }
                 }
         }
-        watchJobs[id.toInt()] = job
+        registerWatchJob(id.toInt(), job)
         return id.toInt()
+    }
+
+    private fun registerWatchJob(id: Int, job: Job) {
+        // A reused id replaces its previous registration, so the replaced job must
+        // be cancelled here or its grant collector would keep running unreachable
+        // for the rest of the session.
+        watchJobs.remove(id)?.cancel("Watch replaced")
+        // Evict oldest-first at the cap so an app that retries watchPosition with
+        // fresh ids after each error (and never calls clearWatch) converges to its
+        // newest registrations instead of accumulating collectors for a session
+        // that can last days.
+        while (watchJobs.size >= MAX_ACTIVE_WATCHES) {
+            val oldest = watchJobs.keys.first()
+            logger.w { "watchPosition: evicting watch $oldest, limit is $MAX_ACTIVE_WATCHES active watches" }
+            watchJobs.remove(oldest)?.cancel("Watch evicted")
+        }
+        watchJobs[id] = job
     }
 
     open fun clearWatch(id: Int) {
         logger.d { "clearWatch()" }
         watchJobs.remove(id)?.cancel("Watch cleared")
+    }
+
+    companion object {
+        // Hard cap on concurrently registered watchPosition watches per session.
+        // Every registration pins a live grant collector until it is cleared or
+        // the session ends (denied watches included, so a re-grant can resume
+        // them), and the bridge is callable from arbitrary page JS, so without a
+        // cap a retry loop grows the collector set for the whole session. Sixteen
+        // is far above any legitimate concurrent use.
+        internal const val MAX_ACTIVE_WATCHES = 16
     }
 }

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/js/PrivatePKJSInterface.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/js/PrivatePKJSInterface.kt
@@ -4,6 +4,8 @@ import co.touchlab.kermit.Logger
 import io.rebble.cobble.shared.data.js.ActivePebbleWatchInfo
 import io.rebble.cobble.shared.data.js.fromWatchInfo
 import io.rebble.libpebblecommon.NotificationConfigFlow
+import io.rebble.libpebblecommon.database.entity.LockerAppPermissionType
+import io.rebble.libpebblecommon.locker.WatchappPermissionResolver
 import io.rebble.libpebblecommon.services.appmessage.AppMessageResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -33,6 +35,7 @@ abstract class PrivatePKJSInterface(
     private val remoteTimelineEmulator: RemoteTimelineEmulator,
     private val httpInterceptorManager: HttpInterceptorManager,
     private val notificationConfigFlow: NotificationConfigFlow,
+    private val watchappPermissions: WatchappPermissionResolver,
 ) {
     companion object {
         private val logger = Logger.withTag("PrivatePKJSInterface")
@@ -88,6 +91,18 @@ abstract class PrivatePKJSInterface(
     open fun onIntercepted(callbackId: String, url: String, method: String, body: String?) {
         val uuid = Uuid.parse(jsRunner.appInfo.uuid)
         scope.launch {
+            // Fork network gate (deterministic, phone-side-egress layer). The phone-side
+            // interceptors (weather) fetch from the network on the app's behalf, so a
+            // network-denied app must not be able to reach them. This bridge method is
+            // exposed directly on `_Pebble`, so a hostile bundle can call it without
+            // going through the XHR shim; gating here (not only in JS) is what actually
+            // closes that vector. Denial surfaces to the app as a 500, i.e. a failed
+            // request, mirroring genuine offline behaviour.
+            if (!watchappPermissions.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network)) {
+                logger.d { "Network denied for $uuid; refusing intercepted request to $url" }
+                jsRunner.signalInterceptResponse(callbackId, InterceptResponse.ERROR)
+                return@launch
+            }
             val result = httpInterceptorManager.onIntercepted(url, method, body, uuid)
             jsRunner.signalInterceptResponse(callbackId, result)
         }

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/locker/Locker.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/locker/Locker.kt
@@ -81,6 +81,7 @@ class Locker(
     private val lockerEntryDao = database.lockerEntryDao()
     private val timelinePinDao = database.timelinePinDao()
     private val timelineReminderDao = database.timelineReminderDao()
+    private val lockerAppPermissionDao = database.lockerAppPermissionDao()
 
     companion object {
         private val logger = Logger.withTag("Locker")
@@ -183,6 +184,12 @@ class Locker(
         }
         lockerEntryDao.markForDeletion(id)
         timelinePinDao.markAllForDeletionByParentIdsWithReminders(listOf(id), timelineReminderDao)
+        // A removed app's explicit permission grants must not outlive it. PBW UUIDs are
+        // self-declared, so a row left behind would be inherited by any later install
+        // claiming the same UUID (sideloads included), silently bypassing the
+        // deny-by-default baseline without fresh consent. Deleting here also matches
+        // the platform convention that uninstalling an app forfeits its grants.
+        lockerAppPermissionDao.deleteByAppUuid(id)
         if (lockerEntry.sideloaded) {
             logger.d { "Requesting locker sync after removing sideloaded app" }
             // If it was sideloaded, trigger a resync (in case the same app is in the locker).

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/locker/Locker.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/locker/Locker.kt
@@ -251,6 +251,13 @@ class Locker(
         logger.d { "deleting: $toDelete" }
         lockerEntryDao.markAllForDeletion(toDelete)
         timelinePinDao.markAllForDeletionByParentIdsWithReminders(toDelete, timelineReminderDao)
+        // Same invariant as removeApp: an app's explicit permission grants must not
+        // outlive its locker entry, because PBW UUIDs are self-declared and a later
+        // install claiming a departed app's UUID would inherit them without fresh
+        // consent. This sync path is unreachable while the fork is permanently
+        // signed out (fetchLocker always returns null), but it must stay safe if an
+        // upstream merge or a future sync backend ever revives it.
+        toDelete.forEach { lockerAppPermissionDao.deleteByAppUuid(it) }
         performCacheCleanup()
     }
 

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/locker/WatchappPermissions.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/locker/WatchappPermissions.kt
@@ -1,0 +1,118 @@
+package io.rebble.libpebblecommon.locker
+
+import io.rebble.libpebblecommon.LibPebbleConfigFlow
+import io.rebble.libpebblecommon.database.dao.LockerAppPermissionDao
+import io.rebble.libpebblecommon.database.entity.LockerAppPermission
+import io.rebble.libpebblecommon.database.entity.LockerAppPermissionType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlin.uuid.Uuid
+
+/**
+ * Fork: per-app, tri-state permission model for the phone-side capabilities the
+ * app grants to third-party watchapps/watchfaces (their PebbleKit JS running in a
+ * WebView on the phone).
+ *
+ * [FollowGlobal] is the absence of an explicit choice: the app inherits the global
+ * default from [io.rebble.libpebblecommon.WatchConfig]. [Allow]/[Deny] are explicit
+ * per-app overrides that win over the global default in either direction. This is
+ * modelled in storage as the presence/absence of a [LockerAppPermission] row:
+ *  - no row            -> FollowGlobal
+ *  - row(granted=true) -> Allow
+ *  - row(granted=false)-> Deny
+ * so "reset to default" is a row delete, not a third stored state.
+ */
+enum class PermissionSetting {
+    FollowGlobal,
+    Allow,
+    Deny,
+}
+
+/**
+ * Read/observe/set the tri-state per-app permissions, and resolve them against the
+ * global defaults into a single effective grant. This is the one place that owns the
+ * FollowGlobal-vs-default resolution so every enforcement site (geolocation bridge,
+ * WebView network gate, phone-side interceptor) and the UI agree on the answer.
+ */
+interface WatchappPermissions {
+    /** The stored tri-state choice for one app + capability. */
+    fun watchappPermissionSetting(uuid: Uuid, type: LockerAppPermissionType): Flow<PermissionSetting>
+
+    /** The resolved effective grant (tri-state collapsed against the global default). */
+    fun watchappPermissionGranted(uuid: Uuid, type: LockerAppPermissionType): Flow<Boolean>
+
+    /** One-shot resolved grant, for enforcement sites that only need a snapshot. */
+    suspend fun isWatchappPermissionGranted(uuid: Uuid, type: LockerAppPermissionType): Boolean
+
+    /** Current global default for a capability (the value FollowGlobal apps inherit). */
+    fun globalDefault(type: LockerAppPermissionType): Boolean
+
+    suspend fun setWatchappPermission(
+        uuid: Uuid,
+        type: LockerAppPermissionType,
+        setting: PermissionSetting,
+    )
+}
+
+class WatchappPermissionResolver(
+    private val permissionDao: LockerAppPermissionDao,
+    private val configFlow: LibPebbleConfigFlow,
+) : WatchappPermissions {
+
+    override fun globalDefault(type: LockerAppPermissionType): Boolean =
+        configFlow.value.watchConfig.globalDefaultFor(type)
+
+    override fun watchappPermissionSetting(
+        uuid: Uuid,
+        type: LockerAppPermissionType,
+    ): Flow<PermissionSetting> =
+        permissionDao.getByAppUuidAndPermissionFlow(uuid, type).map { it.toSetting() }
+
+    override fun watchappPermissionGranted(
+        uuid: Uuid,
+        type: LockerAppPermissionType,
+    ): Flow<Boolean> =
+        // Recomputes when either the per-app row or the global default changes, so a
+        // live global-default toggle immediately re-resolves every FollowGlobal app.
+        combine(
+            permissionDao.getByAppUuidAndPermissionFlow(uuid, type),
+            configFlow.flow,
+        ) { row, config ->
+            row?.granted ?: config.watchConfig.globalDefaultFor(type)
+        }
+
+    override suspend fun isWatchappPermissionGranted(
+        uuid: Uuid,
+        type: LockerAppPermissionType,
+    ): Boolean =
+        permissionDao.getByAppUuidAndPermission(uuid, type)?.granted ?: globalDefault(type)
+
+    override suspend fun setWatchappPermission(
+        uuid: Uuid,
+        type: LockerAppPermissionType,
+        setting: PermissionSetting,
+    ) {
+        when (setting) {
+            PermissionSetting.FollowGlobal ->
+                permissionDao.deleteByAppUuidAndPermission(uuid, type)
+            PermissionSetting.Allow ->
+                permissionDao.insertOrReplace(LockerAppPermission(uuid, type, granted = true))
+            PermissionSetting.Deny ->
+                permissionDao.insertOrReplace(LockerAppPermission(uuid, type, granted = false))
+        }
+    }
+}
+
+private fun LockerAppPermission?.toSetting(): PermissionSetting = when {
+    this == null -> PermissionSetting.FollowGlobal
+    granted -> PermissionSetting.Allow
+    else -> PermissionSetting.Deny
+}
+
+private fun io.rebble.libpebblecommon.WatchConfig.globalDefaultFor(
+    type: LockerAppPermissionType,
+): Boolean = when (type) {
+    LockerAppPermissionType.Network -> watchappDefaultNetworkAllowed
+    LockerAppPermissionType.Location -> watchappDefaultLocationAllowed
+}

--- a/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/locker/WatchappPermissions.kt
+++ b/libpebble3/src/commonMain/kotlin/io/rebble/libpebblecommon/locker/WatchappPermissions.kt
@@ -45,8 +45,12 @@ interface WatchappPermissions {
     /** One-shot resolved grant, for enforcement sites that only need a snapshot. */
     suspend fun isWatchappPermissionGranted(uuid: Uuid, type: LockerAppPermissionType): Boolean
 
-    /** Current global default for a capability (the value FollowGlobal apps inherit). */
-    fun globalDefault(type: LockerAppPermissionType): Boolean
+    /**
+     * The global default for a capability (the value FollowGlobal apps inherit), as a
+     * live flow so the UI can label the "Default" choice with what it currently
+     * resolves to and track toggles of the default while visible.
+     */
+    fun globalDefault(type: LockerAppPermissionType): Flow<Boolean>
 
     suspend fun setWatchappPermission(
         uuid: Uuid,
@@ -60,8 +64,8 @@ class WatchappPermissionResolver(
     private val configFlow: LibPebbleConfigFlow,
 ) : WatchappPermissions {
 
-    override fun globalDefault(type: LockerAppPermissionType): Boolean =
-        configFlow.value.watchConfig.globalDefaultFor(type)
+    override fun globalDefault(type: LockerAppPermissionType): Flow<Boolean> =
+        configFlow.flow.map { it.watchConfig.globalDefaultFor(type) }
 
     override fun watchappPermissionSetting(
         uuid: Uuid,
@@ -86,7 +90,8 @@ class WatchappPermissionResolver(
         uuid: Uuid,
         type: LockerAppPermissionType,
     ): Boolean =
-        permissionDao.getByAppUuidAndPermission(uuid, type)?.granted ?: globalDefault(type)
+        permissionDao.getByAppUuidAndPermission(uuid, type)?.granted
+            ?: configFlow.value.watchConfig.globalDefaultFor(type)
 
     override suspend fun setWatchappPermission(
         uuid: Uuid,

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/CompanionSessionCoordinatorTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/connection/endpointmanager/CompanionSessionCoordinatorTest.kt
@@ -1,0 +1,219 @@
+package io.rebble.libpebblecommon.connection.endpointmanager
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.uuid.Uuid
+
+/**
+ * Pins the fork's companion session decision model: watch-side app changes are
+ * conflated to the newest state (no session churn for apps the watch has already
+ * left), restart requests serialize with app changes and are dropped unless they
+ * still target the exact session that raised them, and the deny-to-allow detector
+ * fires only on that transition. CompanionAppLifecycleManager itself cannot be
+ * constructed here (Room-backed dependencies), which is why the decisions live in
+ * the coordinator with injected effects; these tests drive the real coordinator
+ * with recording effects whose begin/end markers make any interleaving visible.
+ */
+class CompanionSessionCoordinatorTest {
+    private val appA = Uuid.parse("00000000-0000-0000-0000-0000000000aa")
+    private val appB = Uuid.parse("00000000-0000-0000-0000-0000000000bb")
+    private val appC = Uuid.parse("00000000-0000-0000-0000-0000000000cc")
+
+    private class Harness {
+        val runningApp = MutableStateFlow<Uuid?>(null)
+        val log = mutableListOf<String>()
+        var currentApp: Uuid? = null
+
+        /**
+         * When set, startSession parks on it after its begin marker, keeping the
+         * single consumer busy so later events queue behind it.
+         */
+        var startGate: CompletableDeferred<Unit>? = null
+
+        val coordinator = CompanionSessionCoordinator(
+            latestRunningApp = { runningApp.value },
+            currentSessionApp = { currentApp },
+            stopSession = {
+                currentApp = null
+                log += "stop"
+            },
+            startSession = { uuid ->
+                // The real effect assigns currentEntry before its first suspension
+                // point; mirror that so restart guards see the app mid-build.
+                currentApp = uuid
+                log += "start:$uuid:begin"
+                startGate?.await()
+                log += "start:$uuid:end"
+            },
+        )
+    }
+
+    private fun TestScope.harness(): Harness {
+        val h = Harness()
+        backgroundScope.launch { h.coordinator.run(h.runningApp) }
+        return h
+    }
+
+    @Test
+    fun appChangesStartAndStopSessions() = runTest {
+        val h = harness()
+        runCurrent()
+        // The initial null state matches the initial processed state: no effect.
+        assertEquals(emptyList(), h.log)
+
+        h.runningApp.value = appA
+        runCurrent()
+        assertEquals(listOf("stop", "start:$appA:begin", "start:$appA:end"), h.log)
+
+        h.runningApp.value = null
+        runCurrent()
+        assertEquals(listOf("stop", "start:$appA:begin", "start:$appA:end", "stop"), h.log)
+    }
+
+    @Test
+    fun rapidAppChangesConflateToTheLatest() = runTest {
+        val h = harness()
+        h.startGate = CompletableDeferred()
+        h.runningApp.value = appA
+        runCurrent()
+        assertEquals(listOf("stop", "start:$appA:begin"), h.log)
+
+        // Two switches land while A's session is still being built.
+        h.runningApp.value = appB
+        runCurrent()
+        h.runningApp.value = appC
+        runCurrent()
+
+        h.startGate!!.complete(Unit)
+        h.startGate = null
+        runCurrent()
+        // B never gets a session: by the time its event is processed the watch has
+        // already moved on, so building it would only delay C.
+        assertEquals(
+            listOf(
+                "stop", "start:$appA:begin", "start:$appA:end",
+                "stop", "start:$appC:begin", "start:$appC:end",
+            ),
+            h.log,
+        )
+    }
+
+    @Test
+    fun blipAwayAndBackKeepsTheSessionAlive() = runTest {
+        val h = harness()
+        h.startGate = CompletableDeferred()
+        h.runningApp.value = appA
+        runCurrent()
+
+        // The watch blips away and back before A's session finishes building.
+        h.runningApp.value = null
+        runCurrent()
+        h.runningApp.value = appA
+        runCurrent()
+
+        h.startGate!!.complete(Unit)
+        h.startGate = null
+        runCurrent()
+        // The null is stale (the watch is back on A) and the second A equals the
+        // last processed value; the surviving session must not be torn down.
+        assertEquals(listOf("stop", "start:$appA:begin", "start:$appA:end"), h.log)
+    }
+
+    @Test
+    fun restartRequestForTheLiveSessionRestartsIt() = runTest {
+        val h = harness()
+        h.runningApp.value = appA
+        runCurrent()
+
+        h.coordinator.requestRestart(appA, h.coordinator.currentGeneration)
+        runCurrent()
+        assertEquals(
+            listOf(
+                "stop", "start:$appA:begin", "start:$appA:end",
+                "stop", "start:$appA:begin", "start:$appA:end",
+            ),
+            h.log,
+        )
+    }
+
+    @Test
+    fun restartRequestFromAReplacedSessionIsDropped() = runTest {
+        val h = harness()
+        h.runningApp.value = appA
+        runCurrent()
+        val firstSessionGeneration = h.coordinator.currentGeneration
+
+        // The watch relaunches A: a fresh session of the same app.
+        h.runningApp.value = null
+        runCurrent()
+        h.runningApp.value = appA
+        runCurrent()
+        val logAfterRelaunch = h.log.toList()
+
+        // A request raised by the first session must not restart the second one;
+        // the second session already started with the grant in place, and the app
+        // uuid alone cannot tell the two sessions apart.
+        h.coordinator.requestRestart(appA, firstSessionGeneration)
+        runCurrent()
+        assertEquals(logAfterRelaunch, h.log)
+    }
+
+    @Test
+    fun restartRequestForADifferentAppIsDropped() = runTest {
+        val h = harness()
+        h.runningApp.value = appA
+        runCurrent()
+        val logAfterStart = h.log.toList()
+
+        h.coordinator.requestRestart(appB, h.coordinator.currentGeneration)
+        runCurrent()
+        assertEquals(logAfterStart, h.log)
+    }
+
+    @Test
+    fun restartRequestsSerializeWithAppChanges() = runTest {
+        val h = harness()
+        h.startGate = CompletableDeferred()
+        h.runningApp.value = appA
+        runCurrent()
+
+        // A restart raised while the session is still being built must wait for
+        // the build to finish; the begin/end markers would expose interleaving.
+        h.coordinator.requestRestart(appA, h.coordinator.currentGeneration)
+        runCurrent()
+        assertEquals(listOf("stop", "start:$appA:begin"), h.log)
+
+        h.startGate!!.complete(Unit)
+        h.startGate = null
+        runCurrent()
+        assertEquals(
+            listOf(
+                "stop", "start:$appA:begin", "start:$appA:end",
+                "stop", "start:$appA:begin", "start:$appA:end",
+            ),
+            h.log,
+        )
+    }
+
+    @Test
+    fun denyToAllowEmitsOnlyOnThatTransition() = runTest {
+        assertEquals(
+            0,
+            flowOf(true, true, false, false).denyToAllowTransitions().toList().size,
+            "allowed at load or revoked mid-session must not restart",
+        )
+        assertEquals(
+            2,
+            flowOf(false, true, true, false, true).denyToAllowTransitions().toList().size,
+            "each denied-to-allowed flip restarts exactly once",
+        )
+    }
+}

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/dao/FakeLockerAppPermissionDao.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/dao/FakeLockerAppPermissionDao.kt
@@ -1,0 +1,44 @@
+package io.rebble.libpebblecommon.database.dao
+
+import io.rebble.libpebblecommon.database.entity.LockerAppPermission
+import io.rebble.libpebblecommon.database.entity.LockerAppPermissionType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlin.uuid.Uuid
+
+/**
+ * In-memory stand-in for the Room DAO, backed by a single state flow so the reactive
+ * queries used by the permission resolver emit on change. Shared by every test that
+ * exercises the watchapp permission model (resolver, geolocation gate, PKJS bridge
+ * gate), so they all resolve through the same storage semantics as production:
+ * row absence = FollowGlobal.
+ */
+class FakeLockerAppPermissionDao : LockerAppPermissionDao {
+    private val rows = MutableStateFlow<Map<Pair<Uuid, LockerAppPermissionType>, LockerAppPermission>>(emptyMap())
+
+    override suspend fun insertOrReplace(permission: LockerAppPermission) {
+        rows.value = rows.value + ((permission.appUuid to permission.permission) to permission)
+    }
+
+    override suspend fun deleteByAppUuid(appUuid: Uuid) {
+        rows.value = rows.value.filterKeys { it.first != appUuid }
+    }
+
+    override suspend fun deleteByAppUuidAndPermission(appUuid: Uuid, permission: LockerAppPermissionType) {
+        rows.value = rows.value - (appUuid to permission)
+    }
+
+    override suspend fun getByAppUuid(appUuid: Uuid): List<LockerAppPermission> =
+        rows.value.values.filter { it.appUuid == appUuid }
+
+    override suspend fun getByAppUuidAndPermission(
+        appUuid: Uuid,
+        permission: LockerAppPermissionType,
+    ): LockerAppPermission? = rows.value[appUuid to permission]
+
+    override fun getByAppUuidAndPermissionFlow(
+        appUuid: Uuid,
+        permission: LockerAppPermissionType,
+    ): Flow<LockerAppPermission?> = rows.map { it[appUuid to permission] }
+}

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/dao/FakeTimelineDaos.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/database/dao/FakeTimelineDaos.kt
@@ -1,0 +1,100 @@
+package io.rebble.libpebblecommon.database.dao
+
+import io.rebble.libpebblecommon.database.entity.TimelinePin
+import io.rebble.libpebblecommon.database.entity.TimelinePinEntity
+import io.rebble.libpebblecommon.database.entity.TimelinePinSyncEntity
+import io.rebble.libpebblecommon.database.entity.TimelineReminder
+import io.rebble.libpebblecommon.database.entity.TimelineReminderEntity
+import io.rebble.libpebblecommon.database.entity.TimelineReminderSyncEntity
+import kotlinx.coroutines.flow.Flow
+import kotlin.uuid.Uuid
+
+/**
+ * Structural stand-ins for the timeline DAOs, for tests that need to construct
+ * timeline-adjacent classes (e.g. RemoteTimelineEmulator as a dependency of
+ * HttpInterceptorManager) without a Room database. Every member fails loudly:
+ * these exist to satisfy constructors on code paths the test never exercises,
+ * and an unexpected call means the test wandered onto a path it does not fake.
+ */
+class FakeTimelinePinRealDao : TimelinePinRealDao {
+    override fun dirtyRecordsForWatchInsert(
+        identifier: String,
+        timestampMs: Long,
+        insertOnlyAfterMs: Long,
+    ): Flow<List<TimelinePinEntity>> = TODO("not faked")
+
+    override fun dirtyRecordsForWatchDelete(
+        identifier: String,
+        timestampMs: Long,
+    ): Flow<List<TimelinePinEntity>> = TODO("not faked")
+
+    override suspend fun deleteStaleRecords(timestampMs: Long): Unit = TODO("not faked")
+
+    override suspend fun markSyncedToWatch(syncRecord: TimelinePinSyncEntity): Unit = TODO("not faked")
+
+    override suspend fun markDeletedFromWatch(syncRecord: TimelinePinSyncEntity): Unit = TODO("not faked")
+
+    override fun existsOnWatch(identifier: String, primaryKey: Uuid): Flow<Boolean> = TODO("not faked")
+
+    override suspend fun insertOrReplace(item: TimelinePinEntity): Unit = TODO("not faked")
+
+    override suspend fun insertOrReplaceAll(items: List<TimelinePinEntity>): Unit = TODO("not faked")
+
+    override suspend fun markForDeletion(itemId: Uuid): Unit = TODO("not faked")
+
+    override suspend fun markAllForDeletion(itemIds: List<Uuid>): Unit = TODO("not faked")
+
+    override suspend fun markAllDeletedFromWatch(identifier: String): Unit = TODO("not faked")
+
+    override suspend fun deleteSyncRecordsForDevicesWhichDontExist(): Unit = TODO("not faked")
+
+    override suspend fun getEntry(itemId: Uuid): TimelinePin? = TODO("not faked")
+
+    override fun getEntryFlow(itemId: Uuid): Flow<TimelinePin?> = TODO("not faked")
+
+    override suspend fun getPinsForWatchapp(parentId: Uuid): List<TimelinePin> = TODO("not faked")
+}
+
+/** See [FakeTimelinePinRealDao]. */
+class FakeTimelineReminderRealDao : TimelineReminderRealDao {
+    override fun dirtyRecordsForWatchInsert(
+        identifier: String,
+        timestampMs: Long,
+        insertOnlyAfterMs: Long,
+    ): Flow<List<TimelineReminderEntity>> = TODO("not faked")
+
+    override fun dirtyRecordsForWatchDelete(
+        identifier: String,
+        timestampMs: Long,
+    ): Flow<List<TimelineReminderEntity>> = TODO("not faked")
+
+    override suspend fun deleteStaleRecords(timestampMs: Long): Unit = TODO("not faked")
+
+    override suspend fun markSyncedToWatch(syncRecord: TimelineReminderSyncEntity): Unit = TODO("not faked")
+
+    override suspend fun markDeletedFromWatch(syncRecord: TimelineReminderSyncEntity): Unit = TODO("not faked")
+
+    override fun existsOnWatch(identifier: String, primaryKey: Uuid): Flow<Boolean> = TODO("not faked")
+
+    override suspend fun insertOrReplace(item: TimelineReminderEntity): Unit = TODO("not faked")
+
+    override suspend fun insertOrReplaceAll(items: List<TimelineReminderEntity>): Unit = TODO("not faked")
+
+    override suspend fun markForDeletion(itemId: Uuid): Unit = TODO("not faked")
+
+    override suspend fun markAllForDeletion(itemIds: List<Uuid>): Unit = TODO("not faked")
+
+    override suspend fun markAllDeletedFromWatch(identifier: String): Unit = TODO("not faked")
+
+    override suspend fun deleteSyncRecordsForDevicesWhichDontExist(): Unit = TODO("not faked")
+
+    override suspend fun getEntry(itemId: Uuid): TimelineReminder? = TODO("not faked")
+
+    override fun getEntryFlow(itemId: Uuid): Flow<TimelineReminder?> = TODO("not faked")
+
+    override suspend fun getRemindersForPin(parentId: Uuid): List<TimelineReminder> = TODO("not faked")
+
+    override suspend fun markForDeletionByParentId(parentId: Uuid): Unit = TODO("not faked")
+
+    override suspend fun markForDeletionByParentIds(parentIds: List<Uuid>): Unit = TODO("not faked")
+}

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/js/FakeJsRunner.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/js/FakeJsRunner.kt
@@ -1,0 +1,71 @@
+package io.rebble.libpebblecommon.js
+
+import io.rebble.libpebblecommon.connection.ConnectedPebbleDevice
+import io.rebble.libpebblecommon.connection.FakeAppMessages
+import io.rebble.libpebblecommon.connection.fakeWatch
+import io.rebble.libpebblecommon.database.entity.LockerEntry
+import io.rebble.libpebblecommon.metadata.pbw.appinfo.PbwAppInfo
+import io.rebble.libpebblecommon.metadata.pbw.appinfo.Resources
+import kotlinx.coroutines.channels.Channel
+import kotlinx.io.files.Path
+import kotlin.uuid.Uuid
+
+/**
+ * Recording JsRunner for unit tests of the bridge interfaces (geolocation gate,
+ * private PKJS interface). Captures everything the code under test signals back
+ * towards the app's JS so assertions can check what the app would have observed,
+ * without any real JS engine behind it.
+ */
+class FakeJsRunner(
+    appInfo: PbwAppInfo,
+    lockerEntry: LockerEntry,
+    device: CompanionAppDevice,
+) : JsRunner(appInfo, lockerEntry, Path("unused.js"), device, Channel(Channel.UNLIMITED)) {
+    val evals = mutableListOf<String>()
+    val interceptResponses = mutableListOf<Pair<String, InterceptResponse>>()
+
+    override suspend fun start() {}
+    override suspend fun stop() {}
+    override suspend fun loadAppJs(jsUrl: String) {}
+    override suspend fun signalInterceptResponse(callbackId: String, result: InterceptResponse) {
+        interceptResponses += callbackId to result
+    }
+    override suspend fun signalNewAppMessageData(data: String?): Boolean = true
+    override suspend fun signalTimelineToken(callId: String, token: String) {}
+    override suspend fun signalTimelineTokenFail(callId: String) {}
+    override suspend fun signalReady() {}
+    override suspend fun signalShowConfiguration() {}
+    override suspend fun signalWebviewClosed(data: String?) {}
+    override suspend fun eval(js: String) {
+        evals += js
+    }
+    override suspend fun evalWithResult(js: String): Any? {
+        evals += js
+        return null
+    }
+    override fun debugForceGC() {}
+}
+
+/** A runner for [uuid] wired to a fake connected watch; enough for bridge tests. */
+fun fakeJsRunner(uuid: Uuid): FakeJsRunner {
+    val watch = fakeWatch(connected = true) as ConnectedPebbleDevice
+    return FakeJsRunner(
+        appInfo = PbwAppInfo(
+            uuid = uuid.toString(),
+            shortName = "Test App",
+            versionLabel = "1.0",
+            resources = Resources(emptyList()),
+        ),
+        lockerEntry = LockerEntry(
+            id = uuid,
+            version = "1.0",
+            title = "Test App",
+            type = "watchapp",
+            developerName = "Test Developer",
+            configurable = false,
+            pbwVersionCode = "1",
+            platforms = emptyList(),
+        ),
+        device = CompanionAppDevice(watch.identifier, watch.watchInfo, FakeAppMessages()),
+    )
+}

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/js/GeolocationInterfaceTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/js/GeolocationInterfaceTest.kt
@@ -184,6 +184,53 @@ class GeolocationInterfaceTest {
     }
 
     @Test
+    fun reusingAWatchIdCancelsThePreviousRegistration() = runTest {
+        val f = fixture(this, locationDefault = true)
+        f.geo.watchPosition(id = 7.0, interval = 1000.0, highAccuracy = 0.0)
+        runCurrent()
+        assertEquals(1, f.systemGeolocation.activeWatchers)
+
+        // Same id again: the first registration must die with the overwrite, or a
+        // page re-registering its watch would leak one collector per call.
+        f.geo.watchPosition(id = 7.0, interval = 1000.0, highAccuracy = 0.0)
+        runCurrent()
+        assertEquals(1, f.systemGeolocation.activeWatchers, "id reuse must not stack streams")
+
+        f.geo.clearWatch(7)
+        runCurrent()
+        assertEquals(0, f.systemGeolocation.activeWatchers, "exactly one job may back a reused id")
+    }
+
+    @Test
+    fun deniedWatchRegistrationsAreBoundedByEviction() = runTest {
+        // A denied watch stays registered so a re-grant can resume it, which means
+        // an app retrying watchPosition with fresh ids after each denial (never
+        // calling clearWatch) would otherwise pin one grant collector per retry
+        // for a session that can last days.
+        val f = fixture(this, locationDefault = false)
+        val extra = 3
+        repeat(GeolocationInterface.MAX_ACTIVE_WATCHES + extra) { i ->
+            f.geo.watchPosition(id = (100 + i).toDouble(), interval = 1000.0, highAccuracy = 0.0)
+        }
+        runCurrent()
+        assertEquals(0, f.systemGeolocation.activeWatchers, "denied watches must not open GPS streams")
+
+        // A grant resumes every registration still tracked, so the stream count
+        // proves eviction bounded the denied backlog at the cap.
+        f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Location, PermissionSetting.Allow)
+        runCurrent()
+        assertEquals(
+            GeolocationInterface.MAX_ACTIVE_WATCHES,
+            f.systemGeolocation.activeWatchers,
+            "a retry loop must not accumulate unbounded watch registrations",
+        )
+
+        repeat(GeolocationInterface.MAX_ACTIVE_WATCHES + extra) { i -> f.geo.clearWatch(100 + i) }
+        runCurrent()
+        assertEquals(0, f.systemGeolocation.activeWatchers)
+    }
+
+    @Test
     fun getCurrentPositionIsGatedPerCall() = runTest {
         val f = fixture(this, locationDefault = false)
         f.systemGeolocation.currentPositionResult = position(4.0)

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/js/GeolocationInterfaceTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/js/GeolocationInterfaceTest.kt
@@ -1,0 +1,206 @@
+package io.rebble.libpebblecommon.js
+
+import io.rebble.libpebblecommon.LibPebbleConfig
+import io.rebble.libpebblecommon.LibPebbleConfigFlow
+import io.rebble.libpebblecommon.WatchConfig
+import io.rebble.libpebblecommon.database.dao.FakeLockerAppPermissionDao
+import io.rebble.libpebblecommon.database.entity.LockerAppPermissionType
+import io.rebble.libpebblecommon.di.LibPebbleKoinComponent
+import io.rebble.libpebblecommon.locker.PermissionSetting
+import io.rebble.libpebblecommon.locker.WatchappPermissionResolver
+import io.rebble.libpebblecommon.util.GeolocationPositionResult
+import io.rebble.libpebblecommon.util.SystemGeolocation
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.koin.core.module.Module
+import org.koin.dsl.module
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Instant
+import kotlin.uuid.Uuid
+
+/**
+ * Proves the location enforcement site actually consults the permission resolver and,
+ * for continuous watches, keeps enforcing it: a revocation mid-watch must cancel the
+ * running GPS stream (a watchface can hold one for days), a re-grant must restart it,
+ * and denial must surface to the app's JS callback as a geolocation error.
+ *
+ * GeolocationInterface takes its dependencies from the library's isolated Koin
+ * context, so each test loads a module with the fakes into that context and unloads
+ * it afterwards; no full DI graph is booted.
+ */
+class GeolocationInterfaceTest {
+    private val uuid = Uuid.parse("00000000-0000-0000-0000-0000000000aa")
+    private val koin = (object : LibPebbleKoinComponent {}).getKoin()
+    private var loadedModule: Module? = null
+
+    private class FakeSystemGeolocation : SystemGeolocation {
+        val positions = MutableSharedFlow<GeolocationPositionResult>(extraBufferCapacity = 16)
+        var activeWatchers = 0
+            private set
+        var currentPositionResult: GeolocationPositionResult =
+            GeolocationPositionResult.Error("not configured")
+
+        override suspend fun getCurrentPosition(
+            maximumAge: Duration?,
+            timeout: Duration?,
+            highAccuracy: Boolean,
+        ): GeolocationPositionResult = currentPositionResult
+
+        override suspend fun watchPosition(
+            interval: Duration,
+            highAccuracy: Boolean,
+        ): Flow<GeolocationPositionResult> = positions
+            .onStart { activeWatchers++ }
+            .onCompletion { activeWatchers-- }
+    }
+
+    private class Fixture(
+        val geo: GeolocationInterface,
+        val runner: FakeJsRunner,
+        val systemGeolocation: FakeSystemGeolocation,
+        val resolver: WatchappPermissionResolver,
+    )
+
+    private fun fixture(scope: CoroutineScope, locationDefault: Boolean = false): Fixture {
+        val resolver = WatchappPermissionResolver(
+            FakeLockerAppPermissionDao(),
+            LibPebbleConfigFlow(
+                MutableStateFlow(
+                    LibPebbleConfig(
+                        watchConfig = WatchConfig(watchappDefaultLocationAllowed = locationDefault),
+                    ),
+                ),
+            ),
+        )
+        val systemGeolocation = FakeSystemGeolocation()
+        val module = module {
+            single { resolver }
+            single<SystemGeolocation> { systemGeolocation }
+        }
+        koin.loadModules(listOf(module), allowOverride = true)
+        loadedModule = module
+        val runner = fakeJsRunner(uuid)
+        // The abstract class carries the whole gate; the platform subclasses only add
+        // bridge annotations, so an anonymous subclass exercises the production logic.
+        val geo = object : GeolocationInterface(scope, runner) {}
+        return Fixture(geo, runner, systemGeolocation, resolver)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        loadedModule?.let { koin.unloadModules(listOf(it)) }
+        loadedModule = null
+    }
+
+    private fun position(lat: Double) = GeolocationPositionResult.Success(
+        timestamp = Instant.fromEpochMilliseconds(0),
+        latitude = lat,
+        longitude = 0.0,
+        accuracy = 1.0,
+        altitude = null,
+        heading = null,
+        speed = null,
+    )
+
+    private fun Fixture.watchSuccessCount() =
+        runner.evals.count { it.startsWith("_PebbleGeoCB._resultWatchSuccess(7,") }
+
+    private fun Fixture.watchErrorCount() =
+        runner.evals.count { it.startsWith("_PebbleGeoCB._resultWatchError(7,") }
+
+    @Test
+    fun watchDeniedAtStartReportsErrorAndNeverStartsStream() = runTest {
+        val f = fixture(this, locationDefault = false)
+        f.geo.watchPosition(id = 7.0, interval = 1000.0, highAccuracy = 0.0)
+        runCurrent()
+        assertEquals(0, f.systemGeolocation.activeWatchers, "denied watch must not open a GPS stream")
+        assertEquals(1, f.watchErrorCount())
+        f.geo.clearWatch(7)
+    }
+
+    @Test
+    fun revokingLocationCancelsRunningStream() = runTest {
+        val f = fixture(this, locationDefault = true)
+        f.geo.watchPosition(id = 7.0, interval = 1000.0, highAccuracy = 0.0)
+        runCurrent()
+        assertEquals(1, f.systemGeolocation.activeWatchers)
+
+        f.systemGeolocation.positions.emit(position(1.0))
+        runCurrent()
+        assertEquals(1, f.watchSuccessCount())
+
+        // The user revokes while the watch is live: the stream must die immediately
+        // and the app must be told, not keep receiving GPS until the session ends.
+        f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Location, PermissionSetting.Deny)
+        runCurrent()
+        assertEquals(0, f.systemGeolocation.activeWatchers, "revocation must cancel the GPS stream")
+        assertEquals(1, f.watchErrorCount())
+
+        // Positions produced after revocation must never reach the app.
+        f.systemGeolocation.positions.emit(position(2.0))
+        runCurrent()
+        assertEquals(1, f.watchSuccessCount(), "no positions may be delivered after revocation")
+        f.geo.clearWatch(7)
+    }
+
+    @Test
+    fun regrantRestartsRevokedStream() = runTest {
+        val f = fixture(this, locationDefault = true)
+        f.geo.watchPosition(id = 7.0, interval = 1000.0, highAccuracy = 0.0)
+        runCurrent()
+        f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Location, PermissionSetting.Deny)
+        runCurrent()
+        assertEquals(0, f.systemGeolocation.activeWatchers)
+
+        f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Location, PermissionSetting.Allow)
+        runCurrent()
+        assertEquals(1, f.systemGeolocation.activeWatchers, "re-grant must restart the stream")
+        f.systemGeolocation.positions.emit(position(3.0))
+        runCurrent()
+        assertEquals(1, f.watchSuccessCount())
+        f.geo.clearWatch(7)
+    }
+
+    @Test
+    fun clearWatchStopsStreamAndGrantTracking() = runTest {
+        val f = fixture(this, locationDefault = true)
+        f.geo.watchPosition(id = 7.0, interval = 1000.0, highAccuracy = 0.0)
+        runCurrent()
+        assertEquals(1, f.systemGeolocation.activeWatchers)
+
+        f.geo.clearWatch(7)
+        runCurrent()
+        assertEquals(0, f.systemGeolocation.activeWatchers)
+    }
+
+    @Test
+    fun getCurrentPositionIsGatedPerCall() = runTest {
+        val f = fixture(this, locationDefault = false)
+        f.systemGeolocation.currentPositionResult = position(4.0)
+
+        f.geo.getCurrentPosition(id = 3.0, maximumAgeMs = -1.0, timeoutMs = -1.0, highAccuracy = 0.0)
+        runCurrent()
+        assertTrue(
+            f.runner.evals.any { it.startsWith("_PebbleGeoCB._resultGetError(3,") },
+            "denied getCurrentPosition must report an error to JS",
+        )
+
+        f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Location, PermissionSetting.Allow)
+        f.geo.getCurrentPosition(id = 4.0, maximumAgeMs = -1.0, timeoutMs = -1.0, highAccuracy = 0.0)
+        runCurrent()
+        assertTrue(
+            f.runner.evals.any { it.startsWith("_PebbleGeoCB._resultGetSuccess(4,") },
+            "granted getCurrentPosition must deliver the position",
+        )
+    }
+}

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/js/PrivatePKJSInterfaceGateTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/js/PrivatePKJSInterfaceGateTest.kt
@@ -1,0 +1,125 @@
+package io.rebble.libpebblecommon.js
+
+import io.rebble.libpebblecommon.LibPebbleConfig
+import io.rebble.libpebblecommon.LibPebbleConfigFlow
+import io.rebble.libpebblecommon.NotificationConfigFlow
+import io.rebble.libpebblecommon.WatchConfig
+import io.rebble.libpebblecommon.WatchConfigFlow
+import io.rebble.libpebblecommon.connection.TokenProvider
+import io.rebble.libpebblecommon.database.dao.FakeLockerAppPermissionDao
+import io.rebble.libpebblecommon.database.dao.FakeLockerEntryDao
+import io.rebble.libpebblecommon.database.dao.FakeTimelinePinRealDao
+import io.rebble.libpebblecommon.database.dao.FakeTimelineReminderRealDao
+import io.rebble.libpebblecommon.database.entity.LockerAppPermissionType
+import io.rebble.libpebblecommon.locker.PermissionSetting
+import io.rebble.libpebblecommon.locker.WatchappPermissionResolver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * Proves the phone-side interceptor gate in [PrivatePKJSInterface.onIntercepted]
+ * consults the permission resolver. onIntercepted is exposed directly on the
+ * `_Pebble` bridge, so a hostile bundle can call it without going through the XHR
+ * shim; the Kotlin-side check is what actually closes the egress-on-behalf vector,
+ * which makes "denied never reaches the interceptor" the load-bearing assertion.
+ */
+class PrivatePKJSInterfaceGateTest {
+    private val uuid = Uuid.parse("00000000-0000-0000-0000-0000000000aa")
+
+    private class RecordingInterceptor : HttpInterceptor {
+        val requests = mutableListOf<String>()
+        override fun shouldIntercept(url: String): Boolean = true
+        override suspend fun onIntercepted(
+            url: String,
+            method: String,
+            body: String?,
+            appUuid: Uuid,
+        ): InterceptResponse {
+            requests += url
+            return InterceptResponse(result = "intercepted", status = 200)
+        }
+    }
+
+    private class Fixture(
+        val bridge: PrivatePKJSInterface,
+        val runner: FakeJsRunner,
+        val interceptor: RecordingInterceptor,
+        val resolver: WatchappPermissionResolver,
+    )
+
+    private fun fixture(scope: CoroutineScope, networkDefault: Boolean = false): Fixture {
+        val configFlow = MutableStateFlow(
+            LibPebbleConfig(
+                watchConfig = WatchConfig(watchappDefaultNetworkAllowed = networkDefault),
+            ),
+        )
+        val resolver = WatchappPermissionResolver(
+            FakeLockerAppPermissionDao(),
+            LibPebbleConfigFlow(configFlow),
+        )
+        val watchConfigFlow = WatchConfigFlow(configFlow)
+        val runner = fakeJsRunner(uuid)
+        val interceptor = RecordingInterceptor()
+        // The emulator's DAOs are never touched here (nothing routes to the timeline
+        // emulator in these tests); it exists only because HttpInterceptorManager
+        // requires the concrete type.
+        val emulator = RemoteTimelineEmulator(
+            watchConfigFlow,
+            Json,
+            FakeTimelinePinRealDao(),
+            FakeTimelineReminderRealDao(),
+        )
+        val bridge = object : PrivatePKJSInterface(
+            runner,
+            runner.device,
+            scope,
+            MutableSharedFlow(extraBufferCapacity = 8),
+            Channel(Channel.UNLIMITED),
+            JsTokenUtil(
+                object : TokenProvider {
+                    override suspend fun getDevToken(): String? = null
+                },
+                FakeLockerEntryDao(),
+                watchConfigFlow,
+            ),
+            emulator,
+            HttpInterceptorManager(emulator, InjectedPKJSHttpInterceptors(listOf(interceptor))),
+            NotificationConfigFlow(configFlow),
+            resolver,
+        ) {}
+        return Fixture(bridge, runner, interceptor, resolver)
+    }
+
+    @Test
+    fun deniedAppNeverReachesInterceptorAndGetsError() = runTest {
+        val f = fixture(this, networkDefault = false)
+        f.bridge.onIntercepted("cb1", "https://api.example.com/weather", "GET", null)
+        advanceUntilIdle()
+        assertTrue(
+            f.interceptor.requests.isEmpty(),
+            "a network-denied app must not reach the phone-side interceptors",
+        )
+        assertEquals(listOf("cb1" to InterceptResponse.ERROR), f.runner.interceptResponses)
+    }
+
+    @Test
+    fun grantedAppReachesInterceptorAndGetsItsResponse() = runTest {
+        val f = fixture(this, networkDefault = false)
+        f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Allow)
+        f.bridge.onIntercepted("cb2", "https://api.example.com/weather", "GET", null)
+        advanceUntilIdle()
+        assertEquals(listOf("https://api.example.com/weather"), f.interceptor.requests)
+        val (callbackId, response) = f.runner.interceptResponses.single()
+        assertEquals("cb2", callbackId)
+        assertEquals(200, response.status)
+    }
+}

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/locker/WatchappPermissionResolverTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/locker/WatchappPermissionResolverTest.kt
@@ -3,13 +3,12 @@ package io.rebble.libpebblecommon.locker
 import io.rebble.libpebblecommon.LibPebbleConfig
 import io.rebble.libpebblecommon.LibPebbleConfigFlow
 import io.rebble.libpebblecommon.WatchConfig
-import io.rebble.libpebblecommon.database.dao.LockerAppPermissionDao
-import io.rebble.libpebblecommon.database.entity.LockerAppPermission
+import io.rebble.libpebblecommon.database.dao.FakeLockerAppPermissionDao
 import io.rebble.libpebblecommon.database.entity.LockerAppPermissionType
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -20,31 +19,38 @@ import kotlin.uuid.Uuid
 
 /**
  * Covers the security-critical decision logic: deny-by-default, per-app overrides winning
- * over the global default in both directions, and FollowGlobal being represented as the
- * absence of a stored row. Every enforcement site (geolocation bridge, WebView network
- * gate, phone-side interceptor) resolves through this, so this is where the "network/
- * location off by default" guarantee is actually proven.
+ * over the global default in both directions, FollowGlobal being represented as the
+ * absence of a stored row, each capability mapping to its own global default, and the
+ * resolved-grant flow re-emitting on live default/row changes (which the running-app
+ * enforcement collectors depend on). Every enforcement site (geolocation bridge, WebView
+ * network gate, phone-side interceptor) resolves through this, so this is where the
+ * "network/location off by default" guarantee is actually proven.
  */
 class WatchappPermissionResolverTest {
     private val uuid = Uuid.parse("00000000-0000-0000-0000-0000000000aa")
     private val other = Uuid.parse("00000000-0000-0000-0000-0000000000bb")
 
-    private fun resolver(
+    /** The config flow is exposed so tests can flip a global default mid-collection. */
+    private class Fixture(
+        val resolver: WatchappPermissionResolver,
+        val dao: FakeLockerAppPermissionDao,
+        val config: MutableStateFlow<LibPebbleConfig>,
+    )
+
+    private fun fixture(
         networkDefault: Boolean = false,
         locationDefault: Boolean = false,
-    ): Pair<WatchappPermissionResolver, FakeLockerAppPermissionDao> {
+    ): Fixture {
         val dao = FakeLockerAppPermissionDao()
-        val configFlow = LibPebbleConfigFlow(
-            MutableStateFlow(
-                LibPebbleConfig(
-                    watchConfig = WatchConfig(
-                        watchappDefaultNetworkAllowed = networkDefault,
-                        watchappDefaultLocationAllowed = locationDefault,
-                    ),
+        val config = MutableStateFlow(
+            LibPebbleConfig(
+                watchConfig = WatchConfig(
+                    watchappDefaultNetworkAllowed = networkDefault,
+                    watchappDefaultLocationAllowed = locationDefault,
                 ),
             ),
         )
-        return WatchappPermissionResolver(dao, configFlow) to dao
+        return Fixture(WatchappPermissionResolver(dao, LibPebbleConfigFlow(config)), dao, config)
     }
 
     @Test
@@ -57,116 +63,157 @@ class WatchappPermissionResolverTest {
 
     @Test
     fun noRowFollowsGlobalDefault() = runTest {
-        val (denyResolver, _) = resolver(networkDefault = false, locationDefault = false)
-        assertFalse(denyResolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
-        assertFalse(denyResolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Location))
+        val deny = fixture(networkDefault = false, locationDefault = false)
+        assertFalse(deny.resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
+        assertFalse(deny.resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Location))
 
-        val (allowResolver, _) = resolver(networkDefault = true, locationDefault = true)
-        assertTrue(allowResolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
-        assertTrue(allowResolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Location))
+        val allow = fixture(networkDefault = true, locationDefault = true)
+        assertTrue(allow.resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
+        assertTrue(allow.resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Location))
+    }
+
+    @Test
+    fun asymmetricDefaultsResolvePerCapability() = runTest {
+        // Symmetric defaults cannot tell the two capability-to-config-field mappings
+        // apart, so a cross-wire (Location reading the network default, or the
+        // reverse) would pass every symmetric test while granting the wrong
+        // capability globally. Pin each direction with the defaults split.
+        val networkOnly = fixture(networkDefault = true, locationDefault = false)
+        assertTrue(networkOnly.resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
+        assertFalse(
+            networkOnly.resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Location),
+            "location must not inherit the network default",
+        )
+
+        val locationOnly = fixture(networkDefault = false, locationDefault = true)
+        assertFalse(
+            locationOnly.resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network),
+            "network must not inherit the location default",
+        )
+        assertTrue(locationOnly.resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Location))
+    }
+
+    @Test
+    fun globalDefaultFlowTracksItsOwnCapability() = runTest {
+        val f = fixture(networkDefault = true, locationDefault = false)
+        assertTrue(f.resolver.globalDefault(LockerAppPermissionType.Network).first())
+        assertFalse(f.resolver.globalDefault(LockerAppPermissionType.Location).first())
+
+        // Flipping one default must be visible on that capability's flow only.
+        f.config.value = f.config.value.copy(
+            watchConfig = f.config.value.watchConfig.copy(watchappDefaultLocationAllowed = true),
+        )
+        assertTrue(f.resolver.globalDefault(LockerAppPermissionType.Location).first())
+        assertTrue(f.resolver.globalDefault(LockerAppPermissionType.Network).first())
     }
 
     @Test
     fun perAppAllowOverridesDenyGlobal() = runTest {
-        val (resolver, _) = resolver(networkDefault = false)
-        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Allow)
-        assertTrue(resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
+        val f = fixture(networkDefault = false)
+        f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Allow)
+        assertTrue(f.resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
         // A different app is unaffected and still follows the deny default.
-        assertFalse(resolver.isWatchappPermissionGranted(other, LockerAppPermissionType.Network))
+        assertFalse(f.resolver.isWatchappPermissionGranted(other, LockerAppPermissionType.Network))
     }
 
     @Test
     fun perAppDenyOverridesAllowGlobal() = runTest {
-        val (resolver, _) = resolver(networkDefault = true)
-        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Deny)
-        assertFalse(resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
+        val f = fixture(networkDefault = true)
+        f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Deny)
+        assertFalse(f.resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
     }
 
     @Test
     fun followGlobalDeletesRowAndReinheritsDefault() = runTest {
-        val (resolver, dao) = resolver(networkDefault = true)
-        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Deny)
-        assertFalse(resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
+        val f = fixture(networkDefault = true)
+        f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Deny)
+        assertFalse(f.resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
 
-        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.FollowGlobal)
+        f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.FollowGlobal)
         assertNull(
-            dao.getByAppUuidAndPermission(uuid, LockerAppPermissionType.Network),
+            f.dao.getByAppUuidAndPermission(uuid, LockerAppPermissionType.Network),
             "FollowGlobal must remove the row, not store a third state",
         )
         // Now re-inherits the (allow) global default.
-        assertTrue(resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
+        assertTrue(f.resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
     }
 
     @Test
     fun networkAndLocationAreIndependent() = runTest {
-        val (resolver, _) = resolver(networkDefault = false, locationDefault = false)
-        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Location, PermissionSetting.Allow)
-        assertTrue(resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Location))
+        val f = fixture(networkDefault = false, locationDefault = false)
+        f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Location, PermissionSetting.Allow)
+        assertTrue(f.resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Location))
         assertFalse(
-            resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network),
+            f.resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network),
             "granting Location must not grant Network",
         )
     }
 
     @Test
     fun settingFlowReflectsStoredTriState() = runTest {
-        val (resolver, _) = resolver()
+        val f = fixture()
         assertEquals(
             PermissionSetting.FollowGlobal,
-            resolver.watchappPermissionSetting(uuid, LockerAppPermissionType.Network).first(),
+            f.resolver.watchappPermissionSetting(uuid, LockerAppPermissionType.Network).first(),
         )
-        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Allow)
+        f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Allow)
         assertEquals(
             PermissionSetting.Allow,
-            resolver.watchappPermissionSetting(uuid, LockerAppPermissionType.Network).first(),
+            f.resolver.watchappPermissionSetting(uuid, LockerAppPermissionType.Network).first(),
         )
-        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Deny)
+        f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Deny)
         assertEquals(
             PermissionSetting.Deny,
-            resolver.watchappPermissionSetting(uuid, LockerAppPermissionType.Network).first(),
+            f.resolver.watchappPermissionSetting(uuid, LockerAppPermissionType.Network).first(),
         )
     }
 
     @Test
     fun grantedFlowResolvesRowThenDefault() = runTest {
-        val (resolver, _) = resolver(networkDefault = false)
+        val f = fixture(networkDefault = false)
         // No row -> follows deny default.
-        assertFalse(resolver.watchappPermissionGranted(uuid, LockerAppPermissionType.Network).first())
+        assertFalse(f.resolver.watchappPermissionGranted(uuid, LockerAppPermissionType.Network).first())
         // Explicit allow -> granted.
-        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Allow)
-        assertTrue(resolver.watchappPermissionGranted(uuid, LockerAppPermissionType.Network).first())
-    }
-}
-
-/**
- * In-memory stand-in for the Room DAO, backed by a single state flow so the reactive
- * queries used by the resolver emit on change.
- */
-private class FakeLockerAppPermissionDao : LockerAppPermissionDao {
-    private val rows = MutableStateFlow<Map<Pair<Uuid, LockerAppPermissionType>, LockerAppPermission>>(emptyMap())
-
-    override suspend fun insertOrReplace(permission: LockerAppPermission) {
-        rows.value = rows.value + ((permission.appUuid to permission.permission) to permission)
+        f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Allow)
+        assertTrue(f.resolver.watchappPermissionGranted(uuid, LockerAppPermissionType.Network).first())
     }
 
-    override suspend fun deleteByAppUuid(appUuid: Uuid) {
-        rows.value = rows.value.filterKeys { it.first != appUuid }
+    @Test
+    fun grantedFlowReEmitsOnLiveGlobalDefaultChange() = runTest {
+        // The running-app enforcement (the WebView network collector) keeps a
+        // collection of this flow open for the whole session and relies on a
+        // global-default toggle producing a fresh emission; a resolver that read the
+        // default once per collection would pass every one-shot test in this suite
+        // and silently break live enforcement.
+        val f = fixture(networkDefault = false)
+        val emissions = mutableListOf<Boolean>()
+        backgroundScope.launch {
+            f.resolver.watchappPermissionGranted(uuid, LockerAppPermissionType.Network)
+                .collect { emissions += it }
+        }
+        runCurrent()
+        assertEquals(listOf(false), emissions)
+
+        f.config.value = f.config.value.copy(
+            watchConfig = f.config.value.watchConfig.copy(watchappDefaultNetworkAllowed = true),
+        )
+        runCurrent()
+        assertEquals(listOf(false, true), emissions, "a live default flip must re-resolve FollowGlobal apps")
     }
 
-    override suspend fun deleteByAppUuidAndPermission(appUuid: Uuid, permission: LockerAppPermissionType) {
-        rows.value = rows.value - (appUuid to permission)
+    @Test
+    fun grantedFlowReEmitsOnLivePerAppRowChange() = runTest {
+        val f = fixture(networkDefault = true)
+        val emissions = mutableListOf<Boolean>()
+        backgroundScope.launch {
+            f.resolver.watchappPermissionGranted(uuid, LockerAppPermissionType.Network)
+                .collect { emissions += it }
+        }
+        runCurrent()
+        assertEquals(listOf(true), emissions)
+
+        f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Deny)
+        runCurrent()
+        assertEquals(listOf(true, false), emissions, "a live per-app deny must reach open collections")
     }
-
-    override suspend fun getByAppUuid(appUuid: Uuid): List<LockerAppPermission> =
-        rows.value.values.filter { it.appUuid == appUuid }
-
-    override suspend fun getByAppUuidAndPermission(
-        appUuid: Uuid,
-        permission: LockerAppPermissionType,
-    ): LockerAppPermission? = rows.value[appUuid to permission]
-
-    override fun getByAppUuidAndPermissionFlow(
-        appUuid: Uuid,
-        permission: LockerAppPermissionType,
-    ): Flow<LockerAppPermission?> = rows.map { it[appUuid to permission] }
 }

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/locker/WatchappPermissionResolverTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/locker/WatchappPermissionResolverTest.kt
@@ -108,6 +108,27 @@ class WatchappPermissionResolverTest {
     }
 
     @Test
+    fun globalDefaultFlowReEmitsOnLiveToggle() = runTest {
+        // The per-app selector keeps a collection of this flow open to label its
+        // "Default" choice and relies on a toggle re-emitting while it is visible;
+        // a snapshot implementation would pass the fresh-collection assertions
+        // above while freezing the label at its first-composition value.
+        val f = fixture(networkDefault = false)
+        val emissions = mutableListOf<Boolean>()
+        backgroundScope.launch {
+            f.resolver.globalDefault(LockerAppPermissionType.Network).collect { emissions += it }
+        }
+        runCurrent()
+        assertEquals(listOf(false), emissions)
+
+        f.config.value = f.config.value.copy(
+            watchConfig = f.config.value.watchConfig.copy(watchappDefaultNetworkAllowed = true),
+        )
+        runCurrent()
+        assertEquals(listOf(false, true), emissions, "a live default toggle must reach open collections")
+    }
+
+    @Test
     fun perAppAllowOverridesDenyGlobal() = runTest {
         val f = fixture(networkDefault = false)
         f.resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Allow)

--- a/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/locker/WatchappPermissionResolverTest.kt
+++ b/libpebble3/src/commonTest/kotlin/io/rebble/libpebblecommon/locker/WatchappPermissionResolverTest.kt
@@ -1,0 +1,172 @@
+package io.rebble.libpebblecommon.locker
+
+import io.rebble.libpebblecommon.LibPebbleConfig
+import io.rebble.libpebblecommon.LibPebbleConfigFlow
+import io.rebble.libpebblecommon.WatchConfig
+import io.rebble.libpebblecommon.database.dao.LockerAppPermissionDao
+import io.rebble.libpebblecommon.database.entity.LockerAppPermission
+import io.rebble.libpebblecommon.database.entity.LockerAppPermissionType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * Covers the security-critical decision logic: deny-by-default, per-app overrides winning
+ * over the global default in both directions, and FollowGlobal being represented as the
+ * absence of a stored row. Every enforcement site (geolocation bridge, WebView network
+ * gate, phone-side interceptor) resolves through this, so this is where the "network/
+ * location off by default" guarantee is actually proven.
+ */
+class WatchappPermissionResolverTest {
+    private val uuid = Uuid.parse("00000000-0000-0000-0000-0000000000aa")
+    private val other = Uuid.parse("00000000-0000-0000-0000-0000000000bb")
+
+    private fun resolver(
+        networkDefault: Boolean = false,
+        locationDefault: Boolean = false,
+    ): Pair<WatchappPermissionResolver, FakeLockerAppPermissionDao> {
+        val dao = FakeLockerAppPermissionDao()
+        val configFlow = LibPebbleConfigFlow(
+            MutableStateFlow(
+                LibPebbleConfig(
+                    watchConfig = WatchConfig(
+                        watchappDefaultNetworkAllowed = networkDefault,
+                        watchappDefaultLocationAllowed = locationDefault,
+                    ),
+                ),
+            ),
+        )
+        return WatchappPermissionResolver(dao, configFlow) to dao
+    }
+
+    @Test
+    fun shippedDefaultsDenyBothCapabilities() {
+        // The whole feature hinges on this: an untouched install must deny.
+        val defaults = WatchConfig()
+        assertFalse(defaults.watchappDefaultNetworkAllowed, "network must default deny")
+        assertFalse(defaults.watchappDefaultLocationAllowed, "location must default deny")
+    }
+
+    @Test
+    fun noRowFollowsGlobalDefault() = runTest {
+        val (denyResolver, _) = resolver(networkDefault = false, locationDefault = false)
+        assertFalse(denyResolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
+        assertFalse(denyResolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Location))
+
+        val (allowResolver, _) = resolver(networkDefault = true, locationDefault = true)
+        assertTrue(allowResolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
+        assertTrue(allowResolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Location))
+    }
+
+    @Test
+    fun perAppAllowOverridesDenyGlobal() = runTest {
+        val (resolver, _) = resolver(networkDefault = false)
+        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Allow)
+        assertTrue(resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
+        // A different app is unaffected and still follows the deny default.
+        assertFalse(resolver.isWatchappPermissionGranted(other, LockerAppPermissionType.Network))
+    }
+
+    @Test
+    fun perAppDenyOverridesAllowGlobal() = runTest {
+        val (resolver, _) = resolver(networkDefault = true)
+        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Deny)
+        assertFalse(resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
+    }
+
+    @Test
+    fun followGlobalDeletesRowAndReinheritsDefault() = runTest {
+        val (resolver, dao) = resolver(networkDefault = true)
+        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Deny)
+        assertFalse(resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
+
+        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.FollowGlobal)
+        assertNull(
+            dao.getByAppUuidAndPermission(uuid, LockerAppPermissionType.Network),
+            "FollowGlobal must remove the row, not store a third state",
+        )
+        // Now re-inherits the (allow) global default.
+        assertTrue(resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network))
+    }
+
+    @Test
+    fun networkAndLocationAreIndependent() = runTest {
+        val (resolver, _) = resolver(networkDefault = false, locationDefault = false)
+        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Location, PermissionSetting.Allow)
+        assertTrue(resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Location))
+        assertFalse(
+            resolver.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network),
+            "granting Location must not grant Network",
+        )
+    }
+
+    @Test
+    fun settingFlowReflectsStoredTriState() = runTest {
+        val (resolver, _) = resolver()
+        assertEquals(
+            PermissionSetting.FollowGlobal,
+            resolver.watchappPermissionSetting(uuid, LockerAppPermissionType.Network).first(),
+        )
+        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Allow)
+        assertEquals(
+            PermissionSetting.Allow,
+            resolver.watchappPermissionSetting(uuid, LockerAppPermissionType.Network).first(),
+        )
+        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Deny)
+        assertEquals(
+            PermissionSetting.Deny,
+            resolver.watchappPermissionSetting(uuid, LockerAppPermissionType.Network).first(),
+        )
+    }
+
+    @Test
+    fun grantedFlowResolvesRowThenDefault() = runTest {
+        val (resolver, _) = resolver(networkDefault = false)
+        // No row -> follows deny default.
+        assertFalse(resolver.watchappPermissionGranted(uuid, LockerAppPermissionType.Network).first())
+        // Explicit allow -> granted.
+        resolver.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Allow)
+        assertTrue(resolver.watchappPermissionGranted(uuid, LockerAppPermissionType.Network).first())
+    }
+}
+
+/**
+ * In-memory stand-in for the Room DAO, backed by a single state flow so the reactive
+ * queries used by the resolver emit on change.
+ */
+private class FakeLockerAppPermissionDao : LockerAppPermissionDao {
+    private val rows = MutableStateFlow<Map<Pair<Uuid, LockerAppPermissionType>, LockerAppPermission>>(emptyMap())
+
+    override suspend fun insertOrReplace(permission: LockerAppPermission) {
+        rows.value = rows.value + ((permission.appUuid to permission.permission) to permission)
+    }
+
+    override suspend fun deleteByAppUuid(appUuid: Uuid) {
+        rows.value = rows.value.filterKeys { it.first != appUuid }
+    }
+
+    override suspend fun deleteByAppUuidAndPermission(appUuid: Uuid, permission: LockerAppPermissionType) {
+        rows.value = rows.value - (appUuid to permission)
+    }
+
+    override suspend fun getByAppUuid(appUuid: Uuid): List<LockerAppPermission> =
+        rows.value.values.filter { it.appUuid == appUuid }
+
+    override suspend fun getByAppUuidAndPermission(
+        appUuid: Uuid,
+        permission: LockerAppPermissionType,
+    ): LockerAppPermission? = rows.value[appUuid to permission]
+
+    override fun getByAppUuidAndPermissionFlow(
+        appUuid: Uuid,
+        permission: LockerAppPermissionType,
+    ): Flow<LockerAppPermission?> = rows.map { it[appUuid to permission] }
+}

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/LockerAppScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/LockerAppScreen.kt
@@ -90,6 +90,7 @@ import io.ktor.http.parseUrl
 import io.rebble.libpebblecommon.connection.ConnectedPebbleDevice
 import io.rebble.libpebblecommon.connection.LibPebble
 import io.rebble.libpebblecommon.connection.PebbleIdentifier
+import io.rebble.libpebblecommon.database.entity.LockerAppPermissionType
 import io.rebble.libpebblecommon.locker.AppCapability
 import io.rebble.libpebblecommon.locker.AppType
 import io.rebble.libpebblecommon.locker.orderIndexForInsert
@@ -468,13 +469,28 @@ fun LockerAppScreen(topBarParams: TopBarParams, uuid: Uuid?, navBarNav: NavBarNa
                             modifier = Modifier.padding(5.dp),
                         )
                     }
-                    // Only show for store, right now (until we figure out populating data or locker)
-                    if (storeEntry?.capabilities?.isNotEmpty() == true) {
-                        FlowRow(modifier = Modifier.padding(5.dp)) {
-                            storeEntry.capabilities.forEach { permission ->
-                                PermissionItem(permission, entry, topBarParams)
-                            }
+                    // Fork: phone-side permission surface. For an installed (locker) app,
+                    // show the real per-app controls (internet + location tri-state). For a
+                    // store listing not yet installed, show what it declares plus an honest
+                    // note that phone-side JS means internet access; the appstore capability
+                    // vocabulary can't express "network", so upstream never disclosed it.
+                    when (entry.commonAppType) {
+                        is CommonAppType.Locker -> {
+                            WatchappPermissionControls(
+                                uuid = entry.uuid,
+                                modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
+                            )
                         }
+
+                        is CommonAppType.Store -> {
+                            StoreCapabilityDisclosure(
+                                capabilities = storeEntry?.capabilities.orEmpty(),
+                                entry = entry,
+                                topBarParams = topBarParams,
+                            )
+                        }
+
+                        is CommonAppType.System -> Unit
                     }
                     if (entry.commonAppType is CommonAppType.Store && !viewModel.addedToLocker) {
 //                    val hasUuidConflict = remember(viewModel.storeEntries) { // One store has multiple entries with same uuid
@@ -884,7 +900,8 @@ private fun PropertyRow(
 @Composable
 fun PermissionItem(permission: AppCapability, entry: CommonApp, topBarParams: TopBarParams) {
     if (entry.commonAppType is CommonAppType.Locker) {
-        // TODO
+        // Installed apps render the functional controls (WatchappPermissionControls)
+        // instead of these informational chips.
     } else {
         AssistChip(
             onClick = {
@@ -893,6 +910,38 @@ fun PermissionItem(permission: AppCapability, entry: CommonApp, topBarParams: To
             label = { Text(permission.name()) },
             leadingIcon = { Icon(permission.icon(), null) },
             modifier = Modifier.padding(horizontal = 6.dp)
+        )
+    }
+}
+
+/**
+ * Fork: honest capability disclosure for a store listing that isn't installed yet.
+ * Shows the capabilities the listing declares (location/health/timeline) and, crucially,
+ * states plainly that apps can also reach the internet through phone-side code (a fact the
+ * appstore metadata cannot express and upstream never surfaced), and points to where that
+ * can be controlled once installed.
+ */
+@Composable
+fun StoreCapabilityDisclosure(
+    capabilities: List<AppCapability>,
+    entry: CommonApp,
+    topBarParams: TopBarParams,
+) {
+    Column(modifier = Modifier.padding(horizontal = 5.dp)) {
+        if (capabilities.isNotEmpty()) {
+            FlowRow(modifier = Modifier.padding(5.dp)) {
+                capabilities.forEach { permission ->
+                    PermissionItem(permission, entry, topBarParams)
+                }
+            }
+        }
+        Text(
+            "Apps can also use the internet through code that runs on your phone (for example " +
+                "to fetch weather). After installing, control internet and location for this app " +
+                "in Settings > Apps > Watch App Permissions.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 4.dp),
         )
     }
 }
@@ -911,7 +960,9 @@ fun AppCapability.name(): String = when (this) {
 
 fun AppCapability.description(): String = when (this) {
     AppCapability.Health -> "Can access health data"
-    AppCapability.Location -> "Can access location"
+    // Fork: state the real flow. A watchface asking for location almost always feeds it
+    // to a phone-side network call (e.g. weather), so "access location" understates it.
+    AppCapability.Location -> "Can read your phone's location, and may send it to outside servers over the internet"
     AppCapability.Timeline -> "Can create timeline pins"
 }
 
@@ -976,6 +1027,20 @@ suspend fun CommonApp.showSettings(
 ) {
     when (commonAppType) {
         is CommonAppType.Locker -> {
+            // Fork: the developer settings page URL is built by the app's own PKJS and
+            // loaded in a WebView, so opening it is an app-controlled network request to
+            // a developer-chosen server, and the app can pack anything it has gathered
+            // (location included) into that URL. If the user has denied this app's
+            // internet access, honour that here rather than loading the page; otherwise
+            // the config page would be a hole exactly the size of the thing we closed.
+            if (!libPebble.isWatchappPermissionGranted(uuid, LockerAppPermissionType.Network)) {
+                logger.d { "Config page blocked for $uuid: network denied" }
+                topBarParams.showSnackbar(
+                    "This app's settings page needs internet, which is turned off for it. " +
+                        "Enable it in Settings > Apps > Watch App Permissions."
+                )
+                return
+            }
             val watch = libPebble.watches.value.filterIsInstance<ConnectedPebbleDevice>()
                 .firstOrNull()
             //TODO: Handle multiple watches connected, selector?

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/LockerAppScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/LockerAppScreen.kt
@@ -900,8 +900,10 @@ private fun PropertyRow(
 @Composable
 fun PermissionItem(permission: AppCapability, entry: CommonApp, topBarParams: TopBarParams) {
     if (entry.commonAppType is CommonAppType.Locker) {
-        // Installed apps render the functional controls (WatchappPermissionControls)
-        // instead of these informational chips.
+        // Unreachable from current call sites: PermissionItem is only rendered for
+        // store listings (via StoreCapabilityDisclosure); installed apps get
+        // WatchappPermissionControls on their detail page instead. The branch is
+        // kept so the function keeps its upstream shape for cheap merges.
     } else {
         AssistChip(
             onClick = {

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/PebbleRoutes.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/PebbleRoutes.kt
@@ -91,6 +91,10 @@ object PebbleNavBarRoutes {
     @Serializable
     data object PermissionsRoute : NavBarRoute
 
+    // Fork: Settings > Apps > Watch App Permissions (global defaults + per-app list).
+    @Serializable
+    data object WatchappPermissionsRoute : NavBarRoute
+
     @Serializable
     data object CalendarsRoute : NavBarRoute
 
@@ -207,6 +211,9 @@ fun NavGraphBuilder.addNavBarRoutes(
     }
     composableWithAnimations<PebbleNavBarRoutes.PermissionsRoute>(viewModel) {
         PermissionsScreen(nav, topBarParams)
+    }
+    composableWithAnimations<PebbleNavBarRoutes.WatchappPermissionsRoute>(viewModel) {
+        WatchappPermissionsScreen(nav, topBarParams)
     }
     composableWithAnimations<PebbleNavBarRoutes.AppNotificationViewerRoute>(viewModel) {
         val route: PebbleNavBarRoutes.AppNotificationViewerRoute = it.toRoute()

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -605,6 +605,16 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                     section = Section.Apps,
                     action = { nav.navigateTo(PebbleNavBarRoutes.AppstoreSettingsRoute) },
                 ) },
+                // Fork: entry point to the watchapp/watchface phone-side permission
+                // controls (internet + location), global defaults and per-app.
+                navBarNav?.let { nav -> basicSettingsActionItem(
+                    title = "Watch App Permissions",
+                    description = "Control internet and location access for watchfaces and apps",
+                    topLevelType = TopLevelType.Phone,
+                    section = Section.Apps,
+                    keywords = "internet network location privacy watchface pkjs permission",
+                    action = { nav.navigateTo(PebbleNavBarRoutes.WatchappPermissionsRoute) },
+                ) },
                 basicSettingsDropdownItem(
                     title = "App Theme",
                     topLevelType = TopLevelType.Phone,

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchappPermissionsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchappPermissionsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -251,14 +252,12 @@ private fun WatchappPermissionSelector(
     label: String,
     libPebble: LibPebble,
 ) {
-    val scope = rememberCoroutineScopeForPermissions()
+    val scope = rememberCoroutineScope()
     val setting by libPebble.watchappPermissionSetting(uuid, type)
         .collectAsState(PermissionSetting.FollowGlobal)
-    val config by libPebble.config.collectAsState()
-    val globalAllowed = when (type) {
-        LockerAppPermissionType.Network -> config.watchConfig.watchappDefaultNetworkAllowed
-        LockerAppPermissionType.Location -> config.watchConfig.watchappDefaultLocationAllowed
-    }
+    // Resolved by the permission resolver, which owns the type-to-config-field
+    // mapping, so this label cannot drift from what FollowGlobal actually grants.
+    val globalAllowed by libPebble.globalDefault(type).collectAsState(false)
     // The "Default" option names what it currently resolves to, so the choice is honest
     // about the effect (e.g. "Default (Off)") rather than hiding it behind a word.
     val options = listOf(
@@ -280,9 +279,3 @@ private fun WatchappPermissionSelector(
         }
     }
 }
-
-// Small local helper so the two composables above share one scope-obtaining call without
-// each importing the same set of runtime symbols; keeps the imports at the top tidy.
-@Composable
-private fun rememberCoroutineScopeForPermissions() =
-    androidx.compose.runtime.rememberCoroutineScope()

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchappPermissionsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchappPermissionsScreen.kt
@@ -1,0 +1,288 @@
+package coredevices.pebble.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coredevices.pebble.rememberLibPebble
+import io.rebble.libpebblecommon.connection.LibPebble
+import io.rebble.libpebblecommon.database.entity.LockerAppPermissionType
+import io.rebble.libpebblecommon.locker.AppType
+import io.rebble.libpebblecommon.locker.LockerWrapper
+import io.rebble.libpebblecommon.locker.PermissionSetting
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import kotlin.uuid.Uuid
+
+/**
+ * Fork feature: Settings > Apps > Watch App Permissions.
+ *
+ * Third-party watchapps/watchfaces run companion JavaScript on the phone (PebbleKit
+ * JS in a WebView), through which they can reach the internet and the phone's GPS with
+ * no involvement from the watch. Upstream exposed neither disclosure nor control over
+ * that; this screen is the control surface. It holds the global defaults (what an app
+ * with no explicit choice inherits) and a list of installed apps; the per-app tri-state
+ * controls themselves live on each app's page (and are shared via
+ * [WatchappPermissionControls]).
+ */
+@Composable
+fun WatchappPermissionsScreen(nav: NavBarNav, topBarParams: TopBarParams) {
+    LaunchedEffect(Unit) {
+        topBarParams.searchAvailable(null)
+        topBarParams.actions {}
+        topBarParams.title("Watch App Permissions")
+    }
+
+    val libPebble = rememberLibPebble()
+    val config by libPebble.config.collectAsState()
+    val watchConfig = config.watchConfig
+
+    // Installed watchapps + watchfaces (system apps excluded: they are first-party and
+    // do not run third-party phone-side code). Limit is generous; the locker is small.
+    val apps by remember {
+        combine(
+            libPebble.getLocker(AppType.Watchapp, null, 500),
+            libPebble.getLocker(AppType.Watchface, null, 500),
+        ) { watchapps, watchfaces ->
+            (watchapps + watchfaces)
+                .filterIsInstance<LockerWrapper.NormalApp>()
+                .sortedBy { it.properties.title.lowercase() }
+        }
+    }.collectAsState(emptyList())
+
+    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+        item {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    "Some watchfaces and apps run code on your phone to fetch things like " +
+                        "weather. These settings control what that code can reach. Turning " +
+                        "access off can stop features that rely on it, such as third-party " +
+                        "weather, from working for those apps.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    "Default for all apps",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    "Applied to any app you haven't set individually.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(8.dp))
+                GlobalDefaultToggle(
+                    label = "Internet access",
+                    checked = watchConfig.watchappDefaultNetworkAllowed,
+                    onCheckedChange = { allowed ->
+                        libPebble.updateConfig(
+                            config.copy(watchConfig = watchConfig.copy(watchappDefaultNetworkAllowed = allowed)),
+                        )
+                    },
+                )
+                GlobalDefaultToggle(
+                    label = "Location",
+                    checked = watchConfig.watchappDefaultLocationAllowed,
+                    onCheckedChange = { allowed ->
+                        libPebble.updateConfig(
+                            config.copy(watchConfig = watchConfig.copy(watchappDefaultLocationAllowed = allowed)),
+                        )
+                    },
+                )
+                Spacer(Modifier.height(16.dp))
+                HorizontalDivider()
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    "Individual apps",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+        }
+        if (apps.isEmpty()) {
+            item {
+                Text(
+                    "No watchapps or watchfaces installed yet.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
+        }
+        items(apps, key = { it.properties.id.toString() }) { app ->
+            WatchappPermissionListRow(
+                app = app,
+                libPebble = libPebble,
+                onClick = {
+                    // Reuse the app's own detail page, which hosts the per-app controls.
+                    nav.navigateTo(
+                        PebbleNavBarRoutes.LockerAppRoute(
+                            uuid = app.properties.id.toString(),
+                            storedId = null,
+                            storeSource = null,
+                        ),
+                    )
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun GlobalDefaultToggle(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyLarge)
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}
+
+@Composable
+private fun WatchappPermissionListRow(
+    app: LockerWrapper.NormalApp,
+    libPebble: LibPebble,
+    onClick: () -> Unit,
+) {
+    val uuid = app.properties.id
+    val network by libPebble.watchappPermissionGranted(uuid, LockerAppPermissionType.Network)
+        .collectAsState(false)
+    val location by libPebble.watchappPermissionGranted(uuid, LockerAppPermissionType.Location)
+        .collectAsState(false)
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(app.properties.title, style = MaterialTheme.typography.bodyLarge, maxLines = 1)
+            Text(
+                buildString {
+                    append("Internet: ")
+                    append(if (network) "On" else "Off")
+                    append("   •   Location: ")
+                    append(if (location) "On" else "Off")
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null)
+    }
+}
+
+/**
+ * Shared per-app permission controls, embedded on an app's detail page. Renders the two
+ * tri-state selectors (Default / Allow / Deny) plus an honest disclosure of what phone-side
+ * network access means. [WatchappPermissionsScreen] deliberately reuses the app detail page
+ * rather than duplicating these controls.
+ */
+@Composable
+fun WatchappPermissionControls(uuid: Uuid, modifier: Modifier = Modifier) {
+    val libPebble = rememberLibPebble()
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            "This app's access on your phone",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(bottom = 4.dp),
+        )
+        Text(
+            "If this app runs code on your phone (many watchfaces do, to fetch weather), " +
+                "these control what it can reach. Turning internet off also stops it sending " +
+                "your data to outside servers, but can stop features that need it, such as " +
+                "third-party weather, from working.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+        WatchappPermissionSelector(
+            uuid = uuid,
+            type = LockerAppPermissionType.Network,
+            label = "Internet access",
+            libPebble = libPebble,
+        )
+        Spacer(Modifier.height(12.dp))
+        WatchappPermissionSelector(
+            uuid = uuid,
+            type = LockerAppPermissionType.Location,
+            label = "Location",
+            libPebble = libPebble,
+        )
+    }
+}
+
+@Composable
+private fun WatchappPermissionSelector(
+    uuid: Uuid,
+    type: LockerAppPermissionType,
+    label: String,
+    libPebble: LibPebble,
+) {
+    val scope = rememberCoroutineScopeForPermissions()
+    val setting by libPebble.watchappPermissionSetting(uuid, type)
+        .collectAsState(PermissionSetting.FollowGlobal)
+    val config by libPebble.config.collectAsState()
+    val globalAllowed = when (type) {
+        LockerAppPermissionType.Network -> config.watchConfig.watchappDefaultNetworkAllowed
+        LockerAppPermissionType.Location -> config.watchConfig.watchappDefaultLocationAllowed
+    }
+    // The "Default" option names what it currently resolves to, so the choice is honest
+    // about the effect (e.g. "Default (Off)") rather than hiding it behind a word.
+    val options = listOf(
+        PermissionSetting.FollowGlobal to "Default (${if (globalAllowed) "On" else "Off"})",
+        PermissionSetting.Allow to "Allow",
+        PermissionSetting.Deny to "Deny",
+    )
+    Text(label, style = MaterialTheme.typography.bodyLarge)
+    Spacer(Modifier.height(4.dp))
+    SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+        options.forEachIndexed { index, (value, text) ->
+            SegmentedButton(
+                selected = setting == value,
+                onClick = { scope.launch { libPebble.setWatchappPermission(uuid, type, value) } },
+                shape = SegmentedButtonDefaults.itemShape(index, options.size),
+            ) {
+                Text(text)
+            }
+        }
+    }
+}
+
+// Small local helper so the two composables above share one scope-obtaining call without
+// each importing the same set of runtime symbols; keeps the imports at the top tidy.
+@Composable
+private fun rememberCoroutineScopeForPermissions() =
+    androidx.compose.runtime.rememberCoroutineScope()

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/ui/WatchappConfigPageGateTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/ui/WatchappConfigPageGateTest.kt
@@ -1,0 +1,90 @@
+package coredevices.pebble.ui
+
+import io.rebble.libpebblecommon.connection.FakeLibPebble
+import io.rebble.libpebblecommon.database.entity.LockerAppPermissionType
+import io.rebble.libpebblecommon.locker.AppType
+import io.rebble.libpebblecommon.locker.PermissionSetting
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.uuid.Uuid
+
+/**
+ * Pins the network gate on the developer config page. The page URL is built by the
+ * app's own PKJS and loaded in a WebView, so opening it is an app-controlled network
+ * request to a developer-chosen server; a network-denied app must be refused (with the
+ * pointer snackbar) and a granted app must get past the gate. showSettings lives in
+ * upstream-touched code, so an upstream merge dropping the fork-added guard is the
+ * regression this exists to catch.
+ */
+class WatchappConfigPageGateTest {
+    private val uuid = Uuid.parse("00000000-0000-0000-0000-0000000000aa")
+
+    private fun installedApp() = CommonApp(
+        title = "Test App",
+        developerName = "Test Developer",
+        uuid = uuid,
+        androidCompanion = null,
+        commonAppType = CommonAppType.Locker(
+            sideloaded = false,
+            configurable = true,
+            sync = true,
+            order = 0,
+        ),
+        type = AppType.Watchapp,
+        category = null,
+        version = null,
+        listImageUrl = null,
+        screenshotImageUrl = null,
+        isCompatible = true,
+        isNativelyCompatible = true,
+        hearts = null,
+        description = null,
+        developerId = null,
+        categorySlug = null,
+        storeId = null,
+        sourceLink = null,
+        appstoreSource = null,
+        capabilities = emptyList(),
+    )
+
+    private fun topBarParams(snackbars: MutableList<String>) = TopBarParams(
+        searchAvailable = {},
+        actions = {},
+        title = {},
+        overrideGoBack = MutableStateFlow(Unit),
+        showSnackbar = { snackbars += it },
+        scrollToTop = MutableStateFlow(Unit),
+    )
+
+    @Test
+    fun configPageRefusedWhenNetworkDenied() = runTest {
+        val libPebble = FakeLibPebble()
+        // No explicit grant: resolves through the deny-by-default baseline.
+        libPebble.watches.value = emptyList()
+        val snackbars = mutableListOf<String>()
+
+        installedApp().showSettings(NoOpNavBarNav, libPebble, topBarParams(snackbars))
+
+        assertEquals(1, snackbars.size, "a denied app must be refused with an explanation")
+        assertContains(snackbars.single(), "Watch App Permissions")
+    }
+
+    @Test
+    fun configPageProceedsPastGateWhenNetworkAllowed() = runTest {
+        val libPebble = FakeLibPebble()
+        // Empty watch list makes the flow stop right after the gate (no connected
+        // watch), which keeps the test on the gate itself: passing it silently is
+        // exactly the granted behaviour, refusing it would surface the snackbar.
+        libPebble.watches.value = emptyList()
+        libPebble.setWatchappPermission(uuid, LockerAppPermissionType.Network, PermissionSetting.Allow)
+        val snackbars = mutableListOf<String>()
+
+        installedApp().showSettings(NoOpNavBarNav, libPebble, topBarParams(snackbars))
+
+        assertTrue(snackbars.isEmpty(), "a granted app must get past the permission gate")
+    }
+}

--- a/util/src/commonMain/kotlin/coredevices/util/CoreConfig.kt
+++ b/util/src/commonMain/kotlin/coredevices/util/CoreConfig.kt
@@ -98,6 +98,15 @@ data class CoreConfig(
     val hidePermissionWarningBadges: Boolean = false,
     val androidForegroundServiceForWatchConnectionV2: Boolean = true,
     val showWatchConnectionDebugInfo: Boolean = false,
+    /**
+     * Fork: highest "What's New" changelog revision the user has already seen. Compared
+     * against WHATS_NEW_VERSION to decide whether to show the one-time update dialog.
+     * Defaults to 0 so an existing install upgrading into this build (whose stored config
+     * predates the field) is shown the current entries once; fresh installs stamp it to
+     * the current version at the end of onboarding so they are not shown what they just
+     * chose during setup.
+     */
+    val lastSeenWhatsNewVersion: Int = 0,
 )
 
 @Serializable

--- a/util/src/commonMain/kotlin/theme/Theme.kt
+++ b/util/src/commonMain/kotlin/theme/Theme.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.lerp
 import com.russhwolf.settings.Settings
 import coreapp.util.generated.resources.Res
 import coreapp.util.generated.resources.black
@@ -28,6 +29,11 @@ import theme.CoreAppTheme.Companion.asCoreAppTheme
 // Replaces upstream's coreOrange 0xFFFA4A36 everywhere; the launcher background in
 // util res/values/ic_launcher_background.xml is chosen to contrast with this.
 val gravelPurple = Color(0xFF9129DE)
+
+// Deepened brand purple for dialog surfaces under the onboarding scheme: white
+// and 80 percent white body text clear the 4.5:1 AA contrast floor against this,
+// which they do not against a whitened purple. See onboardingScheme.
+val gravelPurpleDeep = lerp(gravelPurple, Color.Black, 0.2f)
 val coreGrey = Color(0xFF333333)
 val coreDarkGrey = Color(0xFF2B2930)
 val coreDarkGreen = Color(0xFF157a30)
@@ -138,6 +144,14 @@ val onboardingScheme = lightColorScheme(
     scrim = gravelPurple,
     surfaceContainer = gravelPurple,
     surfaceContainerHighest = Color.White.copy(alpha = 0.15f),
+    // Material3 components draw on the container tiers (dialogs use
+    // surfaceContainerHigh), and any tier left unset falls back to
+    // lightColorScheme's near-white default, which renders this scheme's white
+    // content colors invisible. Every tier must stay in the purple family;
+    // legibility is pinned by OnboardingSchemeContrastTest.
+    surfaceContainerHigh = gravelPurpleDeep,
+    surfaceContainerLow = gravelPurple,
+    surfaceContainerLowest = gravelPurple,
     error = error,
     onError = Color.White,
     errorContainer = error,

--- a/util/src/commonTest/kotlin/theme/OnboardingSchemeContrastTest.kt
+++ b/util/src/commonTest/kotlin/theme/OnboardingSchemeContrastTest.kt
@@ -1,0 +1,51 @@
+package theme
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Pins the legibility of Material3 dialogs under the onboarding scheme.
+ * AlertDialog draws its card on surfaceContainerHigh with onSurface (title),
+ * onSurfaceVariant (body), and primary (text buttons) as content colors. A
+ * container tier left unset in the scheme silently falls back to
+ * lightColorScheme's near-white default, which renders this scheme's white
+ * content colors invisible; the fresh-install privacy confirm dialog rendered
+ * exactly that way and was only caught on-device. The floor is the WCAG AA
+ * body-text ratio, 4.5:1.
+ */
+class OnboardingSchemeContrastTest {
+
+    private fun contrast(a: Color, b: Color): Float {
+        val lighter = maxOf(a.luminance(), b.luminance())
+        val darker = minOf(a.luminance(), b.luminance())
+        return (lighter + 0.05f) / (darker + 0.05f)
+    }
+
+    /** The scheme's translucent content colors render composited over the card. */
+    private fun Color.over(bg: Color): Color = Color(
+        red = red * alpha + bg.red * (1f - alpha),
+        green = green * alpha + bg.green * (1f - alpha),
+        blue = blue * alpha + bg.blue * (1f - alpha),
+    )
+
+    @Test
+    fun `dialog title clears AA contrast`() {
+        val ratio = contrast(onboardingScheme.onSurface, onboardingScheme.surfaceContainerHigh)
+        assertTrue(ratio >= 4.5f, "onSurface on surfaceContainerHigh is $ratio:1")
+    }
+
+    @Test
+    fun `dialog body clears AA contrast`() {
+        val body = onboardingScheme.onSurfaceVariant.over(onboardingScheme.surfaceContainerHigh)
+        val ratio = contrast(body, onboardingScheme.surfaceContainerHigh)
+        assertTrue(ratio >= 4.5f, "composited onSurfaceVariant on surfaceContainerHigh is $ratio:1")
+    }
+
+    @Test
+    fun `dialog buttons clear AA contrast`() {
+        val ratio = contrast(onboardingScheme.primary, onboardingScheme.surfaceContainerHigh)
+        assertTrue(ratio >= 4.5f, "primary on surfaceContainerHigh is $ratio:1")
+    }
+}


### PR DESCRIPTION
Watchapps and watchfaces can ship PebbleKit JS that runs in a WebView
on the phone. Before this branch that JS had unrestricted internet
access, and the geolocation shim's permission check read a per-app row
that nothing ever wrote and treated a missing row as granted, so every
installed watchapp silently got both the network and real phone GPS.

Both capabilities are now real permissions. A tri-state model (Allow /
Deny / Follow global default) is stored per app and capability, the
shipped global defaults deny both, and one shared resolver gives every
enforcement site and the UI the same answer. Enforcement is layered:
the injected bridge script guards the JS entry points (XMLHttpRequest,
fetch, WebSocket, EventSource, geolocation) and re-checks the grant
per call; the WebView network layer black-holes traffic for denied
apps; the phone-side PKJS interceptor refuses service to denied apps;
the geolocation bridge checks per call, cancels live watchPosition
streams the moment location is revoked, and resumes them on re-grant;
and the developer config page opens only for granted apps. The JS
guards are best-effort hardening inside the page; the deny direction
is enforced deterministically by the native layers.

A network grant made mid-session restarts the app's companion session
once, so the grant takes effect without waiting for the next app
switch. Session decisions (conflating watch-side app switches to the
newest state, serializing restarts with app changes, dropping stale
restart requests) live in a dedicated coordinator with injected
effects. Permission rows are deleted on both locker-exit paths, so a
later install self-declaring the same UUID cannot inherit grants.

The UI adds a Watch App Permissions screen (global defaults plus
per-app tri-state, with the Default choice labelled by what it
currently resolves to, tracked live), a privacy stage in fresh-install
onboarding, and a one-time What's-New announcement for upgrading
installs. Cleartext HTTP stays blocked app-wide; the rationale and the
accepted cost for http-only watchapps are recorded in KNOWN_ISSUES.md.

Verification record:

- Tests: 35 unit tests across six suites cover the resolver's
  tri-state and default resolution (asymmetric-default cross-wire
  pins, live re-emission on default and row changes), the geolocation
  gate (denied at start, revoked mid-watch, re-granted, cleared,
  id-reuse cancellation, registration bounding), the PKJS interceptor
  and config-page gates, the session coordinator (conflation, blip
  survival, restart guards, serialization), and dialog contrast under
  the onboarding color scheme. Each guarded decision fails its test
  when individually reverted, checked by mutation.
- On-device (a Pixel running GrapheneOS): deny at load, grant
  mid-session with a single automatic restart, live revocation of both
  capabilities mid-session, config-page gate in both directions, proxy
  teardown, grant deletion on app removal, menu-speed app switching,
  and fresh-install onboarding twice with asymmetric defaults verified
  in the persisted config; the upgrade path shows the What's-New
  announcement once.
- Two pre-merge review rounds (the feature range, then the review-fix
  range) with adversarially verified findings; every confirmed finding
  was resolved on-branch or refuted on reachability.
