### PR TITLE
Make the tree F-Droid deliverable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          # Full history with tags: versionName is `git describe --tags HEAD`
+          # and versionCode the commit count, and the check below compares
+          # the built values against them.
+          fetch-depth: 0
       - name: Cache build deps
         uses: actions/cache@v4
         with:
@@ -24,8 +28,17 @@ jobs:
           key: android-deps-${{ runner.os }}-${{ hashFiles('gradle/**', 'gradlew*', 'gradle.properties', '*.gradle*') }}
           restore-keys: |
             android-deps-${{ runner.os }}-
+      # assembleRelease on a checkout with no keystore is the F-Droid shape:
+      # release packages unsigned, and the packaging-time APK checks in
+      # androidApp/build.gradle.kts run against both variants.
       - name: Build and Test
-        run: ./gradlew :androidApp:assembleDebug testDebugUnitTest testAndroidHostTest jvmTest lintDebug
-        env:
-          GITHUB_ACTOR: ${{ secrets.READ_PACKAGES_ACTOR }}
-          GITHUB_TOKEN: ${{ secrets.READ_PACKAGES_TOKEN }}
+        run: ./gradlew :androidApp:assembleDebug :androidApp:assembleRelease testDebugUnitTest testAndroidHostTest jvmTest lintDebug
+      - name: Check the built version against the built commit
+        run: |
+          expected="$(git describe --tags HEAD 2>/dev/null || echo unknown)"
+          aapt2="$(ls -d "$ANDROID_HOME"/build-tools/*/aapt2 | sort -V | tail -n 1)"
+          badging="$("$aapt2" dump badging androidApp/build/outputs/apk/release/androidApp-release-unsigned.apk | head -n 1)"
+          actual="$(printf '%s' "$badging" | sed -n "s/.*versionName='\([^']*\)'.*/\1/p")"
+          echo "expected versionName: $expected"
+          echo "built:                $badging"
+          test "$expected" = "$actual"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,8 +61,11 @@ Firebase stubs, the unplugged Ring module) lives in `DESIGN_NOTES.md`.
 - **Stay F-Droid deliverable.** The fork targets inclusion in F-Droid's
   main repository, so a change must not add non-free dependencies,
   dependencies from repositories F-Droid does not allow, or prebuilt
-  binaries in the tree. The pre-existing violations are recorded in
-  `KNOWN_ISSUES.md`; do not add new ones.
+  binaries in the tree. `FdroidGuardrailsTest` in `:androidApp` replicates
+  F-Droid's source scanner over the tracked tree (dependency lines in every
+  gradle file, iOS-only and unplugged modules included; maven URLs; checked-in
+  binaries) and defines the envelope: it must stay green, and a change that
+  needs it loosened is a change that breaks the target.
 - **Security first.** No known security flaw ships, however small; genuinely
   deferred issues are documented in `KNOWN_ISSUES.md` with rationale. Any
   cross-app interface (e.g. the third-party mic API) must be explicitly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,11 +17,11 @@ Firebase stubs, the unplugged Ring module) lives in `DESIGN_NOTES.md`.
   upstream call sites intact so upstream merges stay cheap. `DESIGN_NOTES.md`
   maps the existing seams (the `:firebase-stubs` and `:haversine-stubs`
   modules, the unplugged `experimental` module, the no-op `LibIndex`);
-  extend those seams rather than deleting upstream code. The FCM push stack is the one deliberate
-  exception to the seam rule: push either registers a device token with
-  Google or does not exist, so `PushMessaging`, `PushService`, and their
-  call sites were deleted outright rather than no-opped; do not read that
-  deletion as precedent for other strips.
+  extend those seams rather than deleting upstream code. The FCM push stack
+  is the one deliberate exception to the seam rule: push either registers a
+  device token with Google or does not exist, so `PushMessaging`,
+  `PushService`, and their call sites were deleted outright rather than
+  no-opped; do not read that deletion as precedent for other strips.
 - **The speech engine is whisper.cpp, built from source.** Upstream's
   proprietary Cactus engine modules are replaced by the fork's
   `:whisper`/`:whisper-native` pair; the engine is a pinned git submodule

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,10 +62,13 @@ Firebase stubs, the unplugged Ring module) lives in `DESIGN_NOTES.md`.
   main repository, so a change must not add non-free dependencies,
   dependencies from repositories F-Droid does not allow, or prebuilt
   binaries in the tree. `FdroidGuardrailsTest` in `:androidApp` replicates
-  F-Droid's source scanner over the tracked tree (dependency lines in every
-  gradle file, iOS-only and unplugged modules included; maven URLs; checked-in
-  binaries) and defines the envelope: it must stay green, and a change that
-  needs it loosened is a change that breaks the target.
+  F-Droid's source scanner over the tracked tree, the whisper.cpp submodule
+  included, minus the paths the F-Droid recipe removes (dependency lines in
+  every gradle file, iOS-only and unplugged modules included; maven URLs;
+  checked-in binaries; lockfile-less dependency manifests), and defines the
+  envelope: it must stay green, and a change that needs it loosened is a
+  change that breaks the target. The recipe contract the tree assumes is in
+  `DESIGN_NOTES.md` (F-Droid section).
 - **Security first.** No known security flaw ships, however small; genuinely
   deferred issues are documented in `KNOWN_ISSUES.md` with rationale. Any
   cross-app interface (e.g. the third-party mic API) must be explicitly

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,9 +15,9 @@ Firebase stubs, the unplugged Ring module) lives in `DESIGN_NOTES.md`.
 - **De-Google at the DI seam, not by mass deletion.** Swap Firebase/GMS-backed
   implementations for no-op or GMS-free ones at the Koin module level, keeping
   upstream call sites intact so upstream merges stay cheap. `DESIGN_NOTES.md`
-  maps the existing seams (the `:firebase-stubs` module, the unplugged
-  `experimental` module, the no-op `LibIndex`); extend those seams rather
-  than deleting upstream code. The FCM push stack is the one deliberate
+  maps the existing seams (the `:firebase-stubs` and `:haversine-stubs`
+  modules, the unplugged `experimental` module, the no-op `LibIndex`);
+  extend those seams rather than deleting upstream code. The FCM push stack is the one deliberate
   exception to the seam rule: push either registers a device token with
   Google or does not exist, so `PushMessaging`, `PushService`, and their
   call sites were deleted outright rather than no-opped; do not read that

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -32,6 +32,23 @@ entities, which need `mcp`. Their runtime is dead:
   the `experimental` module trips duplicate-class errors;
 - `CoreConfig.enableIndex` has no reachable set-point.
 
+The Ring satellite library `libindex` compiles against
+(`io.github.coredevices.haversine`, a prebuilt AAR with no public source
+that bundles two native libraries per ABI) is replaced by the fork module
+`:haversine-stubs`: inert same-FQN stand-ins for the seven symbols
+`libindex` references, whose satellite classes have private constructors
+and no factory, so no ring object can exist anywhere in the app. The
+wiring is a `dependencySubstitution` rule in `settings.gradle.kts` rather
+than an edited dependency line, because the only consumer,
+`libindex/build.gradle.kts`, is an upstream file the fork otherwise leaves
+untouched; the rule matches the coordinate by group and name, so an
+upstream version bump still lands on the stub. `AppClasspathSentinelTest`
+in `:androidApp` pins the swap from the shipping runtime graph (the AAR's
+wrapped `com.wtlp.*` vendor classes must be absent), and the release APK
+carries no `libhaversinesatellitelibrary.so` / `libppcommon.so`. This was
+the last prebuilt native code in the app and the last tree-level F-Droid
+inclusion blocker.
+
 ## Firebase
 
 The Firebase SDKs are gone via the same idea at a different seam: the

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -254,6 +254,72 @@ existing installs rides the incompatible-model sweep in
 user's local mode is stashed, and `SttModelUpdatePrompt` restores it
 once a catalog model is downloaded.
 
+## F-Droid
+
+The fork targets inclusion in F-Droid's main repository. What that means
+in practice is a split between what the tree guarantees on its own and
+what the build recipe (the app's metadata file in F-Droid's `fdroiddata`
+repository, maintained out of tree) has to supply. The two must agree, so
+both halves are recorded here.
+
+What the tree guarantees, and how it is pinned:
+
+- No binaries are tracked, no dependency comes from a repository outside
+  F-Droid's allowlist, and no dependency line matches F-Droid's "usual
+  suspects" signature database. `FdroidGuardrailsTest` in `:androidApp`
+  replicates the buildserver's source scanner (`FdroidScannerReplica`
+  holds the checks, `FdroidScannerReplicaTest` proves each one fires) over
+  the tracked tree, the whisper.cpp submodule included, minus the paths the
+  recipe removes before scanning. Its `recipeRemovedPaths` list is the
+  tree's copy of the recipe's `rm:` field. F-Droid's inclusion policy is
+  about the tree and about dependency provenance, not about native code as
+  such: free-software Maven artifacts from allowed repositories may carry
+  compiled native libraries, and the APK does still ship such libraries
+  (the Speex codec from `io.github.coredevices.speex`, Apache-2.0 with
+  public source; SQLite from `androidx.sqlite:sqlite-bundled`; androidx
+  graphics-path) next to the whisper engine built from source. What the
+  fork removed was prebuilt native code with no public source (the Cactus
+  engine, the Ring satellite AAR), which the policy does reject.
+- The engine toolchain is pinned in `whisper-native/build.gradle.kts`
+  (`ndkVersion` 28.2.13676358, that is NDK r28c, and CMake 3.22.1), so a
+  build is the same on every machine and the recipe has exact values to
+  provision.
+- `versionName` is `git describe --tags HEAD` and `versionCode` the commit
+  count, both functions of the built commit (`androidApp/build.gradle.kts`),
+  so a tag checkout reports exactly the tag name and the values the recipe
+  declares for that tag can be checked against the built APK.
+- A checkout without `keystore.jks` packages release unsigned, and the
+  APK carries no dependency-metadata signing block (both in
+  `androidApp/build.gradle.kts`, verified against the built APK).
+
+What the recipe has to supply (field names as in the fdroiddata format):
+
+- `submodules: yes`: the engine is compiled from the whisper.cpp submodule.
+- `rm:` exactly the directories `FdroidGuardrailsTest.recipeRemovedPaths`
+  lists under `whisper-native/src/main/cpp/whisper.cpp/` (bindings,
+  examples, models, samples, tests). They hold language bindings with their
+  own gradle builds and a lockfile-less `package.json`, example apps naming
+  a maven host off the allowlist, binary test-fixture models, and sample
+  audio, none of it part of the fork's build. `rm:`, not `scandelete:`: the
+  scanner counts a `scandelete` entry that removed nothing as an error,
+  while `rm:` tolerates a path that is already gone.
+- `ndk:` r28c (28.2.13676358) and a `prebuild`/`sudo` step that installs the
+  SDK package `cmake;3.22.1`, matching the pins above; the buildserver
+  provisions neither by default and a mismatch fails configuration.
+- JDK 17: `libpebble3`, `blobannotations`, and `blobdbgen` pin
+  `jvmToolchain(17)` and Gradle toolchain auto-download is off on the
+  buildserver, which ships a newer JDK, so the recipe installs
+  `openjdk-17-jdk-headless` (`sudo:`).
+- A build against a tag checkout (`commit:` the tag) with the tag's literal
+  `versionName` and `versionCode`; the F-Droid build fails if the built
+  values differ from the declared ones.
+- The build subdirectory is `androidApp`; the unsigned release APK is the
+  output F-Droid signs.
+- Anti-features: the on-device dictation models are runtime downloads from
+  Hugging Face (`WhisperModelCatalog`), which is expected to draw the
+  NonFreeNet anti-feature flag; that documents but does not block
+  inclusion.
+
 ## Branding assets
 
 applicationId is `com.anopticlabs.gravel`; the Kotlin `namespace` and

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -37,17 +37,22 @@ The Ring satellite library `libindex` compiles against
 that bundles two native libraries per ABI) is replaced by the fork module
 `:haversine-stubs`: inert same-FQN stand-ins for the seven symbols
 `libindex` references, whose satellite classes have private constructors
-and no factory, so no ring object can exist anywhere in the app. The
-wiring is a `dependencySubstitution` rule in `settings.gradle.kts` rather
-than an edited dependency line, because the only consumer,
-`libindex/build.gradle.kts`, is an upstream file the fork otherwise leaves
-untouched; the rule matches the coordinate by group and name, so an
-upstream version bump still lands on the stub. `AppClasspathSentinelTest`
-in `:androidApp` pins the swap from the shipping runtime graph (the AAR's
-wrapped `com.wtlp.*` vendor classes must be absent), and the release APK
-carries no `libhaversinesatellitelibrary.so` / `libppcommon.so`. This was
-the last prebuilt native code in the app and the last tree-level F-Droid
-inclusion blocker.
+and no factory, so no ring object can exist anywhere in the app
+(`HaversineStubShapeTest` pins that shape, `HaversineStubTest` the two
+static entry points). The wiring is a `dependencySubstitution` rule in
+`settings.gradle.kts`, applied to every project, rather than an edited
+dependency line: the artifact is a transitive runtime dependency of every
+module that depends on `libindex`, which the rule covers and a single
+edited line would not, and the rule matches the coordinate by group and
+name, so an upstream version bump still lands on the stub. Nothing names
+`:haversine-stubs` directly, so a lost rule would bring the AAR back
+silently; `AppClasspathSentinelTest` in `:androidApp` pins the swap from
+the shipping runtime graph (the AAR's wrapped `com.wtlp.*` vendor classes
+must be absent), and `VerifyApkContents` asserts the release APK carries
+no `libhaversinesatellitelibrary.so` / `libppcommon.so`. This was the
+last dependency whose native code had no public source, and the last
+tree-level F-Droid inclusion blocker (the F-Droid section below records
+what the tree guarantees).
 
 ## Firebase
 

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -289,8 +289,12 @@ What the tree guarantees, and how it is pinned:
   so a tag checkout reports exactly the tag name and the values the recipe
   declares for that tag can be checked against the built APK.
 - A checkout without `keystore.jks` packages release unsigned, and the
-  APK carries no dependency-metadata signing block (both in
-  `androidApp/build.gradle.kts`, verified against the built APK).
+  APK carries no dependency-metadata signing block; both are checked by
+  the packaging-time `VerifyApkContents` task in
+  `androidApp/build.gradle.kts`, which also asserts the excluded assets and
+  the replaced native libraries are absent from every APK. CI builds the
+  release variant on a keystore-less checkout and compares the built
+  `versionName` with `git describe` of the built commit.
 
 What the recipe has to supply (field names as in the fdroiddata format):
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -183,6 +183,24 @@ rules that would keep insecure WebSocket covered deterministically. This
 entry leaves the file if that ships, or if the ecosystem's http-only
 apps age out.
 
+## Language pack downloads are not digest-pinned
+
+**Status: deferred; upstream-inherited, integrity rests on transport security.**
+
+Watch language packs come from a catalog compiled into
+`LanguagePackRepository`: 125 files on binaries.rebble.io and 12 on four
+individual contributors' GitHub repositories, ten of those referenced by a
+mutable branch name rather than a commit. A pack is downloaded and sent to
+the watch with no digest or size check. Firmware bundles and speech models
+in this fork are integrity-pinned; language packs are the one remaining
+install path where a substituted or compromised host, or a force-pushed
+branch, delivers whatever bytes it likes to the watch, bounded only by TLS
+to the host. The fix is per-file digests in the catalog, checked before
+install, in the style of `WhisperModelCatalog`; that needs the catalog
+re-derived with hashes and a decision on the branch-referenced entries
+(pin to a commit or drop), so it is deferred as its own change. This entry
+leaves the file when the catalog carries verified digests.
+
 ## Sleep blob mixes epoch timestamps with seconds-of-day typicals
 
 **Status: deferred; upstream-inherited display defect, no data at risk.**

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -188,18 +188,22 @@ apps age out.
 **Status: deferred; upstream-inherited, integrity rests on transport security.**
 
 Watch language packs come from a catalog compiled into
-`LanguagePackRepository`: 125 files on binaries.rebble.io and 12 on four
-individual contributors' GitHub repositories, ten of those referenced by a
-mutable branch name rather than a commit. A pack is downloaded and sent to
-the watch with no digest or size check. Firmware bundles and speech models
-in this fork are integrity-pinned; language packs are the one remaining
-install path where a substituted or compromised host, or a force-pushed
-branch, delivers whatever bytes it likes to the watch, bounded only by TLS
-to the host. The fix is per-file digests in the catalog, checked before
-install, in the style of `WhisperModelCatalog`; that needs the catalog
-re-derived with hashes and a decision on the branch-referenced entries
-(pin to a commit or drop), so it is deferred as its own change. This entry
-leaves the file when the catalog carries verified digests.
+`LanguagePackRepository`: 137 entries, 125 of them on binaries.rebble.io
+and 12 on four individual contributors' GitHub repositories; of those 12,
+two reference a mutable branch, eight are release assets addressed by a
+tag name (replaceable by the repository owner without a tag change), and
+two are pinned to a commit. A pack is downloaded and sent to the watch
+with no digest or size check. Firmware bundles and speech models in this
+fork are integrity-pinned; language packs are the one remaining install
+path where a substituted or compromised host, a re-uploaded release asset,
+or a force-pushed branch delivers whatever bytes it likes to the watch,
+bounded only by TLS to the host. The fix is per-file digests in the
+catalog, checked before install, in the style of `WhisperModelCatalog`;
+that needs the catalog re-derived with hashes and a decision on the two
+branch-referenced entries (pin to a commit or drop; release assets have no
+commit-addressed form, so the digest is the whole fix there), so it is
+deferred as its own change. This entry leaves the file when the catalog
+carries verified digests.
 
 ## Sleep blob mixes epoch timestamps with seconds-of-day typicals
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -183,29 +183,6 @@ rules that would keep insecure WebSocket covered deterministically. This
 entry leaves the file if that ships, or if the ecosystem's http-only
 apps age out.
 
-## Prebuilt Haversine satellite libraries remain an F-Droid blocker
-
-**Status: open; the speech stack no longer blocks inclusion.**
-
-The fork targets inclusion in F-Droid's main repository. The on-device
-speech stack, formerly the main blocker, is now free software built from
-source: the whisper.cpp engine is an MIT-licensed git submodule compiled
-by the NDK during the build, and the model weights (MIT, the whisper.cpp
-author's own conversions of OpenAI's release) are integrity-pinned
-runtime downloads, never checked in. Runtime model downloads from
-Hugging Face are expected to draw the NonFreeNet anti-feature flag,
-which documents but does not block inclusion.
-
-What still fails policy is the `io.github.coredevices.haversine` AAR,
-which ships prebuilt satellite `.so` libraries into the APK even though
-the Ring runtime they serve is disabled at the DI seam; the satellite C
-sources and their licensing are unconfirmed. Resolving it means removing
-Haversine from the classpath (it remains only as a compile-time
-dependency of the deliberately retained `:libindex`) or upstream
-publishing source and license for it. Routine submission work (build
-recipe, signing, versioning) is not tracked here. This entry leaves the
-file when an F-Droid submission is accepted or the target is dropped.
-
 ## Sleep blob mixes epoch timestamps with seconds-of-day typicals
 
 **Status: deferred; upstream-inherited display defect, no data at risk.**
@@ -246,23 +223,6 @@ leaves the file if the fork adopts the resume machinery for its verified
 flow (plausible follow-up: writing the interrupted-update record at the
 sideload boundary) or upstream's toggle becomes conditional on the
 feature being armable.
-
-## The Haversine AAR embeds an inert debug telemetry endpoint
-
-**Status: accepted; the code is unreachable, the artifact is unchanged.**
-
-The prebuilt `haversine` satellite library AAR (kept on the classpath as
-a compile-time dependency of the deliberately retained `:libindex`) ships
-a default debug-log delegate class containing a hardcoded MongoDB Atlas
-Data API write endpoint and a hardcoded firmware-release URL. The class
-is present in the APK's dex but nothing in this fork constructs it: the
-Ring runtime that would use Haversine is disabled at the DI seam
-(`NoOpLibIndex` never scans, no ring can pair), so no code path reaches
-the delegate. This is the same acceptance already recorded for the
-Haversine prebuilts in the F-Droid entry above, extended to name the
-endpoint explicitly so artifact-level endpoint scans have a documented
-match. This entry leaves the file when Haversine leaves the classpath or
-ships without the debug delegate.
 
 ## The "Use Core OTA service" debug toggle is inert in fork builds
 

--- a/LICENSE-Inter-OFL
+++ b/LICENSE-Inter-OFL
@@ -1,0 +1,92 @@
+Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION AND CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ a security posture tightened beyond upstream's defaults.
   authorization-gated, rather than locking watch mic audio to first-party
   features.
 - **Distribution through F-Droid.** The fork targets inclusion in F-Droid's
-  main repository; the blockers still standing are tracked in
-  [KNOWN_ISSUES.md](KNOWN_ISSUES.md).
+  main repository. The app ships no prebuilt binaries and no non-free
+  dependencies (the speech engine is built from source, the last prebuilt
+  native library, the Ring satellite AAR, is replaced by a stub); what
+  remains is the submission itself.
 
 Out of scope: iOS (sources remain in-tree but are unmaintained here), and the
 Pebble Index 01 (Ring) / Index AI features, due to their heavy reliance on
@@ -61,7 +63,7 @@ De-google work is completed, all telemetry is removed. What remains is polish an
       proprietary Cactus stack)
 - [ ] Third-party microphone API
 - [ ] Local on-device battery analytics (secondary goal, feasibility open)
-- [ ] F-Droid inclusion (blockers tracked in KNOWN_ISSUES.md)
+- [ ] F-Droid inclusion (tree ready; submission pending)
 
 ## Building (Android)
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,12 @@ a security posture tightened beyond upstream's defaults.
   authorization-gated, rather than locking watch mic audio to first-party
   features.
 - **Distribution through F-Droid.** The fork targets inclusion in F-Droid's
-  main repository. The app ships no prebuilt binaries and no non-free
-  dependencies (the speech engine is built from source, the last prebuilt
-  native library, the Ring satellite AAR, is replaced by a stub); what
-  remains is the submission itself.
+  main repository. The tree holds no binaries and every dependency is free
+  software from a repository F-Droid allows: the speech engine is built
+  from source, and the Ring satellite library, the last dependency whose
+  native code had no public source, is replaced by a stub. What remains is
+  the submission itself; `DESIGN_NOTES.md` records what the tree
+  guarantees and what the build recipe has to supply.
 
 Out of scope: iOS (sources remain in-tree but are unmaintained here), and the
 Pebble Index 01 (Ring) / Index AI features, due to their heavy reliance on

--- a/README.md
+++ b/README.md
@@ -124,5 +124,10 @@ documentation describe device compatibility, nothing more; the fork's own
 branding (name, icon, colors) is deliberately distinct so users are never
 confused about which app they are running.
 
+The bundled Inter typeface (version 4.001, copyright 2016 The Inter Project
+Authors) is licensed under the SIL Open Font License 1.1; the notice and
+license text are in [LICENSE-Inter-OFL](LICENSE-Inter-OFL). The whisper.cpp
+speech engine submodule carries its own MIT license file.
+
 Development of this fork uses AI assistance; commits carry `Co-Authored-By`
 trailers accordingly, matching upstream's disclosure practice.

--- a/README.md
+++ b/README.md
@@ -74,9 +74,12 @@ De-google work is completed, all telemetry is removed. What remains is polish an
   `./gradlew :androidApp:assembleDebug`
 - No `google-services.json` is needed: the google-services plugin is gone
   along with the Firebase SDKs.
-- For a release build signed with the debug key, set
-  `LOCAL_RELEASE_BUILD=true` in the root `local.properties`, then
-  `./gradlew :androidApp:assembleRelease`.
+- Release builds: `./gradlew :androidApp:assembleRelease` signs with
+  `keystore.jks` in the repo root when present (credentials from the
+  `RELEASE_KEYSTORE_PASSWORD`, `RELEASE_KEYSTORE_ALIAS`, and
+  `RELEASE_KEY_PASSWORD` environment variables), produces an unsigned APK
+  when it is absent, and signs with the debug key instead if
+  `LOCAL_RELEASE_BUILD=true` is set in the root `local.properties`.
 - Fork builds ship no Memfault token and make no Memfault requests.
   Upstream's optional `memfaultToken` Gradle property would route Core
   watch update checks through `api.memfault.com`, periodically sending the

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -16,6 +16,15 @@ val properties = Properties().apply {
 }
 val localReleaseBuild = properties["LOCAL_RELEASE_BUILD"]?.toString()?.toBooleanStrictOrNull() ?: false
 
+// Fork: release is signed with the keystore only when one is actually present
+// next to the checkout. A checkout without one (a fresh clone, CI, an F-Droid
+// build, which signs the APK itself afterwards) then packages release
+// unsigned instead of failing on a missing keystore file. LOCAL_RELEASE_BUILD
+// keeps its meaning: sign release with the debug key so it installs over a
+// debug build.
+val releaseKeystore = rootDir.resolve("keystore.jks")
+val signReleaseWithKeystore = !localReleaseBuild && releaseKeystore.exists()
+
 // Number of commits in the git history, so it always increases on main.
 val gitVersionCode = providers.exec {
     isIgnoreExitValue = true
@@ -40,10 +49,10 @@ android {
     namespace = "coredevices.coreapp"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
-    if (!localReleaseBuild) {
+    if (signReleaseWithKeystore) {
         signingConfigs {
             create("release") {
-                storeFile = file("../keystore.jks")
+                storeFile = releaseKeystore
                 storePassword = System.getenv("RELEASE_KEYSTORE_PASSWORD")
                 keyAlias = System.getenv("RELEASE_KEYSTORE_ALIAS")
                 keyPassword = System.getenv("RELEASE_KEY_PASSWORD")
@@ -69,13 +78,24 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+    androidResources {
+        // Fork: the two Wispr Flow logos are compose resources of :pebble
+        // (packaged as assets) that nothing references in fork builds, where
+        // the remote Wispr transcription path can never be enabled. Dropped
+        // at the packaging boundary rather than deleted from the upstream
+        // resource directory, which an upstream sync would resurrect. The
+        // property replaces the AGP default, so the default patterns are
+        // restated ahead of the two additions.
+        ignoreAssetsPattern = "!.svn:!.git:!.ds_store:!*.scc:.*:<dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~" +
+            ":!wispr_flow_logo_black.png:!wispr_flow_logo_white.png"
+    }
     buildTypes {
         getByName("release") {
             isMinifyEnabled = true
             isShrinkResources = true
             if (localReleaseBuild) {
                 signingConfig = signingConfigs.getByName("debug")
-            } else {
+            } else if (signReleaseWithKeystore) {
                 signingConfig = signingConfigs.getByName("release")
             }
             isDebuggable = false
@@ -89,6 +109,14 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+    }
+    // Fork: AGP by default appends a dependency-metadata block to the APK
+    // signing block, compressed and encrypted so that only Google Play can
+    // read it. Nothing in this fork's distribution can consume it, and
+    // F-Droid's APK scan reports it as an extra signing block.
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
     }
 }
 

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -279,6 +279,17 @@ abstract class VerifyExportedComponents : DefaultTask() {
     }
 }
 
+// Fork: FdroidGuardrailsTest reads the git-tracked tree (build files, tracked
+// binaries) through git rather than through declared task inputs, so Gradle
+// cannot tell when its verdict is stale. Left tracked, an unchanged test
+// classpath would let the unit test task be skipped as up-to-date or restored
+// from the build cache while the tree it judges had changed, which is the
+// silent-skip shape the guardrail exists to prevent. The module's unit tests
+// are few and fast, so they simply always run.
+tasks.withType<Test>().configureEach {
+    doNotTrackState("FdroidGuardrailsTest scans the git-tracked tree, which is not a declared input")
+}
+
 // Resolved at execution time — a configuration-time .get() makes every commit invalidate the
 // configuration cache.
 androidComponents {

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -16,9 +16,6 @@ val properties = Properties().apply {
 }
 val localReleaseBuild = properties["LOCAL_RELEASE_BUILD"]?.toString()?.toBooleanStrictOrNull() ?: false
 
-// Hoisted out of the lambda below, which must not capture the project.
-val providerFactory = providers
-
 // Number of commits in the git history, so it always increases on main.
 val gitVersionCode = providers.exec {
     isIgnoreExitValue = true
@@ -27,16 +24,17 @@ val gitVersionCode = providers.exec {
     it.trim().toIntOrNull() ?: throw GradleException("Error reading current commit count")
 }
 
-// Newest tag anywhere in the repo, including on branches HEAD doesn't descend from.
+// Fork: described from HEAD, so the value is a function of the built commit:
+// exactly the tag name on a tag checkout, "<tag>-<n>-g<sha>" past one, and
+// "unknown" when no tag is reachable. Upstream derives it from the newest tag
+// anywhere in the repository, so an older tag rebuilt after a newer one
+// exists reports the newer version and every branch reports the newest tag.
+// F-Droid builds a tag checkout and requires the built versionName to equal
+// the one declared for that tag, which needs the per-commit derivation.
 val gitVersionName = providers.exec {
     isIgnoreExitValue = true
-    commandLine("git", "rev-list", "--tags", "--max-count=1")
-}.standardOutput.asText.flatMap { rev ->
-    providerFactory.exec {
-        isIgnoreExitValue = true
-        commandLine("git", "describe", "--tags", rev.trim().ifEmpty { "HEAD" })
-    }.standardOutput.asText
-}.map { it.trim().ifEmpty { "unknown" } }
+    commandLine("git", "describe", "--tags", "HEAD")
+}.standardOutput.asText.map { it.trim().ifEmpty { "unknown" } }
 
 android {
     namespace = "coredevices.coreapp"

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,4 +1,8 @@
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import java.util.Properties
+import java.util.zip.ZipFile
 
 // Fork: upstream applies the google-services and firebase-crashlytics plugins
 // here; both are removed with the rest of the Firebase/GMS stack. See
@@ -279,15 +283,107 @@ abstract class VerifyExportedComponents : DefaultTask() {
     }
 }
 
-// Fork: FdroidGuardrailsTest reads the git-tracked tree (build files, tracked
-// binaries) through git rather than through declared task inputs, so Gradle
-// cannot tell when its verdict is stale. Left tracked, an unchanged test
-// classpath would let the unit test task be skipped as up-to-date or restored
-// from the build cache while the tree it judges had changed, which is the
-// silent-skip shape the guardrail exists to prevent. The module's unit tests
-// are few and fast, so they simply always run.
+/**
+ * Fork: inspects every APK a variant packages, so the packaging decisions taken in this file are
+ * verified against the built artifact on every build rather than by hand:
+ * - no entry matches [forbiddenEntries]: the Wispr Flow logo assets ignoreAssetsPattern drops
+ *   and the two native libraries of the Ring satellite AAR that :haversine-stubs replaces;
+ * - the APK Signing Block is present or absent as the variant's signing configuration says
+ *   ([expectSigned]: a release built without a keystore must come out unsigned, which is the
+ *   shape F-Droid builds), and when present never carries the dependency-metadata pair
+ *   (id 0x504b4453) that the dependenciesInfo block above turns off.
+ * Wired with toListenTo(SingleArtifact.APK), which runs the task as a finalizer of the packaging
+ * task whenever the APK is produced (assemble, install), for every variant. AGP generates the
+ * dependency metadata for release builds only and an unsigned APK has no signing block to carry
+ * it, so that check bites on signed release builds (a keystore build, or LOCAL_RELEASE_BUILD);
+ * the debug build still exercises the signing-block parse on a signed APK.
+ */
+abstract class VerifyApkContents : DefaultTask() {
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val apkDirectory: DirectoryProperty
+
+    /** Regular expressions over zip entry names; any match fails the build. */
+    @get:Input
+    abstract val forbiddenEntries: ListProperty<String>
+
+    @get:Input
+    abstract val expectSigned: Property<Boolean>
+
+    @TaskAction
+    fun verify() {
+        val apks = apkDirectory.get().asFile.walkTopDown().filter { it.isFile && it.extension == "apk" }.toList()
+        if (apks.isEmpty()) throw GradleException("No APK found under ${apkDirectory.get().asFile}")
+        val forbidden = forbiddenEntries.get().map(::Regex)
+        val report = StringBuilder()
+        for (apk in apks) {
+            ZipFile(apk).use { zip ->
+                val hits = zip.entries().asSequence().map { it.name }.filter { name -> forbidden.any { it.matches(name) } }.toList()
+                if (hits.isNotEmpty()) report.appendLine("${apk.name} packages forbidden entries: $hits")
+            }
+            val ids = signingBlockIds(apk)
+            if (expectSigned.get() && ids == null) report.appendLine("${apk.name} has no APK Signing Block but this variant is configured to sign")
+            if (!expectSigned.get() && ids != null) report.appendLine("${apk.name} is signed (block ids ${ids.map { it.toString(16) }}) but no keystore was configured for this variant")
+            if (ids != null && DEPENDENCY_METADATA_ID in ids) report.appendLine("${apk.name} carries the dependency-metadata signing block (0x504b4453); dependenciesInfo must stay disabled")
+        }
+        if (report.isNotEmpty()) throw GradleException("APK contents check failed:\n$report")
+        logger.lifecycle("APK contents verified: ${apks.joinToString { it.name }}")
+    }
+
+    /**
+     * The pair ids in the APK Signing Block, or null when the APK has none (an unsigned APK).
+     * Layout, per the APK signature scheme v2 documentation: the block sits immediately before
+     * the ZIP central directory and ends with a uint64 size followed by the 16-byte magic
+     * "APK Sig Block 42"; the size covers the pairs, the trailing size field, and the magic, and
+     * the same size is repeated as a uint64 at the very start of the block. Each pair is a uint64
+     * length, a uint32 id, and (length - 4) bytes of value.
+     */
+    private fun signingBlockIds(apk: File): List<Long>? = RandomAccessFile(apk, "r").use { raf ->
+        val little = ByteOrder.LITTLE_ENDIAN
+        val length = raf.length()
+        val tailStart = maxOf(0L, length - 22 - 0xFFFF)
+        val tail = ByteArray((length - tailStart).toInt()).also { raf.seek(tailStart); raf.readFully(it) }
+        val tailBuffer = ByteBuffer.wrap(tail).order(little)
+        val eocd = (tail.size - 22 downTo 0).firstOrNull { tailBuffer.getInt(it) == 0x06054b50 }
+            ?: throw GradleException("${apk.name}: no end-of-central-directory record; not a zip")
+        val centralDirectory = tailBuffer.getInt(eocd + 16).toLong() and 0xFFFFFFFFL
+        if (centralDirectory < 32) return null
+        val footer = ByteArray(24).also { raf.seek(centralDirectory - 24); raf.readFully(it) }
+        if (String(footer, 8, 16, Charsets.US_ASCII) != "APK Sig Block 42") return null
+        val size = ByteBuffer.wrap(footer).order(little).getLong(0)
+        val blockStart = centralDirectory - size - 8
+        val header = ByteArray(8).also { raf.seek(blockStart); raf.readFully(it) }
+        if (ByteBuffer.wrap(header).order(little).getLong(0) != size) {
+            throw GradleException("${apk.name}: APK Signing Block size fields disagree")
+        }
+        val ids = mutableListOf<Long>()
+        var position = blockStart + 8
+        val pairsEnd = centralDirectory - 24
+        while (position < pairsEnd) {
+            val pair = ByteArray(12).also { raf.seek(position); raf.readFully(it) }
+            val pairBuffer = ByteBuffer.wrap(pair).order(little)
+            ids += pairBuffer.getInt(8).toLong() and 0xFFFFFFFFL
+            position += 8 + pairBuffer.getLong(0)
+        }
+        ids
+    }
+
+    private companion object {
+        const val DEPENDENCY_METADATA_ID = 0x504b4453L
+    }
+}
+
+// Fork: FdroidGuardrailsTest and ExcludedAssetSentinelTest read the git-tracked
+// tree (build files, tracked binaries, sources) through git rather than
+// through declared task inputs, so Gradle cannot tell when their verdict is
+// stale. Left tracked, an unchanged test classpath would let the unit test
+// task be skipped as up-to-date or restored from the build cache while the
+// tree they judge had changed, which is the silent-skip shape the guardrails
+// exist to prevent. The module's unit tests are few and fast, so they simply
+// always run.
 tasks.withType<Test>().configureEach {
-    doNotTrackState("FdroidGuardrailsTest scans the git-tracked tree, which is not a declared input")
+    doNotTrackState("The tree-reading sentinels scan the git-tracked tree, which is not a declared input")
 }
 
 // Resolved at execution time — a configuration-time .get() makes every commit invalidate the
@@ -298,6 +394,26 @@ androidComponents {
             it.versionCode.set(gitVersionCode)
             it.versionName.set(gitVersionName)
         }
+
+        // Fork: artifact-level check of the packaging decisions above, for
+        // every variant; see VerifyApkContents.
+        val verifyApk = tasks.register<VerifyApkContents>(
+            "verify${variant.name.replaceFirstChar { it.uppercase() }}ApkContents",
+        ) {
+            group = "verification"
+            description = "Fails if the packaged APK carries excluded assets, replaced natives, or an unexpected signing block."
+            forbiddenEntries.set(
+                listOf(
+                    """.*wispr_flow_logo_(black|white)\.png""",
+                    """lib/[^/]+/libhaversinesatellitelibrary\.so""",
+                    """lib/[^/]+/libppcommon\.so""",
+                ),
+            )
+            expectSigned.set(variant.buildType != "release" || localReleaseBuild || signReleaseWithKeystore)
+        }
+        variant.artifacts.use(verifyApk)
+            .wiredWith(VerifyApkContents::apkDirectory)
+            .toListenTo(com.android.build.api.artifact.SingleArtifact.APK)
     }
 
     // Fork: release builds fail unless every exported component is allowlisted

--- a/androidApp/src/test/kotlin/coredevices/coreapp/AppClasspathSentinelTest.kt
+++ b/androidApp/src/test/kotlin/coredevices/coreapp/AppClasspathSentinelTest.kt
@@ -84,4 +84,24 @@ class AppClasspathSentinelTest {
     fun mixpanelIsOffTheAppClasspath() {
         assertAbsent("com.mixpanel.android.mpmetrics.MixpanelAPI")
     }
+
+    @Test
+    fun haversineSatelliteLibraryResolvesToTheForkStub() {
+        // libindex's upstream dependency line still names the prebuilt
+        // io.github.coredevices.haversine AAR; settings.gradle.kts swaps it
+        // for :haversine-stubs across every project. This probe pins the
+        // swap from the app's own runtime graph, so a lost or misapplied
+        // substitution (a settings.gradle.kts merge that drops it, say)
+        // fails here rather than quietly returning the AAR's two native
+        // libraries to the APK. The KMP facade name exists in both the AAR
+        // and the stub, so the positive control alone proves nothing: what
+        // distinguishes them is the AAR's wrapped vendor library
+        // (com.wtlp.*, the JNI side of the bundled .so files) and its
+        // transfer delegate, neither of which the stub declares.
+        Class.forName("coredevices.haversine.KMPHaversineSatelliteManager")
+        assertAbsent("com.wtlp.haversinesatellitelibrary.HaversineSatellite")
+        assertAbsent("com.wtlp.haversinesatellitelibrary.HaversineSatelliteManager")
+        assertAbsent("com.wtlp.ppcommon.PPCommon")
+        assertAbsent("coredevices.haversine.HaversineTransferDelegate")
+    }
 }

--- a/androidApp/src/test/kotlin/coredevices/coreapp/ExcludedAssetSentinelTest.kt
+++ b/androidApp/src/test/kotlin/coredevices/coreapp/ExcludedAssetSentinelTest.kt
@@ -1,0 +1,55 @@
+package coredevices.coreapp
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * The two Wispr Flow logo drawables are compose resources of :pebble that
+ * stay in the tree (an upstream sync would only put them back) but are kept
+ * out of the APK by ignoreAssetsPattern in androidApp/build.gradle.kts. The
+ * generated `Res.drawable` accessors for them still compile, so a Kotlin
+ * reference (upstream's WatchSettingsScreen has one, in a settings row the
+ * fork removed) would build, pass every test, and throw
+ * MissingResourceException the first time the screen composed. This pins the
+ * three facts that make the exclusion safe: no tracked Kotlin source names
+ * the resources, the exclusion is still declared, and the drawables are
+ * still tracked. If the drawables are ever deleted from :pebble, delete
+ * this sentinel and the ignoreAssetsPattern entries with them.
+ */
+class ExcludedAssetSentinelTest {
+
+    private val excludedDrawables = listOf("wispr_flow_logo_black", "wispr_flow_logo_white")
+
+    @Test
+    fun noKotlinSourceReferencesAnExcludedDrawable() {
+        val offenders = TrackedTree.files
+            .filter { it.endsWith(".kt") && !it.endsWith("/ExcludedAssetSentinelTest.kt") }
+            .filter { path ->
+                val text = TrackedTree.file(path).readText()
+                excludedDrawables.any { text.contains(it) }
+            }
+        assertTrue(
+            offenders.isEmpty(),
+            "These sources reference a drawable that ignoreAssetsPattern drops from the APK, which " +
+                "would throw MissingResourceException at runtime:\n" + offenders.joinToString("\n"),
+        )
+    }
+
+    @Test
+    fun theExclusionIsStillDeclared() {
+        val build = TrackedTree.file("androidApp/build.gradle.kts").readText()
+        excludedDrawables.forEach { name ->
+            assertTrue(build.contains("!$name.png"), "androidApp/build.gradle.kts no longer excludes $name.png from the APK")
+        }
+    }
+
+    @Test
+    fun theExcludedDrawablesAreStillTracked() {
+        excludedDrawables.forEach { name ->
+            assertTrue(
+                TrackedTree.files.any { it.endsWith("/composeResources/drawable/$name.png") },
+                "$name.png is no longer in the tree; remove its ignoreAssetsPattern entry and this sentinel",
+            )
+        }
+    }
+}

--- a/androidApp/src/test/kotlin/coredevices/coreapp/FdroidGuardrailsTest.kt
+++ b/androidApp/src/test/kotlin/coredevices/coreapp/FdroidGuardrailsTest.kt
@@ -1,125 +1,90 @@
 package coredevices.coreapp
 
+import coredevices.coreapp.FdroidScannerReplica.VersionCatalog
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertTrue
-import kotlin.test.fail
 
 /**
- * Source-level replica of the checks F-Droid's build scanner runs over a
- * checkout, applied to this repository's tracked tree on every CI run.
+ * F-Droid's source scanner, applied to this repository's tracked tree on
+ * every CI run.
  *
  * The fork targets inclusion in F-Droid's main repository, and most of the
- * ways that can regress arrive silently with an upstream sync: a dependency
- * line naming a Google artifact, a publishing block naming a private maven
- * host, a checked-in native library or archive. F-Droid only reports these
- * at submission or on its next build of a tag, long after the merge, so this
- * class fails the merge itself instead. It replicates fdroidserver's textual
- * scanner (fdroidserver/scanner.py) rather than approximating it: same
- * dependency-line matcher, same catalog resolution, same maven-URL regex and
- * allowlist, same binary-suffix list, and the same "usual suspects" gradle
- * signatures, pinned from the SUSS database (see [scannerGradleSignatures]).
+ * ways that can regress arrive silently with an upstream sync or a submodule
+ * bump: a dependency line naming a Google artifact, a publishing block naming
+ * a private maven host, a checked-in native library or archive. F-Droid only
+ * reports these at submission or on its next build of a tag, long after the
+ * merge, so this class fails the merge itself instead. The checks are
+ * [FdroidScannerReplica]'s; [FdroidScannerReplicaTest] proves each of them
+ * fires on a known-bad sample, so a green run here means the tree is clean
+ * rather than that a matcher went quiet.
  *
- * Three independent layers stand between an upstream sync and a policy
+ * Three independent guards stand between an upstream sync and a policy
  * regression, and this class is the source-text one:
  * - the classpath sentinels ([AppClasspathSentinelTest] and the library
  *   copies) prove the shipped runtime graph is clean;
- * - the release artifact is inspected directly (fork rule: verify against
- *   the APK, not the tree);
+ * - the built APK is inspected directly (fork rule: verify against the
+ *   artifact, not the tree);
  * - this class proves the tracked *tree* passes the scanner as F-Droid runs
  *   it, which the other two cannot see: an unplugged module's build file, an
  *   iOS-only dependency line, or a publishing block never reaches the
  *   Android classpath yet still fails the scan.
  *
- * Only the tracked tree is scanned (git ls-files), because that is what
- * F-Droid clones; the whisper.cpp submodule is deliberately not descended
- * into, since its examples and test fixtures are removed by the F-Droid
- * build recipe before the scan and never participate in the build.
- *
- * Re-syncing: when fdroidserver changes a regex or its allowlist, or the
- * SUSS database gains a signature that matters here, update the constants
- * below in place and note the upstream revision in the commit.
+ * Scope is what F-Droid scans: the tracked tree of the superproject plus the
+ * checked-out whisper.cpp submodule (the buildserver clones it, and
+ * scanner.py walks it like any other directory), minus the paths the F-Droid
+ * build recipe removes before its scan, listed in [recipeRemovedPaths]. That
+ * list is the tree's half of a contract with the out-of-tree recipe, and
+ * DESIGN_NOTES.md (F-Droid section) records the whole contract.
  */
 class FdroidGuardrailsTest {
 
-    // ---- Repository access -------------------------------------------------
-
-    /** The checkout root: the nearest ancestor of the test working directory holding settings.gradle.kts. */
-    private val repoRoot: File by lazy {
-        generateSequence(File("").absoluteFile) { it.parentFile }
-            .firstOrNull { File(it, "settings.gradle.kts").isFile }
-            ?: fail("Could not locate the repository root from ${File("").absolutePath}")
-    }
-
     /**
-     * Tracked paths relative to the root, as F-Droid's clone would see them.
-     * The submodule shows up as a single gitlink entry and is skipped by the
-     * per-file readers below (it is a directory on disk).
+     * Paths (relative to the checkout root, directories with a trailing
+     * slash) that the F-Droid build recipe deletes with its `rm:` field
+     * before building and scanning, so the scanner never sees them. Kept
+     * here so a submodule bump that adds a scanner hit outside them fails
+     * CI, and so the recipe can be written from the tree. Every entry must
+     * still exist in the tree ([recipeRemovedPathsStillExist]), otherwise
+     * the list has rotted away from the recipe. `rm:` rather than
+     * `scandelete:` on purpose: the scanner counts a scandelete entry that
+     * removed nothing as an error, `rm:` tolerates a missing path.
      */
-    private val trackedFiles: List<String> by lazy {
-        val process = ProcessBuilder("git", "-C", repoRoot.path, "ls-files", "-z")
-            .redirectErrorStream(true)
-            .start()
-        val output = process.inputStream.readBytes().toString(Charsets.UTF_8)
-        val exit = process.waitFor()
-        assertTrue(exit == 0, "git ls-files failed ($exit): $output")
-        output.split('\u0000').filter { it.isNotEmpty() }
-    }
-
-    private fun trackedGradleFiles(): List<File> = trackedFiles
-        .filter { it.endsWith(".gradle") || it.endsWith(".gradle.kts") }
-        .map { File(repoRoot, it) }
-        .filter { it.isFile }
-
-    // ---- Layer 1: maven repository URLs -----------------------------------
-
-    /**
-     * fdroidserver/scanner.py MAVEN_URL_REGEX, verbatim apart from Java's
-     * requirement that the literal brace be escaped. Applied, as there, to
-     * the file with line comments and block comments removed.
-     */
-    private val mavenUrlRegex = Regex(
-        """\smaven\s*(?:\{.*?(?:setUrl|url)|\(\s*(?:url)?)\s*=?\s*(?:uri|URI|Uri\.create)?\(?\s*["']?([^\s"']+)["']?[^})]*[)}]""",
-        RegexOption.DOT_MATCHES_ALL,
+    private val recipeRemovedPaths = listOf(
+        // whisper.cpp ships language bindings with their own gradle builds and
+        // a lockfile-less package.json, example apps with a maven URL off the
+        // allowlist, binary test-fixture models, sample audio, and its own
+        // test suite; none of it takes part in the fork's build.
+        "whisper-native/src/main/cpp/whisper.cpp/bindings/",
+        "whisper-native/src/main/cpp/whisper.cpp/examples/",
+        "whisper-native/src/main/cpp/whisper.cpp/models/",
+        "whisper-native/src/main/cpp/whisper.cpp/samples/",
+        "whisper-native/src/main/cpp/whisper.cpp/tests/",
     )
 
-    /** fdroidserver/scanner.py allowed_repos: hosts F-Droid trusts to serve free artifacts. */
-    private val allowedMavenRepos = listOf(
-        "repo1.maven.org/maven2",
-        "jitpack.io",
-        "www.jitpack.io",
-        "repo.maven.apache.org/maven2",
-        "oss.jfrog.org/artifactory/oss-snapshot-local",
-        "central.sonatype.com/repository/maven-snapshots",
-        "oss.sonatype.org/content/repositories/snapshots",
-        "oss.sonatype.org/content/repositories/releases",
-        "oss.sonatype.org/content/groups/public",
-        "oss.sonatype.org/service/local/staging/deploy/maven2",
-        "s01.oss.sonatype.org/content/repositories/snapshots",
-        "s01.oss.sonatype.org/content/repositories/releases",
-        "s01.oss.sonatype.org/content/groups/public",
-        "s01.oss.sonatype.org/service/local/staging/deploy/maven2",
-        "clojars.org/repo",
-        "repo.clojars.org",
-        "s3.amazonaws.com/repo.commonsware.com",
-        "plugins.gradle.org/m2",
-        "maven.google.com",
-    ).map { Regex("^https://" + Regex.escape(it) + "/*") }
+    /** The tracked tree as the scanner sees it after the recipe's removals. */
+    private val scannedFiles: List<String> by lazy {
+        TrackedTree.files.filterNot { path -> recipeRemovedPaths.any { path.startsWith(it) } }
+    }
 
-    private val gradleLineComment = Regex("""^[ ]*//""")
+    private fun scannedGradleFiles(): List<String> = scannedFiles.filter(FdroidScannerReplica::isGradleFile)
+
+    private fun read(path: String): File = TrackedTree.file(path)
+
+    @Test
+    fun recipeRemovedPathsStillExist() {
+        val stale = recipeRemovedPaths.filter { prefix -> TrackedTree.files.none { it.startsWith(prefix) } }
+        assertTrue(
+            stale.isEmpty(),
+            "recipeRemovedPaths names paths no longer in the tree; update the list and the F-Droid recipe together:\n" +
+                stale.joinToString("\n"),
+        )
+    }
 
     @Test
     fun everyMavenRepositoryUrlIsOnTheFdroidAllowlist() {
-        val problems = mutableListOf<String>()
-        for (file in trackedGradleFiles()) {
-            val nonComment = file.readLines().filterNot { gradleLineComment.containsMatchIn(it) }
-            val text = nonComment.joinToString("\n").replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), "")
-            for (match in mavenUrlRegex.findAll(text)) {
-                val url = match.groupValues[1]
-                if (allowedMavenRepos.none { it.containsMatchIn(url) }) {
-                    problems += "${file.relativeTo(repoRoot)}: unknown maven repo '$url'"
-                }
-            }
+        val problems = scannedGradleFiles().flatMap { path ->
+            FdroidScannerReplica.unknownMavenRepos(read(path).readText()).map { "$path: unknown maven repo '$it'" }
         }
         assertTrue(
             problems.isEmpty(),
@@ -127,165 +92,34 @@ class FdroidGuardrailsTest {
         )
     }
 
-    // ---- Layer 2: dependency lines naming non-free artifacts ---------------
-
     /**
-     * The gradle "usual suspects" from F-Droid's SUSS signature database
-     * (https://fdroid.gitlab.io/fdroid-suss/suss.json, version 1, database
-     * timestamp 2026-08-01), copied verbatim. The scanner compiles each as
-     * ".*" + signature, case-insensitive, and matches it against every
-     * dependency line and every catalog coordinate such a line resolves to;
-     * any hit is a build-failing error on the buildserver.
+     * Catalogs are resolved per settings root, as scanner.py does: the
+     * catalog for a gradle file is the default catalog of the nearest
+     * ancestor directory holding a settings file. A settings file declaring
+     * catalogs the replica cannot read fails outright (see
+     * [FdroidScannerReplica.declaresCatalogsTheReplicaCannotRead]).
      */
-    private val scannerGradleSignatures = listOf(
-        """androidx.*play-services""",
-        """androidx.core:core-google-shortcuts""",
-        """androidx.credentials:credentials-play-services-auth""",
-        """androidx.media3:media3-cast""",
-        """androidx.media3:media3-datasource-cronet""",
-        """androidx.media3:media3-exoplayer-ima""",
-        """androidx.navigation:navigation-dynamic-features""",
-        """androidx.wear:wear-remote-interactions""",
-        """androidx.work:work-gcm""",
-        """com(\.google)?\.firebase[.:](?!firebase-jobdispatcher|geofire-java|firebase-encoders)""",
-        """com.amazon.device""",
-        """com.amazonaws:DynamoDBLocal""",
-        """com.amazonaws:aws-android-sdk-auth-facebook""",
-        """com.amazonaws:aws-android-sdk-auth-google""",
-        """com.amazonaws:aws-android-sdk-auth-userpools""",
-        """com.amazonaws:aws-android-sdk-cognitoauth""",
-        """com.amazonaws:aws-android-sdk-cognitoidentityprovider""",
-        """com.amazonaws:aws-android-sdk-cognitoidentityprovider-asf""",
-        """com.amazonaws:aws-android-sdk-cognitoidentityprovider-test""",
-        """com.amazonaws:aws-android-sdk-kinesisvideo""",
-        """com.amazonaws:aws-android-sdk-kinesisvideo-archivedmedia""",
-        """com.amazonaws:aws-android-sdk-location""",
-        """com.amazonaws:aws-android-sdk-mobile-client""",
-        """com.amazonaws:dynamodb-key-diagnostics-library""",
-        """com.amazonaws:dynamodb-lock-client""",
-        """com.amazonaws:ivs-broadcast""",
-        """com.amazonaws:ivs-player""",
-        """com.amazonaws:kinesis-storm-spout""",
-        """com.amplifyframework:aws-push-notifications-pinpoint""",
-        """com.amplifyframework:aws-push-notifications-pinpoint-common""",
-        """com.android.billingclient""",
-        """com.android.installreferrer""",
-        """com.anjlab.android.iab.v3:library""",
-        """com.baidu.mobstat""",
-        """com.bugsense""",
-        """com.cloudinary:cloudinary-android.*:2\.[12]\.""",
-        """com.cloudrail""",
-        """com.crittercism""",
-        """com.evernote:android-job""",
-        """com.facebook.android""",
-        """com.flurry.android""",
-        """com.garmin.connectiq:ciq-companion-app-sdk""",
-        """com.geetest""",
-        """com.giphy.sdk""",
-        """com.github.SanojPunchihewa:InAppUpdater""",
-        """com.github.budowski:android-maps-utils""",
-        """com.github.derysudrajat:compass-qibla""",
-        """com.github.junrar:junrar""",
-        """com.github.omicronapps:7-Zip-JBinding-4Android""",
-        """com.github.penn5:donations""",
-        """com.github.uccmawei:FingerprintIdentify""",
-        """com.google.ads""",
-        """com.google.ai.edge.aicore""",
-        """com.google.ai.edge.litert:litert(-api)?:2""",
-        """com.google.android.exoplayer:extension-cast""",
-        """com.google.android.exoplayer:extension-cronet""",
-        """com.google.android.exoplayer:extension-ima""",
-        """com.google.android.gms(?!.(oss-licenses-plugin|strict-version-matcher-plugin))""",
-        """com.google.android.libraries(?!.mapsplatform.secrets-gradle-plugin)""",
-        """com.google.android.play:app-update""",
-        """com.google.android.play:asset-delivery""",
-        """com.google.android.play:core.*""",
-        """com.google.android.play:feature-delivery""",
-        """com.google.android.play:review""",
-        """com.google.android.support:wearable""",
-        """com.google.android.ump""",
-        """com.google.android.wearable:wearable""",
-        """com.google.androidbrowserhelper:billing""",
-        """com.google.api-client:google-api-client-android""",
-        """com.google.maps.android:android-maps-utils""",
-        """com.google.mlkit""",
-        """com.hypertrack(?!:hyperlog)""",
-        """com.meta.androidbrowserhelper""",
-        """com.meta.horizon""",
-        """com.microsoft.appcenter:appcenter-push""",
-        """com.microsoft.identity.client:msal""",
-        """com.microsoft.identity:common""",
-        """com.onesignal:OneSignal""",
-        """com.paypal""",
-        """com.pierfrancescosoffritti.androidyoutubeplayer:chromecast-sender""",
-        """com.revenuecat.purchases""",
-        """com.suddenh4x.ratingdialog:awesome-app-rating""",
-        """com.tencent.bugly""",
-        """com.umeng""",
-        """com.wei.android.lib:fingerprintidentify""",
-        """com.yayandroid:locationmanager""",
-        """com\.mapbox(?!\.mapboxsdk:mapbox-sdk-(services|geojson|turf):([3-5]))""",
-        """com\.yandex\.android(?!:authsdk)""",
-        """crashlytics""",
-        """io.github.g00fy2.quickie""",
-        """io.github.hyochan.openiap:openiap-amazon""",
-        """io.github.hyochan.openiap:openiap-google""",
-        """io.github.hyochan.openiap:openiap-horizon""",
-        """io.github.sinaweibosdk""",
-        """io.kotzilla""",
-        """io.objectbox:objectbox-gradle-plugin""",
-        """me.proton.core:payment-iap""",
-        """me.pushy""",
-        """org.gradle.toolchains.foojay-resolver""",
-        """org.mariuszgromada.math:MathParser.org-mXparser:[5-9]""",
-        """xyz.belvi.mobilevision:barcodescanner""",
-    ).map { Regex(".*$it", RegexOption.IGNORE_CASE) }
-
-    /**
-     * fdroidserver/scanner.py get_gradle_compile_commands, for a build with
-     * no product flavors: the leading tokens that make a line a dependency
-     * (or plugin) declaration in the scanner's eyes.
-     */
-    private val gradleCompileCommands = listOf(
-        "alias", "api", "apk", "classpath", "compile", "compileOnly", "id",
-        "implementation", "provided", "runtimeOnly",
-    ).flatMap { listOf(it, "release$it") }
-
-    /** A dependency line whose coordinate is a literal string. */
-    private val dependencyLineWithoutCatalog = gradleCompileCommands.map {
-        Regex("""\s*['"]?$it.*\s*\(?['"].*['"]""", RegexOption.IGNORE_CASE)
-    }
-
-    /** A dependency line whose coordinate comes from the version catalog; group 1 is the accessor. */
-    private val dependencyLineWithCatalog = gradleCompileCommands.map {
-        Regex("""\s*['"]?$it.*\s*\(?libs\.([a-z0-9.]+)""", RegexOption.IGNORE_CASE)
-    }
-
     @Test
     fun noDependencyLineNamesAnFdroidUsualSuspect() {
-        val catalog = VersionCatalog.parse(File(repoRoot, "gradle/libs.versions.toml"))
+        val settingsRoots = scannedFiles
+            .filter { it.substringAfterLast('/') in setOf("settings.gradle", "settings.gradle.kts") }
+            .associate { it.substringBeforeLast('/', "") to it }
         val problems = mutableListOf<String>()
-        for (file in trackedGradleFiles()) {
-            file.readLines().forEachIndexed { index, line ->
-                val where = "${file.relativeTo(repoRoot)}:${index + 1}"
-                if (dependencyLineWithoutCatalog.any { it.matchesAt(line, 0) }) {
-                    scannerGradleSignatures.forEach { signature ->
-                        if (signature.matchesAt(line, 0)) {
-                            problems += "$where: usual suspect '${signature.pattern.removePrefix(".*")}' in: ${line.trim()}"
-                        }
-                    }
-                }
-                val accessor = dependencyLineWithCatalog.firstNotNullOfOrNull { it.matchAt(line, 0)?.groupValues?.get(1) }
-                if (accessor != null) {
-                    for (coordinate in catalog.coordinates(accessor)) {
-                        scannerGradleSignatures.forEach { signature ->
-                            if (signature.matchesAt(coordinate, 0)) {
-                                problems += "$where: usual suspect '${signature.pattern.removePrefix(".*")}' via libs.$accessor -> $coordinate"
-                            }
-                        }
-                    }
-                }
+        settingsRoots.values.forEach { settings ->
+            if (FdroidScannerReplica.declaresCatalogsTheReplicaCannotRead(read(settings).readText())) {
+                problems += "$settings declares version catalogs this replica cannot read; extend FdroidScannerReplica"
             }
+        }
+        val catalogs = settingsRoots.keys.associateWith { root ->
+            val catalog = if (root.isEmpty()) "gradle/libs.versions.toml" else "$root/gradle/libs.versions.toml"
+            if (catalog in scannedFiles) VersionCatalog.parse(read(catalog).readLines()) else VersionCatalog.EMPTY
+        }
+        for (path in scannedGradleFiles()) {
+            val root = catalogs.keys
+                .filter { it.isEmpty() || path.startsWith("$it/") }
+                .maxByOrNull { it.length }
+            val catalog = root?.let { catalogs[it] } ?: VersionCatalog.EMPTY
+            problems += FdroidScannerReplica.usualSuspects(read(path).readLines(), catalog).map { "$path, $it" }
         }
         assertTrue(
             problems.isEmpty(),
@@ -293,138 +127,57 @@ class FdroidGuardrailsTest {
         )
     }
 
-    // ---- Layer 3: binaries in the tracked tree ----------------------------
-
-    /**
-     * fdroidserver/scanner.py's binary suffix list. Anything with one of
-     * these suffixes is a scanner error unless removed or ignored by the
-     * build recipe; gradle-wrapper.jar is the one name the scanner exempts.
-     */
-    private val binarySuffixes = listOf(".a", ".aar", ".class", ".dex", ".gz", ".tgz", ".zip", ".jar", ".wasm", ".apk")
-    private val sharedObject = Regex(""".*\.so(\..+)*$""")
+    /** The parser must actually be resolving the real catalog, not degrading to a map that answers nothing. */
+    @Test
+    fun theRealCatalogResolvesAKnownAccessor() {
+        val catalog = VersionCatalog.parse(read("gradle/libs.versions.toml").readLines())
+        val coordinates = catalog.coordinates("androidx.core.ktx")
+        assertTrue(
+            coordinates.singleOrNull()?.startsWith("androidx.core:core-ktx:") == true,
+            "libs.androidx.core.ktx resolved to $coordinates; the catalog reader is no longer reading gradle/libs.versions.toml",
+        )
+    }
 
     @Test
     fun noBinaryIsTrackedInTheTree() {
-        val problems = trackedFiles.filter { path ->
-            val name = path.substringAfterLast('/')
-            name != "gradle-wrapper.jar" &&
-                (binarySuffixes.any { name.endsWith(it) } || sharedObject.matches(name))
-        }
+        val problems = scannedFiles.mapNotNull { path -> FdroidScannerReplica.binaryKind(path)?.let { "$path: $it" } }
         assertTrue(
             problems.isEmpty(),
             "F-Droid rejects checked-in binaries; the build must produce them from source:\n" + problems.joinToString("\n"),
         )
     }
 
-    /**
-     * The scanner also sniffs files with no extension (and .bin/.out/.exe)
-     * for non-text bytes, with the same first-1024-bytes heuristic replicated
-     * here. The submodule gitlink is a directory on disk and is skipped.
-     */
     @Test
-    fun noExtensionlessTrackedFileIsBinary() {
-        val textBytes = (setOf(7, 8, 9, 10, 12, 13, 27) + (0x20..0xFF)).minus(0x7F).map { it.toByte() }.toSet()
-        val problems = trackedFiles.filter { path ->
-            val name = path.substringAfterLast('/')
-            val ext = name.substringAfterLast('.', "")
-            val sniffable = !name.contains('.') || ext in setOf("bin", "out", "exe")
-            val file = File(repoRoot, path)
-            sniffable && file.isFile && file.inputStream().use { it.readNBytes(1024) }.any { it !in textBytes }
+    fun noSniffedTrackedFileIsBinary() {
+        val problems = scannedFiles.filter { path ->
+            FdroidScannerReplica.isSniffed(path) && read(path).let { file ->
+                file.isFile && FdroidScannerReplica.isBinary(file.inputStream().use { it.readNBytes(1024) })
+            }
         }
         assertTrue(
             problems.isEmpty(),
-            "F-Droid's scanner flags these extensionless files as binaries:\n" + problems.joinToString("\n"),
+            "F-Droid's scanner sniffs these files as binaries:\n" + problems.joinToString("\n"),
         )
     }
 
-    // ---- Minimal version-catalog reader ----------------------------------
+    @Test
+    fun everyDependencyManifestHasALockfile() {
+        val tracked = scannedFiles.toSet()
+        val problems = scannedFiles.filter { FdroidScannerReplica.lacksLockfile(it, tracked) }
+        assertTrue(
+            problems.isEmpty(),
+            "F-Droid's scanner fails on dependency files without a lockfile:\n" + problems.joinToString("\n"),
+        )
+    }
 
-    /**
-     * Just enough of gradle/libs.versions.toml to resolve an accessor to the
-     * coordinate(s) the scanner would check, mirroring scanner.py's
-     * GradleVersionCatalog: aliases map to accessors by turning '-' and '_'
-     * into '.'; libraries resolve to group:name[:version], plugins to
-     * id[:version], bundles to their member libraries. Only the single-line
-     * table forms this catalog uses are handled; a line that fails to parse
-     * fails the test rather than silently resolving to nothing.
-     */
-    private class VersionCatalog(
-        private val libraries: Map<String, String>,
-        private val plugins: Map<String, String>,
-        private val bundles: Map<String, List<String>>,
-    ) {
-        fun coordinates(accessor: String): List<String> = when {
-            accessor.startsWith("plugins.") ->
-                listOfNotNull(plugins[accessor.removePrefix("plugins.").removeSuffix(".asLibraryDependency")])
-            accessor.startsWith("bundles.") -> bundles[accessor.removePrefix("bundles.")].orEmpty()
-            else -> listOfNotNull(libraries[accessor])
+    @Test
+    fun noJavaSourceUsesDexClassLoader() {
+        val problems = scannedFiles.filter { path ->
+            path.endsWith(".java") && FdroidScannerReplica.usesDexClassLoader(path, read(path).readLines())
         }
-
-        companion object {
-            private fun accessor(alias: String) = alias.replace('-', '.').replace('_', '.')
-
-            fun parse(file: File): VersionCatalog {
-                val sections = mutableMapOf<String, MutableMap<String, String>>()
-                var current = ""
-                for (raw in file.readLines()) {
-                    val line = raw.substringBefore('#').trim()
-                    if (line.isEmpty()) continue
-                    if (line.startsWith("[") && line.endsWith("]")) {
-                        current = line.trim('[', ']')
-                        continue
-                    }
-                    val key = line.substringBefore('=').trim()
-                    val value = line.substringAfter('=').trim()
-                    if (key.isEmpty() || value.isEmpty()) fail("Cannot parse catalog line: $raw")
-                    sections.getOrPut(current) { linkedMapOf() }[key] = value
-                }
-                val versions = sections["versions"].orEmpty().mapValues { unquote(it.value) }
-
-                fun version(table: Map<String, String>): String? {
-                    table["version"]?.let { return unquote(it) }
-                    table["version.ref"]?.let { ref -> return versions[unquote(ref)] ?: fail("Unknown version ref $ref") }
-                    return null
-                }
-
-                val libraries = sections["libraries"].orEmpty().map { (alias, value) ->
-                    val coordinate = if (value.startsWith("{")) {
-                        val table = inlineTable(value)
-                        val module = table["module"]?.let(::unquote)
-                            ?: table["group"]?.let { g -> table["name"]?.let { n -> "${unquote(g)}:${unquote(n)}" } }
-                            ?: fail("Library $alias has no module or group/name")
-                        version(table)?.let { "$module:$it" } ?: module
-                    } else {
-                        unquote(value)
-                    }
-                    accessor(alias) to coordinate
-                }.toMap()
-
-                val plugins = sections["plugins"].orEmpty().map { (alias, value) ->
-                    val coordinate = if (value.startsWith("{")) {
-                        val table = inlineTable(value)
-                        val id = table["id"]?.let(::unquote) ?: fail("Plugin $alias has no id")
-                        version(table)?.let { "$id:$it" } ?: id
-                    } else {
-                        unquote(value)
-                    }
-                    accessor(alias) to coordinate
-                }.toMap()
-
-                val bundles = sections["bundles"].orEmpty().mapValues { (_, value) ->
-                    value.trim('[', ']').split(',').map { unquote(it.trim()) }.filter { it.isNotEmpty() }
-                        .mapNotNull { libraries[accessor(it)] }
-                }.mapKeys { accessor(it.key) }
-
-                return VersionCatalog(libraries, plugins, bundles)
-            }
-
-            private fun unquote(s: String) = s.trim().trim('"', '\'')
-
-            /** Parses '{ k = "v", k2.sub = "v2" }' into a map; values keep their quotes for [unquote]. */
-            private fun inlineTable(value: String): Map<String, String> =
-                value.trim().removePrefix("{").removeSuffix("}").split(',')
-                    .map { it.trim() }.filter { it.isNotEmpty() }
-                    .associate { entry -> entry.substringBefore('=').trim() to entry.substringAfter('=').trim() }
-        }
+        assertTrue(
+            problems.isEmpty(),
+            "F-Droid's scanner fails on Java sources that load code at runtime:\n" + problems.joinToString("\n"),
+        )
     }
 }

--- a/androidApp/src/test/kotlin/coredevices/coreapp/FdroidGuardrailsTest.kt
+++ b/androidApp/src/test/kotlin/coredevices/coreapp/FdroidGuardrailsTest.kt
@@ -23,8 +23,8 @@ import kotlin.test.assertTrue
  * regression, and this class is the source-text one:
  * - the classpath sentinels ([AppClasspathSentinelTest] and the library
  *   copies) prove the shipped runtime graph is clean;
- * - the built APK is inspected directly (fork rule: verify against the
- *   artifact, not the tree);
+ * - the packaging-time APK inspection in androidApp/build.gradle.kts
+ *   (VerifyApkContents) proves the built artifact is clean;
  * - this class proves the tracked *tree* passes the scanner as F-Droid runs
  *   it, which the other two cannot see: an unplugged module's build file, an
  *   iOS-only dependency line, or a publishing block never reaches the

--- a/androidApp/src/test/kotlin/coredevices/coreapp/FdroidGuardrailsTest.kt
+++ b/androidApp/src/test/kotlin/coredevices/coreapp/FdroidGuardrailsTest.kt
@@ -1,0 +1,430 @@
+package coredevices.coreapp
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Source-level replica of the checks F-Droid's build scanner runs over a
+ * checkout, applied to this repository's tracked tree on every CI run.
+ *
+ * The fork targets inclusion in F-Droid's main repository, and most of the
+ * ways that can regress arrive silently with an upstream sync: a dependency
+ * line naming a Google artifact, a publishing block naming a private maven
+ * host, a checked-in native library or archive. F-Droid only reports these
+ * at submission or on its next build of a tag, long after the merge, so this
+ * class fails the merge itself instead. It replicates fdroidserver's textual
+ * scanner (fdroidserver/scanner.py) rather than approximating it: same
+ * dependency-line matcher, same catalog resolution, same maven-URL regex and
+ * allowlist, same binary-suffix list, and the same "usual suspects" gradle
+ * signatures, pinned from the SUSS database (see [scannerGradleSignatures]).
+ *
+ * Three independent layers stand between an upstream sync and a policy
+ * regression, and this class is the source-text one:
+ * - the classpath sentinels ([AppClasspathSentinelTest] and the library
+ *   copies) prove the shipped runtime graph is clean;
+ * - the release artifact is inspected directly (fork rule: verify against
+ *   the APK, not the tree);
+ * - this class proves the tracked *tree* passes the scanner as F-Droid runs
+ *   it, which the other two cannot see: an unplugged module's build file, an
+ *   iOS-only dependency line, or a publishing block never reaches the
+ *   Android classpath yet still fails the scan.
+ *
+ * Only the tracked tree is scanned (git ls-files), because that is what
+ * F-Droid clones; the whisper.cpp submodule is deliberately not descended
+ * into, since its examples and test fixtures are removed by the F-Droid
+ * build recipe before the scan and never participate in the build.
+ *
+ * Re-syncing: when fdroidserver changes a regex or its allowlist, or the
+ * SUSS database gains a signature that matters here, update the constants
+ * below in place and note the upstream revision in the commit.
+ */
+class FdroidGuardrailsTest {
+
+    // ---- Repository access -------------------------------------------------
+
+    /** The checkout root: the nearest ancestor of the test working directory holding settings.gradle.kts. */
+    private val repoRoot: File by lazy {
+        generateSequence(File("").absoluteFile) { it.parentFile }
+            .firstOrNull { File(it, "settings.gradle.kts").isFile }
+            ?: fail("Could not locate the repository root from ${File("").absolutePath}")
+    }
+
+    /**
+     * Tracked paths relative to the root, as F-Droid's clone would see them.
+     * The submodule shows up as a single gitlink entry and is skipped by the
+     * per-file readers below (it is a directory on disk).
+     */
+    private val trackedFiles: List<String> by lazy {
+        val process = ProcessBuilder("git", "-C", repoRoot.path, "ls-files", "-z")
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.readBytes().toString(Charsets.UTF_8)
+        val exit = process.waitFor()
+        assertTrue(exit == 0, "git ls-files failed ($exit): $output")
+        output.split('\u0000').filter { it.isNotEmpty() }
+    }
+
+    private fun trackedGradleFiles(): List<File> = trackedFiles
+        .filter { it.endsWith(".gradle") || it.endsWith(".gradle.kts") }
+        .map { File(repoRoot, it) }
+        .filter { it.isFile }
+
+    // ---- Layer 1: maven repository URLs -----------------------------------
+
+    /**
+     * fdroidserver/scanner.py MAVEN_URL_REGEX, verbatim apart from Java's
+     * requirement that the literal brace be escaped. Applied, as there, to
+     * the file with line comments and block comments removed.
+     */
+    private val mavenUrlRegex = Regex(
+        """\smaven\s*(?:\{.*?(?:setUrl|url)|\(\s*(?:url)?)\s*=?\s*(?:uri|URI|Uri\.create)?\(?\s*["']?([^\s"']+)["']?[^})]*[)}]""",
+        RegexOption.DOT_MATCHES_ALL,
+    )
+
+    /** fdroidserver/scanner.py allowed_repos: hosts F-Droid trusts to serve free artifacts. */
+    private val allowedMavenRepos = listOf(
+        "repo1.maven.org/maven2",
+        "jitpack.io",
+        "www.jitpack.io",
+        "repo.maven.apache.org/maven2",
+        "oss.jfrog.org/artifactory/oss-snapshot-local",
+        "central.sonatype.com/repository/maven-snapshots",
+        "oss.sonatype.org/content/repositories/snapshots",
+        "oss.sonatype.org/content/repositories/releases",
+        "oss.sonatype.org/content/groups/public",
+        "oss.sonatype.org/service/local/staging/deploy/maven2",
+        "s01.oss.sonatype.org/content/repositories/snapshots",
+        "s01.oss.sonatype.org/content/repositories/releases",
+        "s01.oss.sonatype.org/content/groups/public",
+        "s01.oss.sonatype.org/service/local/staging/deploy/maven2",
+        "clojars.org/repo",
+        "repo.clojars.org",
+        "s3.amazonaws.com/repo.commonsware.com",
+        "plugins.gradle.org/m2",
+        "maven.google.com",
+    ).map { Regex("^https://" + Regex.escape(it) + "/*") }
+
+    private val gradleLineComment = Regex("""^[ ]*//""")
+
+    @Test
+    fun everyMavenRepositoryUrlIsOnTheFdroidAllowlist() {
+        val problems = mutableListOf<String>()
+        for (file in trackedGradleFiles()) {
+            val nonComment = file.readLines().filterNot { gradleLineComment.containsMatchIn(it) }
+            val text = nonComment.joinToString("\n").replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), "")
+            for (match in mavenUrlRegex.findAll(text)) {
+                val url = match.groupValues[1]
+                if (allowedMavenRepos.none { it.containsMatchIn(url) }) {
+                    problems += "${file.relativeTo(repoRoot)}: unknown maven repo '$url'"
+                }
+            }
+        }
+        assertTrue(
+            problems.isEmpty(),
+            "F-Droid rejects builds that declare maven repositories off its allowlist:\n" + problems.joinToString("\n"),
+        )
+    }
+
+    // ---- Layer 2: dependency lines naming non-free artifacts ---------------
+
+    /**
+     * The gradle "usual suspects" from F-Droid's SUSS signature database
+     * (https://fdroid.gitlab.io/fdroid-suss/suss.json, version 1, database
+     * timestamp 2026-08-01), copied verbatim. The scanner compiles each as
+     * ".*" + signature, case-insensitive, and matches it against every
+     * dependency line and every catalog coordinate such a line resolves to;
+     * any hit is a build-failing error on the buildserver.
+     */
+    private val scannerGradleSignatures = listOf(
+        """androidx.*play-services""",
+        """androidx.core:core-google-shortcuts""",
+        """androidx.credentials:credentials-play-services-auth""",
+        """androidx.media3:media3-cast""",
+        """androidx.media3:media3-datasource-cronet""",
+        """androidx.media3:media3-exoplayer-ima""",
+        """androidx.navigation:navigation-dynamic-features""",
+        """androidx.wear:wear-remote-interactions""",
+        """androidx.work:work-gcm""",
+        """com(\.google)?\.firebase[.:](?!firebase-jobdispatcher|geofire-java|firebase-encoders)""",
+        """com.amazon.device""",
+        """com.amazonaws:DynamoDBLocal""",
+        """com.amazonaws:aws-android-sdk-auth-facebook""",
+        """com.amazonaws:aws-android-sdk-auth-google""",
+        """com.amazonaws:aws-android-sdk-auth-userpools""",
+        """com.amazonaws:aws-android-sdk-cognitoauth""",
+        """com.amazonaws:aws-android-sdk-cognitoidentityprovider""",
+        """com.amazonaws:aws-android-sdk-cognitoidentityprovider-asf""",
+        """com.amazonaws:aws-android-sdk-cognitoidentityprovider-test""",
+        """com.amazonaws:aws-android-sdk-kinesisvideo""",
+        """com.amazonaws:aws-android-sdk-kinesisvideo-archivedmedia""",
+        """com.amazonaws:aws-android-sdk-location""",
+        """com.amazonaws:aws-android-sdk-mobile-client""",
+        """com.amazonaws:dynamodb-key-diagnostics-library""",
+        """com.amazonaws:dynamodb-lock-client""",
+        """com.amazonaws:ivs-broadcast""",
+        """com.amazonaws:ivs-player""",
+        """com.amazonaws:kinesis-storm-spout""",
+        """com.amplifyframework:aws-push-notifications-pinpoint""",
+        """com.amplifyframework:aws-push-notifications-pinpoint-common""",
+        """com.android.billingclient""",
+        """com.android.installreferrer""",
+        """com.anjlab.android.iab.v3:library""",
+        """com.baidu.mobstat""",
+        """com.bugsense""",
+        """com.cloudinary:cloudinary-android.*:2\.[12]\.""",
+        """com.cloudrail""",
+        """com.crittercism""",
+        """com.evernote:android-job""",
+        """com.facebook.android""",
+        """com.flurry.android""",
+        """com.garmin.connectiq:ciq-companion-app-sdk""",
+        """com.geetest""",
+        """com.giphy.sdk""",
+        """com.github.SanojPunchihewa:InAppUpdater""",
+        """com.github.budowski:android-maps-utils""",
+        """com.github.derysudrajat:compass-qibla""",
+        """com.github.junrar:junrar""",
+        """com.github.omicronapps:7-Zip-JBinding-4Android""",
+        """com.github.penn5:donations""",
+        """com.github.uccmawei:FingerprintIdentify""",
+        """com.google.ads""",
+        """com.google.ai.edge.aicore""",
+        """com.google.ai.edge.litert:litert(-api)?:2""",
+        """com.google.android.exoplayer:extension-cast""",
+        """com.google.android.exoplayer:extension-cronet""",
+        """com.google.android.exoplayer:extension-ima""",
+        """com.google.android.gms(?!.(oss-licenses-plugin|strict-version-matcher-plugin))""",
+        """com.google.android.libraries(?!.mapsplatform.secrets-gradle-plugin)""",
+        """com.google.android.play:app-update""",
+        """com.google.android.play:asset-delivery""",
+        """com.google.android.play:core.*""",
+        """com.google.android.play:feature-delivery""",
+        """com.google.android.play:review""",
+        """com.google.android.support:wearable""",
+        """com.google.android.ump""",
+        """com.google.android.wearable:wearable""",
+        """com.google.androidbrowserhelper:billing""",
+        """com.google.api-client:google-api-client-android""",
+        """com.google.maps.android:android-maps-utils""",
+        """com.google.mlkit""",
+        """com.hypertrack(?!:hyperlog)""",
+        """com.meta.androidbrowserhelper""",
+        """com.meta.horizon""",
+        """com.microsoft.appcenter:appcenter-push""",
+        """com.microsoft.identity.client:msal""",
+        """com.microsoft.identity:common""",
+        """com.onesignal:OneSignal""",
+        """com.paypal""",
+        """com.pierfrancescosoffritti.androidyoutubeplayer:chromecast-sender""",
+        """com.revenuecat.purchases""",
+        """com.suddenh4x.ratingdialog:awesome-app-rating""",
+        """com.tencent.bugly""",
+        """com.umeng""",
+        """com.wei.android.lib:fingerprintidentify""",
+        """com.yayandroid:locationmanager""",
+        """com\.mapbox(?!\.mapboxsdk:mapbox-sdk-(services|geojson|turf):([3-5]))""",
+        """com\.yandex\.android(?!:authsdk)""",
+        """crashlytics""",
+        """io.github.g00fy2.quickie""",
+        """io.github.hyochan.openiap:openiap-amazon""",
+        """io.github.hyochan.openiap:openiap-google""",
+        """io.github.hyochan.openiap:openiap-horizon""",
+        """io.github.sinaweibosdk""",
+        """io.kotzilla""",
+        """io.objectbox:objectbox-gradle-plugin""",
+        """me.proton.core:payment-iap""",
+        """me.pushy""",
+        """org.gradle.toolchains.foojay-resolver""",
+        """org.mariuszgromada.math:MathParser.org-mXparser:[5-9]""",
+        """xyz.belvi.mobilevision:barcodescanner""",
+    ).map { Regex(".*$it", RegexOption.IGNORE_CASE) }
+
+    /**
+     * fdroidserver/scanner.py get_gradle_compile_commands, for a build with
+     * no product flavors: the leading tokens that make a line a dependency
+     * (or plugin) declaration in the scanner's eyes.
+     */
+    private val gradleCompileCommands = listOf(
+        "alias", "api", "apk", "classpath", "compile", "compileOnly", "id",
+        "implementation", "provided", "runtimeOnly",
+    ).flatMap { listOf(it, "release$it") }
+
+    /** A dependency line whose coordinate is a literal string. */
+    private val dependencyLineWithoutCatalog = gradleCompileCommands.map {
+        Regex("""\s*['"]?$it.*\s*\(?['"].*['"]""", RegexOption.IGNORE_CASE)
+    }
+
+    /** A dependency line whose coordinate comes from the version catalog; group 1 is the accessor. */
+    private val dependencyLineWithCatalog = gradleCompileCommands.map {
+        Regex("""\s*['"]?$it.*\s*\(?libs\.([a-z0-9.]+)""", RegexOption.IGNORE_CASE)
+    }
+
+    @Test
+    fun noDependencyLineNamesAnFdroidUsualSuspect() {
+        val catalog = VersionCatalog.parse(File(repoRoot, "gradle/libs.versions.toml"))
+        val problems = mutableListOf<String>()
+        for (file in trackedGradleFiles()) {
+            file.readLines().forEachIndexed { index, line ->
+                val where = "${file.relativeTo(repoRoot)}:${index + 1}"
+                if (dependencyLineWithoutCatalog.any { it.matchesAt(line, 0) }) {
+                    scannerGradleSignatures.forEach { signature ->
+                        if (signature.matchesAt(line, 0)) {
+                            problems += "$where: usual suspect '${signature.pattern.removePrefix(".*")}' in: ${line.trim()}"
+                        }
+                    }
+                }
+                val accessor = dependencyLineWithCatalog.firstNotNullOfOrNull { it.matchAt(line, 0)?.groupValues?.get(1) }
+                if (accessor != null) {
+                    for (coordinate in catalog.coordinates(accessor)) {
+                        scannerGradleSignatures.forEach { signature ->
+                            if (signature.matchesAt(coordinate, 0)) {
+                                problems += "$where: usual suspect '${signature.pattern.removePrefix(".*")}' via libs.$accessor -> $coordinate"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        assertTrue(
+            problems.isEmpty(),
+            "F-Droid's scanner fails the build on these dependency lines:\n" + problems.joinToString("\n"),
+        )
+    }
+
+    // ---- Layer 3: binaries in the tracked tree ----------------------------
+
+    /**
+     * fdroidserver/scanner.py's binary suffix list. Anything with one of
+     * these suffixes is a scanner error unless removed or ignored by the
+     * build recipe; gradle-wrapper.jar is the one name the scanner exempts.
+     */
+    private val binarySuffixes = listOf(".a", ".aar", ".class", ".dex", ".gz", ".tgz", ".zip", ".jar", ".wasm", ".apk")
+    private val sharedObject = Regex(""".*\.so(\..+)*$""")
+
+    @Test
+    fun noBinaryIsTrackedInTheTree() {
+        val problems = trackedFiles.filter { path ->
+            val name = path.substringAfterLast('/')
+            name != "gradle-wrapper.jar" &&
+                (binarySuffixes.any { name.endsWith(it) } || sharedObject.matches(name))
+        }
+        assertTrue(
+            problems.isEmpty(),
+            "F-Droid rejects checked-in binaries; the build must produce them from source:\n" + problems.joinToString("\n"),
+        )
+    }
+
+    /**
+     * The scanner also sniffs files with no extension (and .bin/.out/.exe)
+     * for non-text bytes, with the same first-1024-bytes heuristic replicated
+     * here. The submodule gitlink is a directory on disk and is skipped.
+     */
+    @Test
+    fun noExtensionlessTrackedFileIsBinary() {
+        val textBytes = (setOf(7, 8, 9, 10, 12, 13, 27) + (0x20..0xFF)).minus(0x7F).map { it.toByte() }.toSet()
+        val problems = trackedFiles.filter { path ->
+            val name = path.substringAfterLast('/')
+            val ext = name.substringAfterLast('.', "")
+            val sniffable = !name.contains('.') || ext in setOf("bin", "out", "exe")
+            val file = File(repoRoot, path)
+            sniffable && file.isFile && file.inputStream().use { it.readNBytes(1024) }.any { it !in textBytes }
+        }
+        assertTrue(
+            problems.isEmpty(),
+            "F-Droid's scanner flags these extensionless files as binaries:\n" + problems.joinToString("\n"),
+        )
+    }
+
+    // ---- Minimal version-catalog reader ----------------------------------
+
+    /**
+     * Just enough of gradle/libs.versions.toml to resolve an accessor to the
+     * coordinate(s) the scanner would check, mirroring scanner.py's
+     * GradleVersionCatalog: aliases map to accessors by turning '-' and '_'
+     * into '.'; libraries resolve to group:name[:version], plugins to
+     * id[:version], bundles to their member libraries. Only the single-line
+     * table forms this catalog uses are handled; a line that fails to parse
+     * fails the test rather than silently resolving to nothing.
+     */
+    private class VersionCatalog(
+        private val libraries: Map<String, String>,
+        private val plugins: Map<String, String>,
+        private val bundles: Map<String, List<String>>,
+    ) {
+        fun coordinates(accessor: String): List<String> = when {
+            accessor.startsWith("plugins.") ->
+                listOfNotNull(plugins[accessor.removePrefix("plugins.").removeSuffix(".asLibraryDependency")])
+            accessor.startsWith("bundles.") -> bundles[accessor.removePrefix("bundles.")].orEmpty()
+            else -> listOfNotNull(libraries[accessor])
+        }
+
+        companion object {
+            private fun accessor(alias: String) = alias.replace('-', '.').replace('_', '.')
+
+            fun parse(file: File): VersionCatalog {
+                val sections = mutableMapOf<String, MutableMap<String, String>>()
+                var current = ""
+                for (raw in file.readLines()) {
+                    val line = raw.substringBefore('#').trim()
+                    if (line.isEmpty()) continue
+                    if (line.startsWith("[") && line.endsWith("]")) {
+                        current = line.trim('[', ']')
+                        continue
+                    }
+                    val key = line.substringBefore('=').trim()
+                    val value = line.substringAfter('=').trim()
+                    if (key.isEmpty() || value.isEmpty()) fail("Cannot parse catalog line: $raw")
+                    sections.getOrPut(current) { linkedMapOf() }[key] = value
+                }
+                val versions = sections["versions"].orEmpty().mapValues { unquote(it.value) }
+
+                fun version(table: Map<String, String>): String? {
+                    table["version"]?.let { return unquote(it) }
+                    table["version.ref"]?.let { ref -> return versions[unquote(ref)] ?: fail("Unknown version ref $ref") }
+                    return null
+                }
+
+                val libraries = sections["libraries"].orEmpty().map { (alias, value) ->
+                    val coordinate = if (value.startsWith("{")) {
+                        val table = inlineTable(value)
+                        val module = table["module"]?.let(::unquote)
+                            ?: table["group"]?.let { g -> table["name"]?.let { n -> "${unquote(g)}:${unquote(n)}" } }
+                            ?: fail("Library $alias has no module or group/name")
+                        version(table)?.let { "$module:$it" } ?: module
+                    } else {
+                        unquote(value)
+                    }
+                    accessor(alias) to coordinate
+                }.toMap()
+
+                val plugins = sections["plugins"].orEmpty().map { (alias, value) ->
+                    val coordinate = if (value.startsWith("{")) {
+                        val table = inlineTable(value)
+                        val id = table["id"]?.let(::unquote) ?: fail("Plugin $alias has no id")
+                        version(table)?.let { "$id:$it" } ?: id
+                    } else {
+                        unquote(value)
+                    }
+                    accessor(alias) to coordinate
+                }.toMap()
+
+                val bundles = sections["bundles"].orEmpty().mapValues { (_, value) ->
+                    value.trim('[', ']').split(',').map { unquote(it.trim()) }.filter { it.isNotEmpty() }
+                        .mapNotNull { libraries[accessor(it)] }
+                }.mapKeys { accessor(it.key) }
+
+                return VersionCatalog(libraries, plugins, bundles)
+            }
+
+            private fun unquote(s: String) = s.trim().trim('"', '\'')
+
+            /** Parses '{ k = "v", k2.sub = "v2" }' into a map; values keep their quotes for [unquote]. */
+            private fun inlineTable(value: String): Map<String, String> =
+                value.trim().removePrefix("{").removeSuffix("}").split(',')
+                    .map { it.trim() }.filter { it.isNotEmpty() }
+                    .associate { entry -> entry.substringBefore('=').trim() to entry.substringAfter('=').trim() }
+        }
+    }
+}

--- a/androidApp/src/test/kotlin/coredevices/coreapp/FdroidScannerReplica.kt
+++ b/androidApp/src/test/kotlin/coredevices/coreapp/FdroidScannerReplica.kt
@@ -1,0 +1,479 @@
+package coredevices.coreapp
+
+import kotlin.test.fail
+
+/**
+ * Replica of the textual checks fdroidserver's source scanner
+ * (fdroidserver/scanner.py, scan_source) runs over a checkout, as pure
+ * functions over a path, a file's text, or its leading bytes.
+ *
+ * Kept free of any tree access on purpose: [FdroidGuardrailsTest] applies
+ * these functions to the tracked tree, and [FdroidScannerReplicaTest] feeds
+ * each one a known-bad and a known-good sample so a transcription slip in a
+ * regex or a parser regression cannot quietly turn the guardrail into a test
+ * that flags nothing. The constants are copied from scanner.py and from the
+ * SUSS signature database; when either changes upstream, update them in
+ * place and name the upstream revision in the commit.
+ *
+ * What is replicated: the maven-URL regex and allowlist over comment-stripped
+ * gradle files; the dependency-line matchers, catalog resolution, and the
+ * "usual suspects" gradle signatures; the binary suffix list and the
+ * `.so` regex; the first-1024-bytes sniff of extensionless files (dotfiles
+ * included, as os.path.splitext sees them) and of `.bin`/`.out`/`.exe`;
+ * the DexClassLoader grep over `.java` files; and the lockfile requirement
+ * for `package.json`, `Cargo.toml`, and `pubspec.yaml`.
+ *
+ * Where this deliberately differs from scanner.py, it is stricter, never
+ * looser, so a green run here cannot hide a red run there:
+ * - a tracked `.apk` fails here; the scanner deletes it with an info message;
+ * - a hit under `src/test` or `/test/` fails here; the scanner downgrades
+ *   those to warnings;
+ * - a settings file that declares extra catalogs (`versionCatalogs {}` or
+ *   `defaultLibrariesExtensionName`) fails here rather than being resolved,
+ *   because only the default `gradle/libs.versions.toml` reader exists;
+ * - the version-catalog reader accepts only the single-line TOML forms this
+ *   catalog uses and fails on anything else, where the scanner uses a full
+ *   TOML parser (see [VersionCatalog]).
+ * Not replicated at all: the scanner's warnings (executable binaries,
+ * unusual file permissions), which do not fail an F-Droid build.
+ */
+internal object FdroidScannerReplica {
+
+    // ---- Maven repository URLs -------------------------------------------
+
+    /**
+     * scanner.py MAVEN_URL_REGEX, verbatim apart from Java's requirement that
+     * the literal brace be escaped. Applied, as there, to the file with line
+     * comments and block comments removed.
+     */
+    val mavenUrlRegex = Regex(
+        """\smaven\s*(?:\{.*?(?:setUrl|url)|\(\s*(?:url)?)\s*=?\s*(?:uri|URI|Uri\.create)?\(?\s*["']?([^\s"']+)["']?[^})]*[)}]""",
+        RegexOption.DOT_MATCHES_ALL,
+    )
+
+    /** scanner.py allowed_repos: the hosts F-Droid trusts to serve free artifacts, plus Debian's local maven repo. */
+    val allowedMavenRepos: List<Regex> = listOf(
+        "repo1.maven.org/maven2",
+        "jitpack.io",
+        "www.jitpack.io",
+        "repo.maven.apache.org/maven2",
+        "oss.jfrog.org/artifactory/oss-snapshot-local",
+        "central.sonatype.com/repository/maven-snapshots",
+        "oss.sonatype.org/content/repositories/snapshots",
+        "oss.sonatype.org/content/repositories/releases",
+        "oss.sonatype.org/content/groups/public",
+        "oss.sonatype.org/service/local/staging/deploy/maven2",
+        "s01.oss.sonatype.org/content/repositories/snapshots",
+        "s01.oss.sonatype.org/content/repositories/releases",
+        "s01.oss.sonatype.org/content/groups/public",
+        "s01.oss.sonatype.org/service/local/staging/deploy/maven2",
+        "clojars.org/repo",
+        "repo.clojars.org",
+        "s3.amazonaws.com/repo.commonsware.com",
+        "plugins.gradle.org/m2",
+        "maven.google.com",
+    ).map { Regex("^https://" + Regex.escape(it) + "/*") } +
+        listOf("/usr/share/maven-repo").map { Regex("^file://" + Regex.escape(it) + "/*") }
+
+    /** common.py gradle_comment: a line the scanner drops before looking for maven URLs. */
+    private val gradleLineComment = Regex("""^[ ]*//""")
+
+    fun isGradleFile(path: String): Boolean = path.endsWith(".gradle") || path.endsWith(".gradle.kts")
+
+    /** Maven repository URLs in a gradle file's text that are off the allowlist, in file order. */
+    fun unknownMavenRepos(gradleText: String): List<String> {
+        val nonComment = gradleText.lines().filterNot { gradleLineComment.containsMatchIn(it) }
+        val text = nonComment.joinToString("\n").replace(Regex("""/\*.*?\*/""", RegexOption.DOT_MATCHES_ALL), "")
+        return mavenUrlRegex.findAll(text)
+            .map { it.groupValues[1] }
+            .filter { url -> allowedMavenRepos.none { it.containsMatchIn(url) } }
+            .toList()
+    }
+
+    // ---- Dependency lines naming non-free artifacts ----------------------
+
+    /**
+     * The gradle "usual suspects" from F-Droid's SUSS signature database
+     * (https://fdroid.gitlab.io/fdroid-suss/suss.json, version 1, database
+     * timestamp 2026-08-01), copied verbatim. The scanner compiles each as
+     * ".*" + signature, case-insensitive, and matches it against every
+     * dependency line and every catalog coordinate such a line resolves to;
+     * any hit is a build-failing error on the buildserver.
+     */
+    val scannerGradleSignatures: List<Regex> = listOf(
+        """androidx.*play-services""",
+        """androidx.core:core-google-shortcuts""",
+        """androidx.credentials:credentials-play-services-auth""",
+        """androidx.media3:media3-cast""",
+        """androidx.media3:media3-datasource-cronet""",
+        """androidx.media3:media3-exoplayer-ima""",
+        """androidx.navigation:navigation-dynamic-features""",
+        """androidx.wear:wear-remote-interactions""",
+        """androidx.work:work-gcm""",
+        """com(\.google)?\.firebase[.:](?!firebase-jobdispatcher|geofire-java|firebase-encoders)""",
+        """com.amazon.device""",
+        """com.amazonaws:DynamoDBLocal""",
+        """com.amazonaws:aws-android-sdk-auth-facebook""",
+        """com.amazonaws:aws-android-sdk-auth-google""",
+        """com.amazonaws:aws-android-sdk-auth-userpools""",
+        """com.amazonaws:aws-android-sdk-cognitoauth""",
+        """com.amazonaws:aws-android-sdk-cognitoidentityprovider""",
+        """com.amazonaws:aws-android-sdk-cognitoidentityprovider-asf""",
+        """com.amazonaws:aws-android-sdk-cognitoidentityprovider-test""",
+        """com.amazonaws:aws-android-sdk-kinesisvideo""",
+        """com.amazonaws:aws-android-sdk-kinesisvideo-archivedmedia""",
+        """com.amazonaws:aws-android-sdk-location""",
+        """com.amazonaws:aws-android-sdk-mobile-client""",
+        """com.amazonaws:dynamodb-key-diagnostics-library""",
+        """com.amazonaws:dynamodb-lock-client""",
+        """com.amazonaws:ivs-broadcast""",
+        """com.amazonaws:ivs-player""",
+        """com.amazonaws:kinesis-storm-spout""",
+        """com.amplifyframework:aws-push-notifications-pinpoint""",
+        """com.amplifyframework:aws-push-notifications-pinpoint-common""",
+        """com.android.billingclient""",
+        """com.android.installreferrer""",
+        """com.anjlab.android.iab.v3:library""",
+        """com.baidu.mobstat""",
+        """com.bugsense""",
+        """com.cloudinary:cloudinary-android.*:2\.[12]\.""",
+        """com.cloudrail""",
+        """com.crittercism""",
+        """com.evernote:android-job""",
+        """com.facebook.android""",
+        """com.flurry.android""",
+        """com.garmin.connectiq:ciq-companion-app-sdk""",
+        """com.geetest""",
+        """com.giphy.sdk""",
+        """com.github.SanojPunchihewa:InAppUpdater""",
+        """com.github.budowski:android-maps-utils""",
+        """com.github.derysudrajat:compass-qibla""",
+        """com.github.junrar:junrar""",
+        """com.github.omicronapps:7-Zip-JBinding-4Android""",
+        """com.github.penn5:donations""",
+        """com.github.uccmawei:FingerprintIdentify""",
+        """com.google.ads""",
+        """com.google.ai.edge.aicore""",
+        """com.google.ai.edge.litert:litert(-api)?:2""",
+        """com.google.android.exoplayer:extension-cast""",
+        """com.google.android.exoplayer:extension-cronet""",
+        """com.google.android.exoplayer:extension-ima""",
+        """com.google.android.gms(?!.(oss-licenses-plugin|strict-version-matcher-plugin))""",
+        """com.google.android.libraries(?!.mapsplatform.secrets-gradle-plugin)""",
+        """com.google.android.play:app-update""",
+        """com.google.android.play:asset-delivery""",
+        """com.google.android.play:core.*""",
+        """com.google.android.play:feature-delivery""",
+        """com.google.android.play:review""",
+        """com.google.android.support:wearable""",
+        """com.google.android.ump""",
+        """com.google.android.wearable:wearable""",
+        """com.google.androidbrowserhelper:billing""",
+        """com.google.api-client:google-api-client-android""",
+        """com.google.maps.android:android-maps-utils""",
+        """com.google.mlkit""",
+        """com.hypertrack(?!:hyperlog)""",
+        """com.meta.androidbrowserhelper""",
+        """com.meta.horizon""",
+        """com.microsoft.appcenter:appcenter-push""",
+        """com.microsoft.identity.client:msal""",
+        """com.microsoft.identity:common""",
+        """com.onesignal:OneSignal""",
+        """com.paypal""",
+        """com.pierfrancescosoffritti.androidyoutubeplayer:chromecast-sender""",
+        """com.revenuecat.purchases""",
+        """com.suddenh4x.ratingdialog:awesome-app-rating""",
+        """com.tencent.bugly""",
+        """com.umeng""",
+        """com.wei.android.lib:fingerprintidentify""",
+        """com.yayandroid:locationmanager""",
+        """com\.mapbox(?!\.mapboxsdk:mapbox-sdk-(services|geojson|turf):([3-5]))""",
+        """com\.yandex\.android(?!:authsdk)""",
+        """crashlytics""",
+        """io.github.g00fy2.quickie""",
+        """io.github.hyochan.openiap:openiap-amazon""",
+        """io.github.hyochan.openiap:openiap-google""",
+        """io.github.hyochan.openiap:openiap-horizon""",
+        """io.github.sinaweibosdk""",
+        """io.kotzilla""",
+        """io.objectbox:objectbox-gradle-plugin""",
+        """me.proton.core:payment-iap""",
+        """me.pushy""",
+        """org.gradle.toolchains.foojay-resolver""",
+        """org.mariuszgromada.math:MathParser.org-mXparser:[5-9]""",
+        """xyz.belvi.mobilevision:barcodescanner""",
+    ).map { Regex(".*$it", RegexOption.IGNORE_CASE) }
+
+    /**
+     * scanner.py get_gradle_compile_commands, for a build with no product
+     * flavors: the leading tokens that make a line a dependency (or plugin)
+     * declaration in the scanner's eyes.
+     */
+    private val gradleCompileCommands = listOf(
+        "alias", "api", "apk", "classpath", "compile", "compileOnly", "id",
+        "implementation", "provided", "runtimeOnly",
+    ).flatMap { listOf(it, "release$it") }
+
+    /** A dependency line whose coordinate is a literal string. */
+    private val dependencyLineWithoutCatalog = gradleCompileCommands.map {
+        Regex("""\s*['"]?$it.*\s*\(?['"].*['"]""", RegexOption.IGNORE_CASE)
+    }
+
+    /** A dependency line whose coordinate comes from the version catalog; group 1 is the accessor. */
+    private val dependencyLineWithCatalog = gradleCompileCommands.map {
+        Regex("""\s*['"]?$it.*\s*\(?libs\.([a-z0-9.]+)""", RegexOption.IGNORE_CASE)
+    }
+
+    /**
+     * Usual-suspect hits in a gradle file, one string per hit naming the
+     * 1-based line, the signature, and what matched: the line itself for a
+     * literal coordinate, or the catalog coordinate an accessor resolved to.
+     */
+    fun usualSuspects(gradleLines: List<String>, catalog: VersionCatalog): List<String> {
+        val hits = mutableListOf<String>()
+        gradleLines.forEachIndexed { index, line ->
+            val where = "line ${index + 1}"
+            if (dependencyLineWithoutCatalog.any { it.matchesAt(line, 0) }) {
+                scannerGradleSignatures.forEach { signature ->
+                    if (signature.matchesAt(line, 0)) {
+                        hits += "$where: usual suspect '${signature.pattern.removePrefix(".*")}' in: ${line.trim()}"
+                    }
+                }
+            }
+            val accessor = dependencyLineWithCatalog.firstNotNullOfOrNull { it.matchAt(line, 0)?.groupValues?.get(1) }
+            if (accessor != null) {
+                for (coordinate in catalog.coordinates(accessor)) {
+                    scannerGradleSignatures.forEach { signature ->
+                        if (signature.matchesAt(coordinate, 0)) {
+                            hits += "$where: usual suspect '${signature.pattern.removePrefix(".*")}' via libs.$accessor -> $coordinate"
+                        }
+                    }
+                }
+            }
+        }
+        return hits
+    }
+
+    /**
+     * scanner.py get_catalogs reads catalogs the settings file declares in a
+     * `versionCatalogs {}` block and honors `defaultLibrariesExtensionName`;
+     * this replica reads only the default `gradle/libs.versions.toml`, so a
+     * settings file using either construct must fail the guardrail until the
+     * replica learns it, rather than have its dependency lines resolve to
+     * nothing here while the scanner resolves them.
+     */
+    fun declaresCatalogsTheReplicaCannotRead(settingsText: String): Boolean =
+        Regex("""versionCatalogs\s*\{""").containsMatchIn(settingsText) ||
+            Regex("""defaultLibrariesExtensionName\s*=""").containsMatchIn(settingsText)
+
+    // ---- Binaries --------------------------------------------------------
+
+    /**
+     * Names the scanner deletes without counting an error (scanner.py's
+     * gradle-wrapper exemption); the replica ignores them likewise.
+     */
+    val scannerExemptNames = setOf("gradle-wrapper.jar", "gradlew", "gradlew.bat", "gradle-daemon-jvm.properties")
+
+    /**
+     * scanner.py's binary suffixes, each a build-failing error unless the
+     * recipe removes or ignores the path. `.apk` is deliberately kept in
+     * this list although the scanner only deletes such files: a tracked APK
+     * has no place in the source tree either way.
+     */
+    private val binarySuffixes = listOf(".a", ".aar", ".class", ".dex", ".gz", ".tgz", ".zip", ".jar", ".wasm", ".apk")
+    private val sharedObject = Regex(""".*\.so(\..+)*$""")
+
+    /** Why the scanner would reject this tracked path on its name alone, or null. */
+    fun binaryKind(path: String): String? {
+        val name = path.substringAfterLast('/')
+        if (name in scannerExemptNames) return null
+        if (sharedObject.matches(name)) return "shared library"
+        return binarySuffixes.firstOrNull { name.endsWith(it) }?.let { "'$it' binary" }
+    }
+
+    /**
+     * Whether the scanner byte-sniffs this path: files whose extension, as
+     * Python's os.path.splitext computes it, is empty or one of .bin/.out/
+     * .exe. splitext ignores leading dots, so `.gitignore` has no extension
+     * and is sniffed, while `foo.` has extension "." and is not. Names the
+     * scanner exempts and names caught by the suffix list above are never
+     * sniffed, mirroring the order of the scanner's checks.
+     */
+    fun isSniffed(path: String): Boolean {
+        val name = path.substringAfterLast('/')
+        if (name in scannerExemptNames || binaryKind(path) != null) return false
+        val stem = name.trimStart('.')
+        val extension = if (stem.contains('.')) stem.substring(stem.lastIndexOf('.')) else ""
+        return extension in setOf("", ".bin", ".out", ".exe")
+    }
+
+    /** scanner.py textchars: the byte set a text file is allowed to contain. */
+    private val textBytes = (setOf(7, 8, 9, 10, 12, 13, 27) + (0x20..0xFF)).minus(0x7F).map { it.toByte() }.toSet()
+
+    /** scanner.py is_binary over the first 1024 bytes of a file. */
+    fun isBinary(leadingBytes: ByteArray): Boolean = leadingBytes.take(1024).any { it !in textBytes }
+
+    // ---- Other source checks --------------------------------------------
+
+    /** scanner.py DEPFILE: dependency manifests that must have a lockfile beside them or in an ancestor directory. */
+    val dependencyFileLocks: Map<String, List<String>> = mapOf(
+        "Cargo.toml" to listOf("Cargo.lock"),
+        "pubspec.yaml" to listOf("pubspec.lock"),
+        "package.json" to listOf("package-lock.json", "yarn.lock", "pnpm-lock.yaml", "bun.lock"),
+    )
+
+    /**
+     * True when [path] is a dependency manifest and no matching lockfile is
+     * tracked in its directory or any ancestor up to the checkout root
+     * (the scanner walks up to the build directory the same way).
+     */
+    fun lacksLockfile(path: String, trackedPaths: Set<String>): Boolean {
+        val locks = dependencyFileLocks[path.substringAfterLast('/')] ?: return false
+        var directory = path.substringBeforeLast('/', "")
+        while (true) {
+            val prefix = if (directory.isEmpty()) "" else "$directory/"
+            if (locks.any { "$prefix$it" in trackedPaths }) return false
+            if (directory.isEmpty()) return true
+            directory = directory.substringBeforeLast('/', "")
+        }
+    }
+
+    /** scanner.py's `.java` check: any line mentioning DexClassLoader is a build-failing error. */
+    fun usesDexClassLoader(path: String, lines: List<String>): Boolean =
+        path.endsWith(".java") && lines.any { it.contains("DexClassLoader") }
+
+    // ---- Minimal version-catalog reader ----------------------------------
+
+    /**
+     * Just enough of gradle/libs.versions.toml to resolve an accessor to the
+     * coordinate(s) the scanner would check, mirroring scanner.py's
+     * GradleVersionCatalog: aliases map to accessors by turning '-' and '_'
+     * into '.'; libraries resolve to group:name[:version], plugins to
+     * id[:version], bundles to their member libraries.
+     *
+     * Only the single-line TOML forms this catalog uses are accepted: a
+     * quoted string, a one-line inline table of quoted strings, or a one-line
+     * array. Anything else (a line without '=', a multi-line array or table,
+     * a nested table such as `version = { strictly = ... }`) fails the parse,
+     * and so the guardrail, rather than being skipped: the scanner reads the
+     * catalog with a full TOML parser, so a form this reader cannot see is a
+     * dependency line it would silently stop checking while F-Droid still
+     * checks it. Extend the reader when the catalog needs a new form.
+     */
+    class VersionCatalog(
+        val libraries: Map<String, String>,
+        val plugins: Map<String, String>,
+        val bundles: Map<String, List<String>>,
+    ) {
+        fun coordinates(accessor: String): List<String> = when {
+            accessor.startsWith("plugins.") ->
+                listOfNotNull(plugins[accessor.removePrefix("plugins.").removeSuffix(".asLibraryDependency")])
+            accessor.startsWith("bundles.") -> bundles[accessor.removePrefix("bundles.")].orEmpty()
+            else -> listOfNotNull(libraries[accessor])
+        }
+
+        companion object {
+            /** A catalog with no entries, for gradle files under a settings root without one. */
+            val EMPTY = VersionCatalog(emptyMap(), emptyMap(), emptyMap())
+
+            private fun accessor(alias: String) = alias.replace('-', '.').replace('_', '.')
+
+            fun parse(tomlLines: List<String>): VersionCatalog {
+                val sections = mutableMapOf<String, MutableMap<String, String>>()
+                var current = ""
+                for (raw in tomlLines) {
+                    val line = stripComment(raw).trim()
+                    if (line.isEmpty()) continue
+                    if (line.startsWith("[") && line.endsWith("]") && !line.contains('=')) {
+                        current = line.trim('[', ']').trim()
+                        continue
+                    }
+                    if (!line.contains('=')) fail("Cannot parse catalog line (no '=', is it a multi-line value?): $raw")
+                    val key = unquote(line.substringBefore('='))
+                    val value = line.substringAfter('=').trim()
+                    if (key.isEmpty() || value.isEmpty()) fail("Cannot parse catalog line: $raw")
+                    val singleLine = when {
+                        value.startsWith("{") -> value.endsWith("}") && !value.drop(1).contains('{')
+                        value.startsWith("[") -> value.endsWith("]") && !value.drop(1).contains('[')
+                        else -> isQuoted(value)
+                    }
+                    if (!singleLine) fail("Cannot parse catalog line (only single-line strings, tables, and arrays are supported): $raw")
+                    sections.getOrPut(current) { linkedMapOf() }[key] = value
+                }
+                val versions = sections["versions"].orEmpty().mapValues { unquote(it.value) }
+
+                fun version(table: Map<String, String>): String? {
+                    table["version"]?.let { return unquote(it) }
+                    table["version.ref"]?.let { ref -> return versions[unquote(ref)] ?: fail("Unknown version ref $ref") }
+                    return null
+                }
+
+                val libraries = sections["libraries"].orEmpty().map { (alias, value) ->
+                    val coordinate = if (value.startsWith("{")) {
+                        val table = inlineTable(value)
+                        val module = table["module"]?.let(::unquote)
+                            ?: table["group"]?.let { g -> table["name"]?.let { n -> "${unquote(g)}:${unquote(n)}" } }
+                            ?: fail("Library $alias has no module or group/name")
+                        version(table)?.let { "$module:$it" } ?: module
+                    } else {
+                        unquote(value)
+                    }
+                    accessor(alias) to coordinate
+                }.toMap()
+
+                val plugins = sections["plugins"].orEmpty().map { (alias, value) ->
+                    val coordinate = if (value.startsWith("{")) {
+                        val table = inlineTable(value)
+                        val id = table["id"]?.let(::unquote) ?: fail("Plugin $alias has no id")
+                        version(table)?.let { "$id:$it" } ?: id
+                    } else {
+                        unquote(value)
+                    }
+                    accessor(alias) to coordinate
+                }.toMap()
+
+                val bundles = sections["bundles"].orEmpty().mapValues { (alias, value) ->
+                    if (!value.startsWith("[")) fail("Bundle $alias is not an array: $value")
+                    value.trim('[', ']').split(',').map { it.trim() }.filter { it.isNotEmpty() }
+                        .map { member ->
+                            if (!isQuoted(member)) fail("Bundle $alias has an unquoted member: $member")
+                            libraries[accessor(unquote(member))] ?: fail("Bundle $alias names unknown library $member")
+                        }
+                }.mapKeys { accessor(it.key) }
+
+                return VersionCatalog(libraries, plugins, bundles)
+            }
+
+            /** Drops a trailing `# comment`, leaving '#' inside quotes alone. */
+            private fun stripComment(line: String): String {
+                var quote: Char? = null
+                line.forEachIndexed { index, c ->
+                    when {
+                        quote != null -> if (c == quote) quote = null
+                        c == '"' || c == '\'' -> quote = c
+                        c == '#' -> return line.substring(0, index)
+                    }
+                }
+                return line
+            }
+
+            private fun isQuoted(s: String): Boolean {
+                val t = s.trim()
+                return t.length >= 2 && (t.first() == '"' || t.first() == '\'') && t.last() == t.first()
+            }
+
+            private fun unquote(s: String) = s.trim().trim('"', '\'')
+
+            /** Parses '{ k = "v", k2.sub = "v2" }' into a map; values keep their quotes for [unquote]. */
+            private fun inlineTable(value: String): Map<String, String> =
+                value.trim().removePrefix("{").removeSuffix("}").split(',')
+                    .map { it.trim() }.filter { it.isNotEmpty() }
+                    .associate { entry ->
+                        if (!entry.contains('=')) fail("Cannot parse inline table entry: $entry")
+                        val v = entry.substringAfter('=').trim()
+                        if (!isQuoted(v)) fail("Inline table value is not a quoted string: $entry")
+                        entry.substringBefore('=').trim() to v
+                    }
+        }
+    }
+}

--- a/androidApp/src/test/kotlin/coredevices/coreapp/FdroidScannerReplicaTest.kt
+++ b/androidApp/src/test/kotlin/coredevices/coreapp/FdroidScannerReplicaTest.kt
@@ -1,0 +1,246 @@
+package coredevices.coreapp
+
+import coredevices.coreapp.FdroidScannerReplica.VersionCatalog
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Positive controls for [FdroidScannerReplica]: every check is shown to fire
+ * on a known-bad sample and stay quiet on a known-good one, so a lost regex
+ * prefix, an escaping slip while re-syncing a constant, or a catalog reader
+ * that starts resolving every accessor to nothing cannot leave
+ * [FdroidGuardrailsTest] green over a tree F-Droid would reject. The samples
+ * are the shapes that have actually mattered here (a Crashlytics wrapper
+ * behind a catalog accessor, a GitHub Packages publishing URL, a checked-in
+ * `.so`) plus the scanner's documented edge cases.
+ */
+class FdroidScannerReplicaTest {
+
+    // ---- Maven repository URLs -------------------------------------------
+
+    @Test
+    fun mavenUrlOffTheAllowlistIsReported() {
+        val text = """
+            publishing {
+                repositories {
+                    maven {
+                        url = uri("https://maven.pkg.github.com/example/repo")
+                    }
+                }
+            }
+        """.trimIndent()
+        assertEquals(listOf("https://maven.pkg.github.com/example/repo"), FdroidScannerReplica.unknownMavenRepos(text))
+    }
+
+    @Test
+    fun allowlistedMavenUrlsAreNotReported() {
+        val text = """
+            repositories {
+                maven { url = uri("https://jitpack.io") }
+                maven { setUrl("https://repo1.maven.org/maven2/") }
+                maven { url = uri("file:///usr/share/maven-repo") }
+                maven("https://maven.google.com")
+            }
+        """.trimIndent()
+        assertEquals(emptyList(), FdroidScannerReplica.unknownMavenRepos(text))
+    }
+
+    @Test
+    fun commentedOutMavenUrlsAreIgnoredLikeTheScannerDoes() {
+        val text = """
+            repositories {
+                // maven { url = uri("https://maven.pkg.github.com/example/repo") }
+                /* maven {
+                     url = uri("https://maven.example.org/private")
+                   } */
+            }
+        """.trimIndent()
+        assertEquals(emptyList(), FdroidScannerReplica.unknownMavenRepos(text))
+    }
+
+    // ---- Dependency lines ------------------------------------------------
+
+    private val catalog = VersionCatalog.parse(
+        """
+        [versions]
+        crash = "0.9.0" # trailing comment with a # inside "quotes # here"
+        gms = "21.0.0"
+
+        [libraries]
+        crashkios = { module = "co.touchlab.crashkios:crashlytics", version.ref = "crash" }
+        location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "gms" }
+        okio = "com.squareup.okio:okio:3.9.0"
+        ktor-client-core = { module = "io.ktor:ktor-client-core", version = "3.0.0" }
+
+        [plugins]
+        crashlytics-plugin = { id = "com.google.firebase.crashlytics", version = "3.0.0" }
+
+        [bundles]
+        tracking = ["crashkios", "okio"]
+        """.trimIndent().lines(),
+    )
+
+    @Test
+    fun literalDependencyLineNamingASuspectIsReported() {
+        val hits = FdroidScannerReplica.usualSuspects(
+            listOf("""    implementation("com.google.firebase:firebase-analytics:22.0.0")"""),
+            VersionCatalog.EMPTY,
+        )
+        assertEquals(1, hits.size, hits.toString())
+        assertTrue(hits.single().contains("firebase"), hits.single())
+    }
+
+    @Test
+    fun catalogAccessorResolvingToASuspectIsReported() {
+        val hits = FdroidScannerReplica.usualSuspects(listOf("        implementation(libs.crashkios)"), catalog)
+        assertEquals(1, hits.size, hits.toString())
+        assertTrue(hits.single().contains("co.touchlab.crashkios:crashlytics:0.9.0"), hits.single())
+    }
+
+    @Test
+    fun groupNameCatalogEntryAndPluginAliasAndBundleAreResolved() {
+        val lines = listOf(
+            "implementation(libs.location)",
+            "alias(libs.plugins.crashlytics.plugin)",
+            "implementation(libs.bundles.tracking)",
+        )
+        val hits = FdroidScannerReplica.usualSuspects(lines, catalog)
+        // The plugin id trips two signatures (firebase and crashlytics), as it does on the buildserver.
+        assertEquals(4, hits.size, hits.toString())
+        assertTrue(hits[0].startsWith("line 1:") && hits[0].endsWith("com.google.android.gms:play-services-location:21.0.0"), hits[0])
+        assertTrue(hits[1].startsWith("line 2:") && hits[1].endsWith("com.google.firebase.crashlytics:3.0.0"), hits[1])
+        assertTrue(hits[2].startsWith("line 2:") && hits[2].endsWith("com.google.firebase.crashlytics:3.0.0"), hits[2])
+        assertTrue(hits[3].startsWith("line 3:") && hits[3].endsWith("co.touchlab.crashkios:crashlytics:0.9.0"), hits[3])
+    }
+
+    @Test
+    fun benignDependencyLinesAreNotReported() {
+        val lines = listOf(
+            """implementation("com.squareup.okio:okio:3.9.0")""",
+            "implementation(libs.okio)",
+            "implementation(libs.ktor.client.core)",
+            "implementation(project(\":pebble\"))",
+            """// implementation("com.google.firebase:firebase-analytics:22.0.0")""",
+        )
+        // The scanner's line matchers are anchored at the start of the line
+        // (optional whitespace, optional quote, then the command), so a line
+        // commented out with // is not a dependency line to it either.
+        assertEquals(emptyList(), FdroidScannerReplica.usualSuspects(lines, catalog))
+    }
+
+    @Test
+    fun settingsDeclaringExtraCatalogsIsDetected() {
+        assertTrue(FdroidScannerReplica.declaresCatalogsTheReplicaCannotRead("dependencyResolutionManagement { versionCatalogs { create(\"tools\") {} } }"))
+        assertTrue(FdroidScannerReplica.declaresCatalogsTheReplicaCannotRead("defaultLibrariesExtensionName = \"deps\""))
+        assertFalse(FdroidScannerReplica.declaresCatalogsTheReplicaCannotRead("include(\":androidApp\")"))
+    }
+
+    // ---- Version catalog reader -----------------------------------------
+
+    @Test
+    fun catalogReaderFailsOnMultiLineArray() {
+        val lines = listOf("[bundles]", "tracking = [", "    \"crashkios\",", "]")
+        assertFailsWith<AssertionError> { VersionCatalog.parse(lines) }
+    }
+
+    @Test
+    fun catalogReaderFailsOnMultiLineInlineTable() {
+        val lines = listOf("[libraries]", "crashkios = { module = \"co.touchlab.crashkios:crashlytics\",", "  version = \"0.9.0\" }")
+        assertFailsWith<AssertionError> { VersionCatalog.parse(lines) }
+    }
+
+    @Test
+    fun catalogReaderFailsOnNestedVersionTable() {
+        val lines = listOf("[libraries]", "okio = { module = \"com.squareup.okio:okio\", version = { strictly = \"3.9.0\" } }")
+        assertFailsWith<AssertionError> { VersionCatalog.parse(lines) }
+    }
+
+    @Test
+    fun catalogReaderFailsOnUnknownVersionRef() {
+        val lines = listOf("[libraries]", "okio = { module = \"com.squareup.okio:okio\", version.ref = \"nope\" }")
+        assertFailsWith<AssertionError> { VersionCatalog.parse(lines) }
+    }
+
+    @Test
+    fun catalogReaderResolvesTheSingleLineForms() {
+        assertEquals(listOf("com.squareup.okio:okio:3.9.0"), catalog.coordinates("okio"))
+        assertEquals(listOf("io.ktor:ktor-client-core:3.0.0"), catalog.coordinates("ktor.client.core"))
+        assertEquals(listOf("com.google.firebase.crashlytics:3.0.0"), catalog.coordinates("plugins.crashlytics.plugin"))
+        assertEquals(listOf("com.google.firebase.crashlytics:3.0.0"), catalog.coordinates("plugins.crashlytics.plugin.asLibraryDependency"))
+        assertEquals(listOf("co.touchlab.crashkios:crashlytics:0.9.0", "com.squareup.okio:okio:3.9.0"), catalog.coordinates("bundles.tracking"))
+        assertEquals(emptyList(), catalog.coordinates("no.such.alias"))
+    }
+
+    // ---- Binaries --------------------------------------------------------
+
+    @Test
+    fun binarySuffixesAndSharedObjectsAreReported() {
+        assertEquals("shared library", FdroidScannerReplica.binaryKind("app/src/main/jniLibs/arm64-v8a/libfoo.so"))
+        assertEquals("shared library", FdroidScannerReplica.binaryKind("vendor/libfoo.so.1.2"))
+        assertEquals("'.aar' binary", FdroidScannerReplica.binaryKind("libs/thing.aar"))
+        assertEquals("'.jar' binary", FdroidScannerReplica.binaryKind("libs/thing.jar"))
+        assertEquals("'.apk' binary", FdroidScannerReplica.binaryKind("dist/app.apk"))
+    }
+
+    @Test
+    fun scannerExemptNamesAndOrdinarySourcesAreNotReported() {
+        assertNull(FdroidScannerReplica.binaryKind("gradle/wrapper/gradle-wrapper.jar"))
+        assertNull(FdroidScannerReplica.binaryKind("gradlew"))
+        assertNull(FdroidScannerReplica.binaryKind("gradlew.bat"))
+        assertNull(FdroidScannerReplica.binaryKind("src/main/kotlin/Foo.kt"))
+        assertNull(FdroidScannerReplica.binaryKind("art/logo.png"))
+        assertNull(FdroidScannerReplica.binaryKind("docs/notes.solo"))
+    }
+
+    @Test
+    fun sniffSelectionFollowsPythonSplitext() {
+        assertTrue(FdroidScannerReplica.isSniffed(".gitignore"))
+        assertTrue(FdroidScannerReplica.isSniffed("util/.gitignore"))
+        assertTrue(FdroidScannerReplica.isSniffed(".gitmodules"))
+        assertTrue(FdroidScannerReplica.isSniffed("LICENSE"))
+        assertTrue(FdroidScannerReplica.isSniffed("models/for-tests-ggml-tiny.bin"))
+        assertTrue(FdroidScannerReplica.isSniffed("tool.exe"))
+        assertTrue(FdroidScannerReplica.isSniffed("a.out"))
+        assertFalse(FdroidScannerReplica.isSniffed("foo."))
+        assertFalse(FdroidScannerReplica.isSniffed(".config.yml"))
+        assertFalse(FdroidScannerReplica.isSniffed("README.md"))
+        assertFalse(FdroidScannerReplica.isSniffed("gradlew"))
+        assertFalse(FdroidScannerReplica.isSniffed("libfoo.so"))
+    }
+
+    @Test
+    fun byteSniffMatchesTheScannerHeuristic() {
+        assertTrue(FdroidScannerReplica.isBinary(byteArrayOf(0x6C, 0x6D, 0x67, 0x67, 0x00, 0x00)))
+        assertTrue(FdroidScannerReplica.isBinary("text then \u007F (DEL)".toByteArray()))
+        assertFalse(FdroidScannerReplica.isBinary("plain text\n\twith tabs\r\n".toByteArray()))
+        assertFalse(FdroidScannerReplica.isBinary("high bytes are text: éÿ".toByteArray(Charsets.ISO_8859_1)))
+        assertFalse(FdroidScannerReplica.isBinary(ByteArray(0)))
+    }
+
+    // ---- Other source checks --------------------------------------------
+
+    @Test
+    fun dependencyManifestWithoutLockfileIsReported() {
+        val tracked = setOf("web/package.json", "web/src/index.js")
+        assertTrue(FdroidScannerReplica.lacksLockfile("web/package.json", tracked))
+    }
+
+    @Test
+    fun lockfileInTheSameOrAnAncestorDirectorySatisfiesTheCheck() {
+        assertFalse(FdroidScannerReplica.lacksLockfile("web/package.json", setOf("web/package.json", "web/yarn.lock")))
+        assertFalse(FdroidScannerReplica.lacksLockfile("web/app/package.json", setOf("web/app/package.json", "package-lock.json")))
+        assertFalse(FdroidScannerReplica.lacksLockfile("rust/Cargo.toml", setOf("rust/Cargo.toml", "rust/Cargo.lock")))
+        assertFalse(FdroidScannerReplica.lacksLockfile("web/index.js", setOf("web/index.js")))
+    }
+
+    @Test
+    fun dexClassLoaderInJavaIsReported() {
+        assertTrue(FdroidScannerReplica.usesDexClassLoader("src/Loader.java", listOf("import dalvik.system.DexClassLoader;")))
+        assertFalse(FdroidScannerReplica.usesDexClassLoader("src/Loader.java", listOf("import java.io.File;")))
+        assertFalse(FdroidScannerReplica.usesDexClassLoader("src/Loader.kt", listOf("import dalvik.system.DexClassLoader")))
+    }
+}

--- a/androidApp/src/test/kotlin/coredevices/coreapp/TrackedTree.kt
+++ b/androidApp/src/test/kotlin/coredevices/coreapp/TrackedTree.kt
@@ -1,0 +1,71 @@
+package coredevices.coreapp
+
+import java.io.File
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * The checkout as F-Droid's buildserver sees it: every git-tracked path of
+ * the superproject plus every tracked path of each checked-out submodule,
+ * relative to the repository root.
+ *
+ * Shared by the tree-reading sentinels in this source set
+ * ([FdroidGuardrailsTest], [ExcludedAssetSentinelTest]) so they agree on
+ * what "the tree" is. Reading through git rather than walking the disk keeps
+ * build outputs, IDE files, and untracked scratch out of the picture, which
+ * is also what an F-Droid clone contains.
+ *
+ * Fails closed on an unpopulated submodule: F-Droid's recipe checks
+ * submodules out (`submodules: yes`) and its scanner walks them like any
+ * other directory, so a scan that silently skipped an empty submodule
+ * directory would pass here and fail there. `git submodule update --init
+ * --recursive` is the fix on a checkout that trips it.
+ */
+internal object TrackedTree {
+
+    /** The checkout root: the nearest ancestor of the test working directory holding settings.gradle.kts. */
+    val root: File by lazy {
+        generateSequence(File("").absoluteFile) { it.parentFile }
+            .firstOrNull { File(it, "settings.gradle.kts").isFile }
+            ?: fail("Could not locate the repository root from ${File("").absolutePath}")
+    }
+
+    /** Submodule paths declared in .gitmodules, relative to the root (empty when there is no .gitmodules). */
+    val submodulePaths: List<String> by lazy {
+        if (!File(root, ".gitmodules").isFile) return@lazy emptyList()
+        git("config", "--file", ".gitmodules", "--get-regexp", """^submodule\..*\.path$""")
+            .lines()
+            .filter { it.isNotBlank() }
+            .map { it.substringAfterLast(' ') }
+    }
+
+    /**
+     * Every tracked path, superproject and submodules together. A submodule
+     * that is declared but not checked out lists as its bare gitlink path
+     * instead of its contents, which is the case this fails on.
+     */
+    val files: List<String> by lazy {
+        val listed = git("ls-files", "-z", "--recurse-submodules").split('\u0000').filter { it.isNotEmpty() }
+        for (submodule in submodulePaths) {
+            assertTrue(
+                listed.any { it.startsWith("$submodule/") },
+                "Submodule $submodule is not checked out, so its tree cannot be scanned; " +
+                    "run `git submodule update --init --recursive`.",
+            )
+        }
+        listed
+    }
+
+    fun file(path: String): File = File(root, path)
+
+    /** Runs git at the root and returns its stdout; a non-zero exit fails the calling test. */
+    fun git(vararg args: String): String {
+        val process = ProcessBuilder(listOf("git", "-C", root.path) + args)
+            .redirectErrorStream(true)
+            .start()
+        val output = process.inputStream.readBytes().toString(Charsets.UTF_8)
+        val exit = process.waitFor()
+        assertTrue(exit == 0, "git ${args.joinToString(" ")} failed ($exit): $output")
+        return output
+    }
+}

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -185,7 +185,11 @@ kotlin {
         }
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)
-            implementation(libs.crashkios)
+            // Fork: upstream adds libs.crashkios (a Crashlytics wrapper) here.
+            // The fork ships no crash reporting on any platform, and the
+            // coordinate is a build-failing F-Droid scanner signature even
+            // on an iOS-only line, since the scanner reads dependency lines
+            // textually. The iOS target is unmaintained in this fork.
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,9 +1,15 @@
-Gravel is an unofficial, de-Googled fork of the Pebble mobile app by Core Devices, for managing Pebble and Core Devices smartwatches without Google Play services or Firebase. Pair your watch, customize your settings, and browse watchfaces and apps on GrapheneOS, LineageOS, and similar phones.
+Gravel is an unofficial, de-Googled fork of the Pebble mobile app by Core Devices, for managing Pebble and Core Devices smartwatches without Google Play services or Firebase. Pair your watch, customize your settings, browse watchfaces and apps, and update watch firmware on GrapheneOS, LineageOS, and similar phones.
 
 Gravel is not affiliated with or endorsed by Core Devices. "Pebble" and "Core Devices" are trademarks of their respective owners; Gravel is an independent fork of their GPLv3-licensed source code, under its own name and icon to avoid any confusion with the official app.
 
 Features include:
-- Bluetooth pairing and reconnection
+- Bluetooth pairing and reconnection, notifications, calendar, music, health, and weather on the watch
 - Watchface and app gallery browsing
-- Works without Google Play services or Firebase
-- No telemetry
+- Core watch firmware updates fetched from the public PebbleOS releases and integrity-verified before install
+- Per-app permissions for watchapps' companion JavaScript: internet and phone location are denied by default until you allow them
+- On-device voice dictation with the whisper.cpp speech engine, built from source; the speech model is an optional, integrity-pinned download you start yourself
+- Works without Google Play services or Firebase; no telemetry, no analytics, no crash reporting
+
+The app talks to the Core Devices and Rebble web services (app store and its search index, weather, timeline, notification icons, language packs), to the PebbleOS release feed on GitHub for firmware, and to the speech model host on first download; there is no Google endpoint. Manual latitude/longitude entry replaces the Play-services place search for weather.
+
+Permissions Gravel asks for are the ones the watch features need: Bluetooth and location for finding and staying connected to the watch (background location so location-based watchapps and weather keep working while the app is not open), notification access to forward notifications, contacts, call log, and phone state for caller names and call control on the watch, calendar for timeline pins, Health Connect write access to sync the watch's health data, and the list of installed apps for per-app notification settings. Each is requested when the corresponding feature is first set up.

--- a/fastlane/metadata/android/en-US/short_description.txt
+++ b/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Gravel: an unofficial, de-Googled companion app for Pebble smartwatches.
+Gravel: an unofficial, de-Googled companion app for Pebble smartwatches

--- a/haversine-stubs/build.gradle.kts
+++ b/haversine-stubs/build.gradle.kts
@@ -1,0 +1,65 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+// Fork module: inert stand-ins for the io.github.coredevices.haversine
+// artifact, the Ring satellite library. The real artifact is a prebuilt AAR
+// with no public source that ships two native libraries per ABI into the
+// APK, which is what stood between the fork and F-Droid's inclusion policy
+// once the speech stack was rebuilt from source. The Ring runtime the
+// library serves is dead in this fork (NoOpLibIndex at the Koin seam), so
+// nothing observable changes: :libindex only needs the seven symbols below
+// to compile.
+//
+// Wiring differs from :firebase-stubs on purpose. That module is named on
+// upstream dependency lines the fork already edits; here the only consumer
+// is libindex/build.gradle.kts, an upstream file the fork has never touched,
+// so settings.gradle.kts substitutes the maven coordinate for this project
+// instead. libindex keeps its upstream dependency line byte-for-byte, and
+// a future upstream version bump of the artifact still lands on the stub.
+// The AAR's absence from the shipped classpath is pinned by
+// AppClasspathSentinelTest in :androidApp.
+//
+// Module shape mirrors :krisp-stubs and :firebase-stubs (KMP Android library
+// plugin, AGP 9). The iOS targets exist only because libindex declares them
+// and KMP resolves a commonMain dependency for every target of the consumer;
+// the iOS app itself is unmaintained in this fork.
+plugins {
+    alias(libs.plugins.kotlin.multiplatform)
+    alias(libs.plugins.androidKotlinMultiplatformLibrary)
+}
+
+kotlin {
+    android {
+        namespace = "coredevices.haversinestubs"
+        compileSdk = libs.versions.android.compileSdk.get().toInt()
+        minSdk = libs.versions.android.minSdk.get().toInt()
+
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+
+        // The stub-behavior tests live in commonTest; without this the
+        // plugin would silently skip them for the android compilation.
+        withHostTestBuilder {}
+    }
+
+    iosArm64()
+
+    iosSimulatorArm64()
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                // The stubbed surface exposes StateFlow-typed properties, as
+                // the real library's does, so the same runtime dep applies.
+                api(libs.coroutines)
+            }
+        }
+
+        commonTest {
+            dependencies {
+                implementation(libs.kotlin.test)
+                implementation(libs.coroutines.test)
+            }
+        }
+    }
+}

--- a/haversine-stubs/build.gradle.kts
+++ b/haversine-stubs/build.gradle.kts
@@ -9,14 +9,11 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 // nothing observable changes: :libindex only needs the seven symbols below
 // to compile.
 //
-// Wiring differs from :firebase-stubs on purpose. That module is named on
-// upstream dependency lines the fork already edits; here the only consumer
-// is libindex/build.gradle.kts, an upstream file the fork has never touched,
-// so settings.gradle.kts substitutes the maven coordinate for this project
-// instead. libindex keeps its upstream dependency line byte-for-byte, and
-// a future upstream version bump of the artifact still lands on the stub.
-// The AAR's absence from the shipped classpath is pinned by
-// AppClasspathSentinelTest in :androidApp.
+// Wired by the dependencySubstitution rule in settings.gradle.kts, not by
+// a dependency line: nothing names this project directly, so a lost rule
+// brings the AAR back silently, which AppClasspathSentinelTest in
+// :androidApp fails on. The seam and its rationale are in DESIGN_NOTES.md
+// (Ring / Index AI).
 //
 // Module shape mirrors :krisp-stubs and :firebase-stubs (KMP Android library
 // plugin, AGP 9). The iOS targets exist only because libindex declares them

--- a/haversine-stubs/build.gradle.kts
+++ b/haversine-stubs/build.gradle.kts
@@ -37,8 +37,9 @@ kotlin {
             jvmTarget.set(JvmTarget.JVM_17)
         }
 
-        // The stub-behavior tests live in commonTest; without this the
-        // plugin would silently skip them for the android compilation.
+        // The stub-behavior tests live in commonTest and the reflection-based
+        // shape test in androidHostTest; without this the plugin would
+        // silently skip both for the android compilation.
         withHostTestBuilder {}
     }
 
@@ -58,7 +59,6 @@ kotlin {
         commonTest {
             dependencies {
                 implementation(libs.kotlin.test)
-                implementation(libs.coroutines.test)
             }
         }
     }

--- a/haversine-stubs/src/androidHostTest/kotlin/coredevices/haversine/HaversineStubShapeTest.kt
+++ b/haversine-stubs/src/androidHostTest/kotlin/coredevices/haversine/HaversineStubShapeTest.kt
@@ -1,0 +1,75 @@
+package coredevices.haversine
+
+import java.lang.reflect.Modifier
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Pins the shape the stub's behavioral contract rests on (see the KDoc on
+ * HaversineStubs.kt): the three satellite classes can only ever be
+ * constructed privately and nothing hands one out, so no ring object can
+ * exist in the app. HaversineStubTest covers what the two static entry
+ * points answer; this test covers the invariant a later edit is most
+ * likely to loosen (a constructor made public or a factory added to reach
+ * an instance from a test), which no other test in the tree observes.
+ * JVM reflection, hence the android host source set rather than commonTest.
+ */
+class HaversineStubShapeTest {
+
+    private val satelliteClasses = listOf(
+        KMPHaversineSatellite::class.java,
+        KMPHaversineSatelliteState::class.java,
+        KMPHaversineSatelliteManager::class.java,
+    )
+
+    @Test
+    fun satelliteClassesHaveOnlyPrivateConstructors() {
+        satelliteClasses.forEach { type ->
+            val constructors = type.declaredConstructors
+            assertTrue(constructors.isNotEmpty(), "${type.simpleName} declares no constructor")
+            constructors.forEach { constructor ->
+                assertTrue(Modifier.isPrivate(constructor.modifiers), "${type.simpleName} has a non-private constructor: $constructor")
+            }
+        }
+    }
+
+    // A companion factory compiles to a nested class plus static accessors;
+    // a top-level factory lands in the file facade class.
+    @Test
+    fun nothingHandsOutASatelliteInstance() {
+        satelliteClasses.forEach { type ->
+            assertTrue(type.declaredClasses.isEmpty(), "${type.simpleName} gained a nested class: ${type.declaredClasses.toList()}")
+            val staticFactories = type.declaredMethods.filter { Modifier.isStatic(it.modifiers) && it.returnType in satelliteClasses }
+            assertTrue(staticFactories.isEmpty(), "${type.simpleName} gained a static factory: $staticFactories")
+        }
+        val facade = Class.forName("coredevices.haversine.HaversineStubsKt")
+        val topLevelFactories = facade.declaredMethods.filter { it.returnType in satelliteClasses }
+        assertTrue(topLevelFactories.isEmpty(), "A top-level function returns a satellite type: $topLevelFactories")
+    }
+
+    // The KDoc's second line of defense: should an instance ever be reached
+    // anyway, its members answer the empty shape rather than throwing.
+    @Test
+    fun anInstanceReachedByReflectionIsInert() {
+        val manager = construct(KMPHaversineSatelliteManager::class.java)
+        assertNull(manager.lastRing.value)
+        assertNull(runBlocking { manager.getSatelliteById("any") })
+
+        val satellite = construct(KMPHaversineSatellite::class.java)
+        assertEquals("", satellite.id)
+        assertNull(satellite.name)
+        assertNull(satellite.state.value)
+        runBlocking { satellite.eraseCollections() }
+
+        val state = construct(KMPHaversineSatelliteState::class.java)
+        assertEquals("", state.firmwareVersion)
+        assertEquals("", state.serialNumber)
+        assertNull(state.programmedSerialNumber)
+    }
+
+    private fun <T> construct(type: Class<T>): T =
+        type.getDeclaredConstructor().apply { isAccessible = true }.newInstance()
+}

--- a/haversine-stubs/src/commonMain/kotlin/coredevices/haversine/HaversineStubs.kt
+++ b/haversine-stubs/src/commonMain/kotlin/coredevices/haversine/HaversineStubs.kt
@@ -29,8 +29,10 @@ import kotlinx.coroutines.flow.StateFlow
  * library's API fails the build here until this surface is extended, which
  * is intended: it forces a look at whether the new call belongs to the dead
  * Ring runtime (extend the stub) or to something the fork actually needs to
- * think about. Re-adding the real artifact next to this module trips
- * duplicate-class errors, the same tripwire the other stub modules rely on.
+ * think about. The settings-level substitution rewrites every reference to
+ * the real artifact's coordinate to this module, so the two cannot meet on
+ * a classpath; were that rule ever lost, the AAR would return silently,
+ * which AppClasspathSentinelTest in :androidApp fails on.
  */
 interface CollectionIndexStorage {
     val lastSuccessfulCollectionIndex: StateFlow<Int?>

--- a/haversine-stubs/src/commonMain/kotlin/coredevices/haversine/HaversineStubs.kt
+++ b/haversine-stubs/src/commonMain/kotlin/coredevices/haversine/HaversineStubs.kt
@@ -1,0 +1,82 @@
+package coredevices.haversine
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Fork stubs for the `io.github.coredevices.haversine` Ring satellite library,
+ * declared under the same fully-qualified names so `:libindex` compiles
+ * unchanged against them.
+ *
+ * Behavioral contract: no Ring can ever be seen, paired, or driven.
+ *
+ * - The satellite classes ([KMPHaversineSatellite], [KMPHaversineSatelliteState],
+ *   [KMPHaversineSatelliteManager]) have private constructors and no factory,
+ *   so no instance can exist anywhere in the app. Every libindex code path
+ *   that would act on a ring first needs one of these in hand, which makes
+ *   this the strongest possible guarantee that the dead Ring runtime stays
+ *   dead. Their members are still inert rather than throwing, matching the
+ *   `:firebase-stubs` house rule: if an instance ever did escape, callers
+ *   degrade to the empty shape instead of crashing a scan or sync path.
+ * - The two static entry points that need no instance, the advertisement
+ *   fingerprint parser and the failsafe check, answer "no ring here"
+ *   (`null` / `false`) so a BLE scan that reaches them ignores the packet.
+ * - The two delegate interfaces are mirrored exactly; libindex implements
+ *   [CollectionIndexStorage] and only calls [KMPHaversineHacksDelegate]
+ *   through a satellite it can never obtain.
+ *
+ * Only what libindex references is declared. A new upstream use of the
+ * library's API fails the build here until this surface is extended, which
+ * is intended: it forces a look at whether the new call belongs to the dead
+ * Ring runtime (extend the stub) or to something the fork actually needs to
+ * think about. Re-adding the real artifact next to this module trips
+ * duplicate-class errors, the same tripwire the other stub modules rely on.
+ */
+interface CollectionIndexStorage {
+    val lastSuccessfulCollectionIndex: StateFlow<Int?>
+    fun setLastSuccessfulCollectionIndex(index: Int?)
+}
+
+interface KMPHaversineHacksDelegate {
+    fun shouldWipeCollectionsBeforeTransfer(satellite: KMPHaversineSatellite): Boolean
+    fun wipedCollectionsBeforeTransfer(satellite: KMPHaversineSatellite)
+}
+
+class KMPHaversineAdvertisement private constructor() {
+    companion object {
+        /**
+         * The real parser decodes the ring's manufacturer-data state
+         * fingerprint. `null` is the library's own "not a ring advertisement"
+         * answer, and libindex's scanner drops the packet on it, so this is
+         * the inert value that keeps a scan quiet rather than one that
+         * invents a device.
+         */
+        @Suppress("UNUSED_PARAMETER")
+        fun parseToStateFingerprint(data: ByteArray): Long? = null
+    }
+}
+
+/** No fingerprint ever parses, so nothing can match the failsafe pattern either. */
+@Suppress("UNUSED_PARAMETER")
+fun fingerprintMatchesFailsafe(fingerprint: Long): Boolean = false
+
+class KMPHaversineSatellite private constructor() {
+    val id: String get() = ""
+    val name: String? get() = null
+    val state: StateFlow<KMPHaversineSatelliteState?> = MutableStateFlow(null)
+    suspend fun eraseCollections() {}
+}
+
+class KMPHaversineSatelliteState private constructor() {
+    val firmwareVersion: String get() = ""
+    val serialNumber: String get() = ""
+    val programmedSerialNumber: String? get() = null
+}
+
+class KMPHaversineSatelliteManager private constructor() {
+    /** Never emits a ring: the flow is created holding null and nothing writes to it. */
+    val lastRing: StateFlow<KMPHaversineSatellite?> = MutableStateFlow(null)
+
+    @Suppress("UNUSED_PARAMETER")
+    suspend fun getSatelliteById(id: String): KMPHaversineSatellite? = null
+}

--- a/haversine-stubs/src/commonTest/kotlin/coredevices/haversine/HaversineStubTest.kt
+++ b/haversine-stubs/src/commonTest/kotlin/coredevices/haversine/HaversineStubTest.kt
@@ -1,0 +1,25 @@
+package coredevices.haversine
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class HaversineStubTest {
+    // The two entry points reachable without a satellite instance must keep
+    // answering "no ring here": libindex's scanner ignores an advertisement
+    // whose fingerprint parses to null, and nothing may ever look like a
+    // failsafe-mode ring. Anything else would let the dead Ring runtime
+    // conjure a device out of arbitrary BLE manufacturer data.
+    @Test
+    fun noAdvertisementEverParsesToAFingerprint() {
+        assertNull(KMPHaversineAdvertisement.parseToStateFingerprint(ByteArray(0)))
+        assertNull(KMPHaversineAdvertisement.parseToStateFingerprint(ByteArray(32) { 0xFF.toByte() }))
+    }
+
+    @Test
+    fun noFingerprintMatchesTheFailsafePattern() {
+        assertFalse(fingerprintMatchesFailsafe(0L))
+        assertFalse(fingerprintMatchesFailsafe(-1L))
+        assertFalse(fingerprintMatchesFailsafe(Long.MAX_VALUE))
+    }
+}

--- a/libpebble3/build.gradle.kts
+++ b/libpebble3/build.gradle.kts
@@ -11,19 +11,6 @@ plugins {
     alias(libs.plugins.kotlinx.atomicfu)
 }
 
-publishing {
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/pebble-dev/libpebblecommon")
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
-}
-
 room {
     schemaDirectory("schema")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -53,3 +53,27 @@ include(":krisp-stubs")
 // strip). Keeps upstream call sites compiling with no Firebase/GMS SDKs
 // in the graph.
 include(":firebase-stubs")
+// Fork module: inert stand-ins for the io.github.coredevices.haversine Ring
+// satellite library (a prebuilt AAR with bundled native libraries and no
+// public source, incompatible with the F-Droid target). Wired below by
+// dependency substitution rather than by editing the consumer's dependency
+// line, because the only consumer, libindex/build.gradle.kts, is an upstream
+// file the fork otherwise leaves untouched.
+include(":haversine-stubs")
+
+// Every project resolves the substitution, not just :libindex: the artifact
+// is a transitive runtime dependency of everything that depends on libindex
+// (:pebble, :composeApp, :androidApp), and a substitution rule only applies
+// to the configurations of the project that declares it, so applying it in
+// libindex alone would keep the real AAR on the app's runtime classpath.
+// The coordinate is matched by group:name only, so an upstream version bump
+// in libs.versions.toml still lands on the stub.
+gradle.lifecycle.beforeProject {
+    configurations.configureEach {
+        resolutionStrategy.dependencySubstitution {
+            substitute(module("io.github.coredevices.haversine:haversine"))
+                .using(project(":haversine-stubs"))
+                .because("Gravel replaces the prebuilt Ring satellite AAR with :haversine-stubs")
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -55,10 +55,9 @@ include(":krisp-stubs")
 include(":firebase-stubs")
 // Fork module: inert stand-ins for the io.github.coredevices.haversine Ring
 // satellite library (a prebuilt AAR with bundled native libraries and no
-// public source, incompatible with the F-Droid target). Wired below by
-// dependency substitution rather than by editing the consumer's dependency
-// line, because the only consumer, libindex/build.gradle.kts, is an upstream
-// file the fork otherwise leaves untouched.
+// public source, incompatible with the F-Droid target). Wired by the
+// dependency substitution rule below; the seam is described in
+// DESIGN_NOTES.md (Ring / Index AI).
 include(":haversine-stubs")
 
 // Every project resolves the substitution, not just :libindex: the artifact

--- a/whisper-native/build.gradle.kts
+++ b/whisper-native/build.gradle.kts
@@ -15,13 +15,12 @@ android {
 
     // Pinned toolchain for the from-source engine build. Both values must
     // match what the F-Droid build recipe provisions (its ndk field and the
-    // cmake package it installs), because that buildserver has neither by
-    // default and a mismatch is a hard configuration failure there; a pin
-    // also keeps the compiled engine identical across machines. The NDK is
-    // the version AGP resolves on its own for this AGP line, so nothing
-    // changes for local builds; the CMake version is the SDK package that
-    // satisfies the floor the engine's CMakeLists requires
-    // (cmake_minimum_required 3.22).
+    // cmake package it installs; the recipe contract is in DESIGN_NOTES.md,
+    // F-Droid section), because that buildserver has neither by default and
+    // a mismatch is a hard configuration failure there; a pin also keeps
+    // the compiled engine identical across machines. The NDK is the version
+    // AGP resolves on its own for this AGP line, so nothing changes for
+    // local builds. The CMake pin sits with the CMake block below.
     ndkVersion = "28.2.13676358"
 
     defaultConfig {
@@ -38,6 +37,10 @@ android {
     externalNativeBuild {
         cmake {
             path = file("src/main/cpp/CMakeLists.txt")
+            // The SDK's cmake package that satisfies the floor the fork's own
+            // wrapper CMakeLists.txt above declares (cmake_minimum_required
+            // 3.22); the engine submodule itself only asks for 3.5. Pinned
+            // for the same reason as ndkVersion.
             version = "3.22.1"
         }
     }

--- a/whisper-native/build.gradle.kts
+++ b/whisper-native/build.gradle.kts
@@ -13,6 +13,17 @@ android {
     namespace = "coredevices.whisper.nativelib"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
+    // Pinned toolchain for the from-source engine build. Both values must
+    // match what the F-Droid build recipe provisions (its ndk field and the
+    // cmake package it installs), because that buildserver has neither by
+    // default and a mismatch is a hard configuration failure there; a pin
+    // also keeps the compiled engine identical across machines. The NDK is
+    // the version AGP resolves on its own for this AGP line, so nothing
+    // changes for local builds; the CMake version is the SDK package that
+    // satisfies the floor the engine's CMakeLists requires
+    // (cmake_minimum_required 3.22).
+    ndkVersion = "28.2.13676358"
+
     defaultConfig {
         minSdk = libs.versions.android.minSdk.get().toInt()
         ndk {
@@ -27,6 +38,7 @@ android {
     externalNativeBuild {
         cmake {
             path = file("src/main/cpp/CMakeLists.txt")
+            version = "3.22.1"
         }
     }
 


### PR DESCRIPTION
Removes the last tree-level blockers to F-Droid inclusion and adds the
guardrails that keep the tree inside F-Droid's envelope across upstream
syncs. After this branch, what remains for F-Droid is the submission
itself: the fdroiddata recipe, out of tree.

The Ring satellite library libindex compiles against
(io.github.coredevices.haversine, a prebuilt AAR with no public source
that ships two native libraries per ABI) is replaced by :haversine-stubs,
inert same-name stand-ins for the seven symbols libindex references. The
satellite classes have private constructors and no factory, so no ring
object can exist in the app; the wiring is a dependencySubstitution rule
in settings.gradle.kts applied to every project, so the artifact leaves
every runtime classpath while the upstream dependency line stays
untouched, and a version bump upstream still lands on the stub.
libpebble3's GitHub Packages publishing block is dropped, since F-Droid's
scanner rejects the maven host textually. The whisper engine build pins
its NDK (28.2.13676358) and CMake (3.22.1) to the values the F-Droid
recipe provisions. versionName is now git describe of the built commit,
so a tag build reports exactly the tag name. Release packages unsigned
when no keystore is present (the shape F-Droid builds), the
dependency-metadata signing block is disabled, and the two unreferenced
Wispr Flow logo assets are dropped at packaging.

FdroidGuardrailsTest replicates fdroidserver's source scanner over the
tracked tree, whisper.cpp submodule included, minus the paths the recipe
removes (recorded in the test as the tree's half of the recipe contract),
with a positive-control test for every check. It found and removed one
live hit, an iOS-only Crashlytics wrapper dependency line. A
packaging-time VerifyApkContents task inspects every built APK for
forbidden entries, signing-block shape, and the dependency-metadata pair,
and CI now builds the release variant unsigned and compares the built
versionName with the commit. DESIGN_NOTES gains an F-Droid section
recording what the tree guarantees and what the recipe must supply; the
fastlane listing is refreshed and the Inter typeface's OFL notice added.

On top of the compliance changes, the branch fixes what review of the
range surfaced:

- The scanner replica gained the checks it was missing (lockfile
  presence for dependency manifests, DexClassLoader in Java sources, the
  Debian maven-repo allowlist entry, dotfile sniffing as os.path.splitext
  sees it) and a version-catalog reader that fails on any line it cannot
  read instead of resolving a multi-line bundle to nothing.
- Sentinels close two gaps: no Kotlin source may reference the excluded
  drawables (their generated accessors still compile, so a returning
  reference would throw at runtime), and the stub's private-constructor
  contract is pinned by reflection.
- README, DESIGN_NOTES, KNOWN_ISSUES and several comments are corrected
  where they overstated: the app still ships native code from free Maven
  artifacts (Speex, bundled SQLite), the language-pack catalog's mutable
  references are two branches and eight release assets rather than ten
  branches, and libindex's build file is not untouched by the fork.

Verification record:

- CI (assembleDebug, assembleRelease, all host suites, lint) green on the
  tip; 1656 host test cases across the modules, zero failures; every
  guardrail and sentinel shown to fail on a probe.
- Release APK: no com.wtlp or coredevices.haversine classes, no
  haversine or ppcommon native libraries, no Wispr assets, no
  dependency-metadata block; a keystore-less release build produces
  androidApp-release-unsigned.apk.
- On-device (a Pixel running GrapheneOS): fresh install and onboarding,
  About showing the git-describe version, the model catalog, watch
  pairing, and dictation end to end on the tip build.
- A pre-merge review of the full range with adversarially verified
  findings; every confirmed finding is fixed on this branch.
