### PR TITLE
Build with the buildserver's JDK and give F-Droid's update checker a version file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,24 @@ jobs:
           echo "expected versionName: $expected"
           echo "built:                $badging"
           test "$expected" = "$actual"
+      # androidApp/version.properties is what F-Droid's update checker reads as
+      # the versionCode of a tag. On a tag build the file, the commit count the
+      # build derives versionCode from, and the versionCode in the built APK
+      # must all agree; the Gradle-time VerifyReleaseVersionFile task and
+      # FdroidGuardrailsTest check the same thing from inside the build, this
+      # step checks it from outside against the artifact.
+      - name: Check the version file against the tag
+        if: github.ref_type == 'tag'
+        run: |
+          count="$(git rev-list --count HEAD)"
+          declared="$(sed -n 's/^versionCode=\([0-9][0-9]*\)$/\1/p' androidApp/version.properties)"
+          aapt2="$(ls -d "$ANDROID_HOME"/build-tools/*/aapt2 | sort -V | tail -n 1)"
+          badging="$("$aapt2" dump badging androidApp/build/outputs/apk/release/androidApp-release-unsigned.apk | head -n 1)"
+          built="$(printf '%s' "$badging" | sed -n "s/.*versionCode='\([^']*\)'.*/\1/p")"
+          echo "commit count: $count"
+          echo "version file: $declared"
+          echo "built APK:    $built"
+          test -n "$declared" && test "$count" = "$declared" && test "$count" = "$built"
       # The built manifest is what store scanners read. The source-level pin
       # is NetworkSecurityConfigTest; this catches a library manifest merging
       # usesCleartextTraffic back into the APK, which the source test cannot see.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,15 @@ jobs:
   android:
     runs-on: ubuntu-latest
     steps:
+      # 21 is the JDK on F-Droid's buildserver, which is why the tree carries no
+      # jvmToolchain pin (see DESIGN_NOTES.md, F-Droid); the bytecode target
+      # stays 17 and any JDK 17+ builds the tree, so CI exercises the one JDK
+      # nobody builds with by hand.
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 21
       - name: Checkout source
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,16 +5,22 @@ on: [push]
 jobs:
   android:
     runs-on: ubuntu-latest
+    # The tree carries no jvmToolchain pin (see DESIGN_NOTES.md, F-Droid), so
+    # the JDK that launches Gradle is the one that compiles. 21 is F-Droid's
+    # buildserver JDK; 17 is the documented floor ("any JDK 17 or newer") and
+    # the bytecode target. Building on both keeps the floor a tested claim: a
+    # dependency or catalog bump that quietly needs 21 fails the 17 leg
+    # instead of only failing whoever still builds on 17 by hand.
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version: [17, 21]
     steps:
-      # 21 is the JDK on F-Droid's buildserver, which is why the tree carries no
-      # jvmToolchain pin (see DESIGN_NOTES.md, F-Droid); the bytecode target
-      # stays 17 and any JDK 17+ builds the tree, so CI exercises the one JDK
-      # nobody builds with by hand.
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 21
+          java-version: ${{ matrix.java-version }}
       - name: Checkout source
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,13 @@ name: Build
 
 on: [push]
 
+# The job only builds and asserts; nothing here writes to the repository, so
+# the workflow token gets read access and no more. actions/checkout persists
+# the token in the checkout by default, which is why the scope matters even
+# though no step names it.
+permissions:
+  contents: read
+
 jobs:
   android:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,9 +59,14 @@ Firebase stubs, the unplugged Ring module) lives in `DESIGN_NOTES.md`.
   `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`) sets it
   to the commit count that commit will have, which is `git rev-list --count
   HEAD` plus one when committing on top of HEAD; between releases the file
-  names the last release. A tag build with a stale file fails three ways:
-  Gradle's `preBuild` (`VerifyReleaseVersionFile`), `FdroidGuardrailsTest`,
-  and the tag-build step in CI.
+  names the last release. The value checks fire only on a tag checkout,
+  so after tagging and before pushing the tag run `./gradlew
+  :androidApp:verifyReleaseVersionFile` (or the guardrail suite) on the
+  tagged commit; otherwise a stale file is first rejected once the tag is
+  public, by Gradle's `preBuild` (`VerifyReleaseVersionFile`),
+  `FdroidGuardrailsTest`, and the tag-build step in CI alike. The test
+  also requires `changelogs/<versionCode>.txt` to exist for the value the
+  file names, on every commit.
 - **Distinct branding: the fork is Gravel.** applicationId is
   `com.anopticlabs.gravel`; the Kotlin `namespace` and source packages
   deliberately stay `coredevices.coreapp` so upstream merges stay cheap;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,16 @@ Firebase stubs, the unplugged Ring module) lives in `DESIGN_NOTES.md`.
   / `compileOptions`, 17). `FdroidGuardrailsTest` fails on any
   `jvmToolchain(` call, which is what an upstream sync would bring back.
   CI builds on 21; this supersedes upstream's "JDK 17 required" below.
+- **A release commit bumps `androidApp/version.properties`.** F-Droid's
+  update checker reads a tag's versionCode from that one-line file because
+  it cannot count commits the way the build does. The commit that gets
+  tagged (the same one that adds
+  `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`) sets it
+  to the commit count that commit will have, which is `git rev-list --count
+  HEAD` plus one when committing on top of HEAD; between releases the file
+  names the last release. A tag build with a stale file fails three ways:
+  Gradle's `preBuild` (`VerifyReleaseVersionFile`), `FdroidGuardrailsTest`,
+  and the tag-build step in CI.
 - **Distinct branding: the fork is Gravel.** applicationId is
   `com.anopticlabs.gravel`; the Kotlin `namespace` and source packages
   deliberately stay `coredevices.coreapp` so upstream merges stay cheap;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,14 @@ Firebase stubs, the unplugged Ring module) lives in `DESIGN_NOTES.md`.
 - **Any JDK 17 or newer builds the tree; there is no toolchain pin.**
   F-Droid's buildserver ships a single JDK (21) with Gradle toolchain
   provisioning switched off, so upstream's `jvmToolchain(17)` calls are
-  removed and each module sets its bytecode target explicitly (`jvmTarget`
-  / `compileOptions`, 17). `FdroidGuardrailsTest` fails on any
-  `jvmToolchain(` call, which is what an upstream sync would bring back.
-  CI builds on 21; this supersedes upstream's "JDK 17 required" below.
+  removed and every JVM-flavoured target (android and `jvm()` alike) sets
+  its bytecode target explicitly (`jvmTarget` / `compileOptions`, 17); a
+  target without one follows the JDK running Gradle and emits different
+  class files on 21 than on 17. `FdroidGuardrailsTest` fails on any
+  toolchain pin (`jvmToolchain(` or `jvmToolchain {`, or a Java
+  `toolchain {` block), which is what an upstream sync would bring back.
+  CI builds on both 17 and 21; this supersedes upstream's "JDK 17
+  required" below.
 - **A release commit bumps `androidApp/version.properties`.** F-Droid's
   update checker reads a tag's versionCode from that one-line file because
   it cannot count commits the way the build does. The commit that gets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,13 @@ Firebase stubs, the unplugged Ring module) lives in `DESIGN_NOTES.md`.
   below still naming `androidUnitTest` / `androidInstrumentedTest`
   predates its own AGP 9 migration. Do not add tests under the old names:
   the new plugins silently ignore those directories.
+- **Any JDK 17 or newer builds the tree; there is no toolchain pin.**
+  F-Droid's buildserver ships a single JDK (21) with Gradle toolchain
+  provisioning switched off, so upstream's `jvmToolchain(17)` calls are
+  removed and each module sets its bytecode target explicitly (`jvmTarget`
+  / `compileOptions`, 17). `FdroidGuardrailsTest` fails on any
+  `jvmToolchain(` call, which is what an upstream sync would bring back.
+  CI builds on 21; this supersedes upstream's "JDK 17 required" below.
 - **Distinct branding: the fork is Gravel.** applicationId is
   `com.anopticlabs.gravel`; the Kotlin `namespace` and source packages
   deliberately stay `coredevices.coreapp` so upstream merges stay cheap;

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -305,10 +305,14 @@ What the tree guarantees, and how it is pinned:
 - No module pins a Gradle JVM toolchain. The buildserver ships a single JDK
   (21) with toolchain provisioning disabled, so upstream's `jvmToolchain(17)`
   calls in `libpebble3`, `blobannotations`, and `blobdbgen` are removed and
-  every JVM-flavoured target sets `jvmTarget` (and Java compatibility) to 17
-  explicitly; the bytecode is unchanged and any JDK 17+ builds the tree.
-  `FdroidGuardrailsTest` fails on a `jvmToolchain(` call anywhere in the
-  tracked gradle files, and CI builds on JDK 21.
+  every JVM-flavoured target, android and `jvm()` alike, sets `jvmTarget`
+  to 17 explicitly (`blobdbgen`, the one plain-JVM module, also sets Java
+  source and target compatibility); a target without an explicit
+  `jvmTarget` follows the JDK running Gradle, so this is what keeps the
+  class files identical on any JDK 17+. `FdroidGuardrailsTest` fails on a
+  toolchain pin in any spelling (`jvmToolchain(`, `jvmToolchain {`, or the
+  Java plugin's `toolchain {` block) anywhere in the tracked gradle files,
+  and CI builds on JDK 17 and 21.
 - A checkout without `keystore.jks` packages release unsigned, and the
   APK carries no dependency-metadata signing block; both are checked by
   the packaging-time `VerifyApkContents` task in

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -293,6 +293,15 @@ What the tree guarantees, and how it is pinned:
   count, both functions of the built commit (`androidApp/build.gradle.kts`),
   so a tag checkout reports exactly the tag name and the values the recipe
   declares for that tag can be checked against the built APK.
+- `androidApp/version.properties` holds one line, `versionCode=<digits>`,
+  the versionCode of the most recent tagged release. It exists for
+  F-Droid's update checker, which reads it from a tag checkout (it cannot
+  count commits) and takes the tag name as versionName. The release commit
+  bumps it to the count that commit will have once tagged; on a tag
+  checkout the Gradle-time `VerifyReleaseVersionFile` task (wired before
+  `preBuild`, so it runs on every build everywhere), the
+  `FdroidGuardrailsTest` copy of the check, and a tag-only CI step all
+  fail if the file, the commit count, and the built APK disagree.
 - No module pins a Gradle JVM toolchain. The buildserver ships a single JDK
   (21) with toolchain provisioning disabled, so upstream's `jvmToolchain(17)`
   calls in `libpebble3`, `blobannotations`, and `blobdbgen` are removed and
@@ -323,9 +332,14 @@ What the recipe has to supply (field names as in the fdroiddata format):
   SDK package `cmake;3.22.1`, matching the pins above; the buildserver
   provisions neither by default and a mismatch fails configuration.
 - No JDK step: the buildserver's own JDK builds the tree (see above).
-- A build against a tag checkout (`commit:` the tag) with the tag's literal
-  `versionName` and `versionCode`; the F-Droid build fails if the built
-  values differ from the declared ones.
+- Per release, a build entry with the tag's literal `versionName` and
+  `versionCode` and `commit:` the full hash of the tagged commit; the
+  F-Droid build fails if the built values differ from the declared ones.
+- Update checking: `UpdateCheckMode: Tags` with `UpdateCheckData` naming
+  `androidApp/version.properties` and the regex `versionCode=(\d+)` for
+  the versionCode, and no file or regex for the versionName so the tag name
+  is used; `AutoUpdateMode: Version` then adds the build entry for a new tag
+  (with the commit resolved to its hash) without a manual recipe change.
 - The build subdirectory is `androidApp`; the unsigned release APK is the
   output F-Droid signs.
 - Anti-features: the on-device dictation models are runtime downloads from

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -297,11 +297,15 @@ What the tree guarantees, and how it is pinned:
   the versionCode of the most recent tagged release. It exists for
   F-Droid's update checker, which reads it from a tag checkout (it cannot
   count commits) and takes the tag name as versionName. The release commit
-  bumps it to the count that commit will have once tagged; on a tag
-  checkout the Gradle-time `VerifyReleaseVersionFile` task (wired before
-  `preBuild`, so it runs on every build everywhere), the
-  `FdroidGuardrailsTest` copy of the check, and a tag-only CI step all
-  fail if the file, the commit count, and the built APK disagree.
+  bumps it to the count that commit will have once tagged. Three checks
+  guard it: the Gradle-time `VerifyReleaseVersionFile` task (wired before
+  `preBuild`, so it runs on every build everywhere) checks the shape on
+  every build and, on a tag checkout, that the value equals the commit
+  count the build stamps into the APK; `FdroidGuardrailsTest` repeats both
+  and also requires a `changelogs/<value>.txt` for the value the file
+  names; a tag-only CI step compares the file, the commit count, and the
+  versionCode read back from the built APK. All three read the file as
+  exactly one LF-terminated `versionCode=<digits>` line.
 - No module pins a Gradle JVM toolchain. The buildserver ships a single JDK
   (21) with toolchain provisioning disabled, so upstream's `jvmToolchain(17)`
   calls in `libpebble3`, `blobannotations`, and `blobdbgen` are removed and
@@ -343,7 +347,11 @@ What the recipe has to supply (field names as in the fdroiddata format):
   `androidApp/version.properties` and the regex `versionCode=(\d+)` for
   the versionCode, and no file or regex for the versionName so the tag name
   is used; `AutoUpdateMode: Version` then adds the build entry for a new tag
-  (with the commit resolved to its hash) without a manual recipe change.
+  without a manual recipe change (current fdroidserver resolves the entry's
+  `commit:` to the tag's hash). The checker inspects only the newest few
+  tags and errors if none of them carries the file, so the recipe can
+  only enable update checking once a tag containing
+  `androidApp/version.properties` exists.
 - The build subdirectory is `androidApp`; the unsigned release APK is the
   output F-Droid signs.
 - Anti-features: the on-device dictation models are runtime downloads from

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -293,6 +293,13 @@ What the tree guarantees, and how it is pinned:
   count, both functions of the built commit (`androidApp/build.gradle.kts`),
   so a tag checkout reports exactly the tag name and the values the recipe
   declares for that tag can be checked against the built APK.
+- No module pins a Gradle JVM toolchain. The buildserver ships a single JDK
+  (21) with toolchain provisioning disabled, so upstream's `jvmToolchain(17)`
+  calls in `libpebble3`, `blobannotations`, and `blobdbgen` are removed and
+  every JVM-flavoured target sets `jvmTarget` (and Java compatibility) to 17
+  explicitly; the bytecode is unchanged and any JDK 17+ builds the tree.
+  `FdroidGuardrailsTest` fails on a `jvmToolchain(` call anywhere in the
+  tracked gradle files, and CI builds on JDK 21.
 - A checkout without `keystore.jks` packages release unsigned, and the
   APK carries no dependency-metadata signing block; both are checked by
   the packaging-time `VerifyApkContents` task in
@@ -315,10 +322,7 @@ What the recipe has to supply (field names as in the fdroiddata format):
 - `ndk:` r28c (28.2.13676358) and a `prebuild`/`sudo` step that installs the
   SDK package `cmake;3.22.1`, matching the pins above; the buildserver
   provisions neither by default and a mismatch fails configuration.
-- JDK 17: `libpebble3`, `blobannotations`, and `blobdbgen` pin
-  `jvmToolchain(17)` and Gradle toolchain auto-download is off on the
-  buildserver, which ships a newer JDK, so the recipe installs
-  `openjdk-17-jdk-headless` (`sudo:`).
+- No JDK step: the buildserver's own JDK builds the tree (see above).
 - A build against a tag checkout (`commit:` the tag) with the tag's literal
   `versionName` and `versionCode`; the F-Droid build fails if the built
   values differ from the declared ones.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ De-google work is completed, all telemetry is removed. What remains is polish an
 - Clone with `--recursive` (or run `git submodule update --init`): the
   whisper.cpp speech engine is a pinned git submodule, compiled from
   source by the Android build.
-- JDK 17; Gradle wrapper included. Debug build:
+- Any JDK 17 or newer; Gradle wrapper included. Debug build:
   `./gradlew :androidApp:assembleDebug`
 - No `google-services.json` is needed: the google-services plugin is gone
   along with the Firebase SDKs.

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -386,7 +386,16 @@ abstract class VerifyApkContents : DefaultTask() {
 val gitTagsAtHead = providers.exec {
     isIgnoreExitValue = true
     commandLine("git", "tag", "--points-at", "HEAD")
-}.standardOutput.asText.map { it.trim() }
+}.let { exec ->
+    // Fail closed: an empty answer means "not a tag checkout" and skips the
+    // value check, so a git failure must not be mistaken for one.
+    exec.result.zip(exec.standardOutput.asText) { result, output ->
+        if (result.exitValue != 0) {
+            throw GradleException("git tag --points-at HEAD failed (exit ${result.exitValue}); cannot tell whether this is a tag checkout")
+        }
+        output.trim()
+    }
+}
 
 abstract class VerifyReleaseVersionFile : DefaultTask() {
 
@@ -405,7 +414,9 @@ abstract class VerifyReleaseVersionFile : DefaultTask() {
     fun verify() {
         val file = versionFile.get().asFile
         val text = file.readText()
-        val declared = Regex("""versionCode=(\d+)\r?\n?""").matchEntire(text)?.groupValues?.get(1)?.toIntOrNull()
+        // Same regex as FdroidGuardrailsTest.declaredVersionCode; LF only, so
+        // the three layers (this task, the test, the CI sed) agree on shape.
+        val declared = Regex("""versionCode=(\d+)\n?""").matchEntire(text)?.groupValues?.get(1)?.toIntOrNull()
             ?: throw GradleException("$file must be exactly one line, versionCode=<digits>, but reads:\n$text")
         val tags = tagsAtHead.get().lines().filter { it.isNotBlank() }
         if (tags.isEmpty()) return

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -374,6 +374,64 @@ abstract class VerifyApkContents : DefaultTask() {
     }
 }
 
+// Fork: F-Droid's update checker reads the versionCode of a tagged release from
+// androidApp/version.properties (the recipe's UpdateCheckData names that file);
+// it cannot count commits the way the build does. The file is bumped in the
+// commit that gets tagged, so on a tag checkout it must equal the count the
+// build itself uses, and anywhere else it names the last tagged release and only
+// its shape is checked. The task runs before every build (preBuild), so a tag
+// build with a stale file fails locally, in CI, and on the buildserver alike;
+// the unit-test copy of the check is FdroidGuardrailsTest, and F-Droid compares
+// the built APK against the recipe as a third, independent layer.
+val gitTagsAtHead = providers.exec {
+    isIgnoreExitValue = true
+    commandLine("git", "tag", "--points-at", "HEAD")
+}.standardOutput.asText.map { it.trim() }
+
+abstract class VerifyReleaseVersionFile : DefaultTask() {
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val versionFile: RegularFileProperty
+
+    /** Tags pointing at the built commit, one per line; empty on an untagged commit. */
+    @get:Input
+    abstract val tagsAtHead: Property<String>
+
+    @get:Input
+    abstract val builtVersionCode: Property<Int>
+
+    @TaskAction
+    fun verify() {
+        val file = versionFile.get().asFile
+        val text = file.readText()
+        val declared = Regex("""versionCode=(\d+)\r?\n?""").matchEntire(text)?.groupValues?.get(1)?.toIntOrNull()
+            ?: throw GradleException("$file must be exactly one line, versionCode=<digits>, but reads:\n$text")
+        val tags = tagsAtHead.get().lines().filter { it.isNotBlank() }
+        if (tags.isEmpty()) return
+        val built = builtVersionCode.get()
+        if (declared != built) {
+            throw GradleException(
+                "Tag ${tags.joinToString()} builds versionCode $built but $file declares $declared; " +
+                    "the release commit must set the file to the commit count it will have once committed.",
+            )
+        }
+    }
+}
+
+val verifyReleaseVersionFile = tasks.register<VerifyReleaseVersionFile>("verifyReleaseVersionFile") {
+    group = "verification"
+    description = "Fails a tag build whose version.properties disagrees with the built versionCode."
+    versionFile.set(layout.projectDirectory.file("version.properties"))
+    tagsAtHead.set(gitTagsAtHead)
+    builtVersionCode.set(gitVersionCode)
+}
+
+// preBuild is created by AGP after this script runs, hence configureEach.
+tasks.configureEach {
+    if (name == "preBuild") dependsOn(verifyReleaseVersionFile)
+}
+
 // Fork: FdroidGuardrailsTest and ExcludedAssetSentinelTest read the git-tracked
 // tree (build files, tracked binaries, sources) through git rather than
 // through declared task inputs, so Gradle cannot tell when their verdict is

--- a/androidApp/src/test/kotlin/coredevices/coreapp/FdroidGuardrailsTest.kt
+++ b/androidApp/src/test/kotlin/coredevices/coreapp/FdroidGuardrailsTest.kt
@@ -36,6 +36,10 @@ import kotlin.test.assertTrue
  * build recipe removes before its scan, listed in [recipeRemovedPaths]. That
  * list is the tree's half of a contract with the out-of-tree recipe, and
  * DESIGN_NOTES.md (F-Droid section) records the whole contract.
+ *
+ * The last test is not a scanner check but another part of that contract
+ * the tree can verify about itself: the build runs on the buildserver's JDK
+ * (no toolchain pin, [noGradleFileConfiguresAJvmToolchain]).
  */
 class FdroidGuardrailsTest {
 
@@ -179,5 +183,49 @@ class FdroidGuardrailsTest {
             problems.isEmpty(),
             "F-Droid's scanner fails on Java sources that load code at runtime:\n" + problems.joinToString("\n"),
         )
+    }
+
+    /**
+     * The buildserver ships one JDK (21 today) with Gradle toolchain
+     * provisioning disabled, so a `jvmToolchain(17)` call, which upstream had
+     * in three modules and an upstream sync would bring back, fails the
+     * F-Droid build outright. The bytecode target is set per module with
+     * `jvmTarget`/`compileOptions` instead, which any JDK 17+ honours.
+     */
+    @Test
+    fun noGradleFileConfiguresAJvmToolchain() {
+        val problems = scannedGradleFiles().flatMap { path ->
+            jvmToolchainCalls(read(path).readLines()).map { "$path: $it" }
+        }
+        assertTrue(
+            problems.isEmpty(),
+            "F-Droid's buildserver has no JDK to satisfy a toolchain pin; set jvmTarget instead:\n" + problems.joinToString("\n"),
+        )
+    }
+
+    /** Positive control for [noGradleFileConfiguresAJvmToolchain]: the matcher fires on the call shapes upstream uses and ignores comments. */
+    @Test
+    fun jvmToolchainMatcherFiresOnAPin() {
+        val sample = listOf(
+            "kotlin {",
+            "    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())",
+            "    // jvmToolchain(17) would fail on the buildserver",
+            "    jvmToolchain (17)",
+            "    jvmToolchainless()",
+            "}",
+        )
+        assertTrue(
+            jvmToolchainCalls(sample) == listOf("2: jvmToolchain(libs.versions.jvm.toolchain.get().toInt())", "4: jvmToolchain (17)"),
+            "matcher returned ${jvmToolchainCalls(sample)}",
+        )
+    }
+
+    /** `<line number>: <line>` for every non-comment line calling `jvmToolchain(`. */
+    private fun jvmToolchainCalls(lines: List<String>): List<String> {
+        val call = Regex("""\bjvmToolchain\s*\(""")
+        return lines.withIndex()
+            .filterNot { (_, line) -> line.trimStart().startsWith("//") }
+            .filter { (_, line) -> call.containsMatchIn(line) }
+            .map { (index, line) -> "${index + 1}: ${line.trim()}" }
     }
 }

--- a/androidApp/src/test/kotlin/coredevices/coreapp/FdroidGuardrailsTest.kt
+++ b/androidApp/src/test/kotlin/coredevices/coreapp/FdroidGuardrailsTest.kt
@@ -37,9 +37,12 @@ import kotlin.test.assertTrue
  * list is the tree's half of a contract with the out-of-tree recipe, and
  * DESIGN_NOTES.md (F-Droid section) records the whole contract.
  *
- * The last test is not a scanner check but another part of that contract
- * the tree can verify about itself: the build runs on the buildserver's JDK
- * (no toolchain pin, [noGradleFileConfiguresAJvmToolchain]).
+ * The last two tests are not scanner checks but the other two halves of that
+ * contract the tree can verify about itself: the build runs on the
+ * buildserver's JDK (no toolchain pin, [noGradleFileConfiguresAJvmToolchain])
+ * and the version file F-Droid's update checker reads has the shape its
+ * regex expects and, on a tag checkout, the value the build produces
+ * ([versionFileMatchesTheBuiltCommitOnATagCheckout]).
  */
 class FdroidGuardrailsTest {
 
@@ -227,5 +230,29 @@ class FdroidGuardrailsTest {
             .filterNot { (_, line) -> line.trimStart().startsWith("//") }
             .filter { (_, line) -> call.containsMatchIn(line) }
             .map { (index, line) -> "${index + 1}: ${line.trim()}" }
+    }
+
+    /**
+     * `androidApp/version.properties` is what the recipe's UpdateCheckData
+     * regex reads as the versionCode of a tag, so it is held to exactly one
+     * `versionCode=<digits>` line: no comment, no second key, nothing the
+     * regex could match first. On a tag checkout the value must be the commit
+     * count the build derives versionCode from; between releases the file
+     * names the last tagged release and only its shape is checked. The
+     * Gradle-time VerifyReleaseVersionFile task makes the same check before
+     * every build; this is the test-suite copy of it.
+     */
+    @Test
+    fun versionFileMatchesTheBuiltCommitOnATagCheckout() {
+        val text = read("androidApp/version.properties").readText()
+        val declared = Regex("""versionCode=(\d+)\r?\n?""").matchEntire(text)?.groupValues?.get(1)?.toIntOrNull()
+        assertTrue(declared != null, "androidApp/version.properties must be exactly one line, versionCode=<digits>, but reads:\n$text")
+        val tags = TrackedTree.git("tag", "--points-at", "HEAD").lines().filter { it.isNotBlank() }
+        if (tags.isEmpty()) return
+        val count = TrackedTree.git("rev-list", "--count", "HEAD").trim().toInt()
+        assertTrue(
+            declared == count,
+            "Tag ${tags.joinToString()} builds versionCode $count but androidApp/version.properties declares $declared",
+        )
     }
 }

--- a/androidApp/src/test/kotlin/coredevices/coreapp/FdroidGuardrailsTest.kt
+++ b/androidApp/src/test/kotlin/coredevices/coreapp/FdroidGuardrailsTest.kt
@@ -263,17 +263,25 @@ class FdroidGuardrailsTest {
      * `androidApp/version.properties` is what the recipe's UpdateCheckData
      * regex reads as the versionCode of a tag, so it is held to exactly one
      * `versionCode=<digits>` line: no comment, no second key, nothing the
-     * regex could match first. On a tag checkout the value must be the commit
-     * count the build derives versionCode from; between releases the file
-     * names the last tagged release and only its shape is checked. The
-     * Gradle-time VerifyReleaseVersionFile task makes the same check before
-     * every build; this is the test-suite copy of it.
+     * regex could match first. The value must name a release that has a
+     * changelog (`fastlane/metadata/android/en-US/changelogs/<value>.txt`,
+     * added by the same release commit), and on a tag checkout it must be
+     * the commit count the build derives versionCode from; between releases
+     * the file names the last tagged release. The Gradle-time
+     * VerifyReleaseVersionFile task makes the shape and tag checks before
+     * every build; this is the test-suite copy of it plus the changelog
+     * pairing.
      */
     @Test
     fun versionFileMatchesTheBuiltCommitOnATagCheckout() {
         val text = read("androidApp/version.properties").readText()
-        val declared = Regex("""versionCode=(\d+)\r?\n?""").matchEntire(text)?.groupValues?.get(1)?.toIntOrNull()
+        val declared = declaredVersionCode(text)
         assertTrue(declared != null, "androidApp/version.properties must be exactly one line, versionCode=<digits>, but reads:\n$text")
+        val changelog = "fastlane/metadata/android/en-US/changelogs/$declared.txt"
+        assertTrue(
+            read(changelog).exists(),
+            "androidApp/version.properties declares $declared but there is no $changelog; the release commit adds both",
+        )
         val tags = TrackedTree.git("tag", "--points-at", "HEAD").lines().filter { it.isNotBlank() }
         if (tags.isEmpty()) return
         val count = TrackedTree.git("rev-list", "--count", "HEAD").trim().toInt()
@@ -282,4 +290,44 @@ class FdroidGuardrailsTest {
             "Tag ${tags.joinToString()} builds versionCode $count but androidApp/version.properties declares $declared",
         )
     }
+
+    /**
+     * Positive control for [versionFileMatchesTheBuiltCommitOnATagCheckout]:
+     * the shape check accepts exactly one LF-terminated (or unterminated)
+     * `versionCode=<digits>` line and rejects a comment line, a second key,
+     * a blank line, leading space, CRLF, and a non-numeric value. CRLF is
+     * rejected on purpose so the check agrees with the per-line sed in the
+     * CI tag step, which anchors on `$` before the newline.
+     */
+    @Test
+    fun versionFileShapeCheckAcceptsOnlyOneLine() {
+        val accepted = mapOf("versionCode=2238\n" to 2238, "versionCode=2238" to 2238)
+        val rejected = listOf(
+            "versionCode=2238\r\n",
+            "# the last release\nversionCode=2238\n",
+            "versionCode=2238\nversionName=0.1.2\n",
+            "versionCode=2238\n\n",
+            " versionCode=2238\n",
+            "versionCode=\n",
+            "versionCode=abc\n",
+            "",
+        )
+        for ((text, expected) in accepted) {
+            assertTrue(declaredVersionCode(text) == expected, "shape check rejected ${text.escaped()}")
+        }
+        for (text in rejected) {
+            assertTrue(declaredVersionCode(text) == null, "shape check accepted ${text.escaped()}")
+        }
+    }
+
+    /**
+     * The versionCode a version file declares, or null when the file is not
+     * exactly one `versionCode=<digits>` line. Mirrored by hand in the
+     * VerifyReleaseVersionFile task in androidApp/build.gradle.kts, which
+     * cannot share test code; keep the two regexes identical.
+     */
+    private fun declaredVersionCode(text: String): Int? =
+        Regex("""versionCode=(\d+)\n?""").matchEntire(text)?.groupValues?.get(1)?.toIntOrNull()
+
+    private fun String.escaped(): String = "\"" + replace("\r", "\\r").replace("\n", "\\n") + "\""
 }

--- a/androidApp/src/test/kotlin/coredevices/coreapp/FdroidGuardrailsTest.kt
+++ b/androidApp/src/test/kotlin/coredevices/coreapp/FdroidGuardrailsTest.kt
@@ -37,11 +37,12 @@ import kotlin.test.assertTrue
  * list is the tree's half of a contract with the out-of-tree recipe, and
  * DESIGN_NOTES.md (F-Droid section) records the whole contract.
  *
- * The last two tests are not scanner checks but the other two halves of that
- * contract the tree can verify about itself: the build runs on the
- * buildserver's JDK (no toolchain pin, [noGradleFileConfiguresAJvmToolchain])
- * and the version file F-Droid's update checker reads has the shape its
- * regex expects and, on a tag checkout, the value the build produces
+ * The tests after the scanner checks are the other two halves of that
+ * contract the tree can verify about itself, each with a positive control
+ * proving its matcher fires: the build runs on the buildserver's JDK (no
+ * toolchain pin, [noGradleFileConfiguresAJvmToolchain]) and the version file
+ * F-Droid's update checker reads has the shape its regex expects and, on a
+ * tag checkout, the value the build produces
  * ([versionFileMatchesTheBuiltCommitOnATagCheckout]).
  */
 class FdroidGuardrailsTest {
@@ -190,15 +191,18 @@ class FdroidGuardrailsTest {
 
     /**
      * The buildserver ships one JDK (21 today) with Gradle toolchain
-     * provisioning disabled, so a `jvmToolchain(17)` call, which upstream had
-     * in three modules and an upstream sync would bring back, fails the
-     * F-Droid build outright. The bytecode target is set per module with
-     * `jvmTarget`/`compileOptions` instead, which any JDK 17+ honours.
+     * provisioning disabled, so any toolchain pin fails the F-Droid build
+     * outright: the `jvmToolchain(17)` call upstream had in three modules and
+     * an upstream sync would bring back, its lambda form
+     * `jvmToolchain { languageVersion.set(...) }`, and the Java plugin's
+     * `java { toolchain { ... } }` block all request the same provisioned JDK.
+     * The bytecode target is set per module with `jvmTarget`/`compileOptions`
+     * instead, which any JDK 17+ honours.
      */
     @Test
     fun noGradleFileConfiguresAJvmToolchain() {
         val problems = scannedGradleFiles().flatMap { path ->
-            jvmToolchainCalls(read(path).readLines()).map { "$path: $it" }
+            toolchainPins(read(path).readLines()).map { "$path: $it" }
         }
         assertTrue(
             problems.isEmpty(),
@@ -206,29 +210,52 @@ class FdroidGuardrailsTest {
         )
     }
 
-    /** Positive control for [noGradleFileConfiguresAJvmToolchain]: the matcher fires on the call shapes upstream uses and ignores comments. */
+    /**
+     * Positive control for [noGradleFileConfiguresAJvmToolchain]: the matcher
+     * fires on every pin spelling (call, lambda, Java toolchain block, and the
+     * property form of the latter) and ignores comments, near-miss identifiers,
+     * and the `libs.versions.jvm.toolchain` catalog accessor that feeds
+     * `jvmTarget`.
+     */
     @Test
-    fun jvmToolchainMatcherFiresOnAPin() {
+    fun toolchainMatcherFiresOnAPin() {
         val sample = listOf(
             "kotlin {",
             "    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())",
             "    // jvmToolchain(17) would fail on the buildserver",
             "    jvmToolchain (17)",
             "    jvmToolchainless()",
+            "    jvmToolchain {",
+            "    jvmTarget.set(JvmTarget.valueOf(\"JVM_${'$'}{libs.versions.jvm.toolchain.get()}\"))",
+            "}",
+            "java {",
+            "    toolchain {",
+            "    toolchain.languageVersion.set(JavaLanguageVersion.of(17))",
+            "    // toolchain { languageVersion = JavaLanguageVersion.of(17) }",
             "}",
         )
-        assertTrue(
-            jvmToolchainCalls(sample) == listOf("2: jvmToolchain(libs.versions.jvm.toolchain.get().toInt())", "4: jvmToolchain (17)"),
-            "matcher returned ${jvmToolchainCalls(sample)}",
+        val expected = listOf(
+            "2: jvmToolchain(libs.versions.jvm.toolchain.get().toInt())",
+            "4: jvmToolchain (17)",
+            "6: jvmToolchain {",
+            "10: toolchain {",
+            "11: toolchain.languageVersion.set(JavaLanguageVersion.of(17))",
         )
+        assertTrue(toolchainPins(sample) == expected, "matcher returned ${toolchainPins(sample)}")
     }
 
-    /** `<line number>: <line>` for every non-comment line calling `jvmToolchain(`. */
-    private fun jvmToolchainCalls(lines: List<String>): List<String> {
-        val call = Regex("""\bjvmToolchain\s*\(""")
+    /**
+     * `<line number>: <line>` for every non-comment line that pins a JVM
+     * toolchain: `jvmToolchain(` or `jvmToolchain {` (Kotlin plugin), and
+     * `toolchain {` or `toolchain.languageVersion` (Java plugin extension).
+     * The catalog accessor `libs.versions.jvm.toolchain.get()` is `toolchain.`
+     * followed by `get`, so it does not match.
+     */
+    private fun toolchainPins(lines: List<String>): List<String> {
+        val pin = Regex("""\bjvmToolchain\s*[({]|\btoolchain\s*(?:\{|\.languageVersion)""")
         return lines.withIndex()
             .filterNot { (_, line) -> line.trimStart().startsWith("//") }
-            .filter { (_, line) -> call.containsMatchIn(line) }
+            .filter { (_, line) -> pin.containsMatchIn(line) }
             .map { (index, line) -> "${index + 1}: ${line.trim()}" }
     }
 

--- a/androidApp/version.properties
+++ b/androidApp/version.properties
@@ -1,0 +1,1 @@
+versionCode=2238

--- a/blobannotations/build.gradle.kts
+++ b/blobannotations/build.gradle.kts
@@ -6,8 +6,10 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
-
+    // Fork: no jvmToolchain pin. F-Droid's buildserver ships a single JDK (21)
+    // with Gradle toolchain provisioning disabled, so the build has to run on
+    // whichever JDK 17+ launches Gradle. The bytecode target stays 17 through
+    // the explicit jvmTarget on each JVM-flavoured target below.
     android {
         namespace = "coredevices.blobannotations"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
@@ -18,7 +20,11 @@ kotlin {
         }
     }
 
-    jvm()
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.valueOf("JVM_${libs.versions.jvm.toolchain.get()}"))
+        }
+    }
 
     val xcfName = "libpebble-annotations"
 

--- a/blobdbgen/build.gradle.kts
+++ b/blobdbgen/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.ksp)
@@ -11,6 +13,16 @@ dependencies {
     implementation("com.squareup:kotlinpoet-ksp:2.1.0")
 }
 
+// Fork: no jvmToolchain pin (see blobannotations/build.gradle.kts). Kotlin and
+// Java compile to the same 17 target so the JVM-target consistency check passes
+// on any JDK 17+.
 kotlin {
-    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
+    compilerOptions {
+        jvmTarget.set(JvmTarget.valueOf("JVM_${libs.versions.jvm.toolchain.get()}"))
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.toVersion(libs.versions.jvm.toolchain.get())
+    targetCompatibility = JavaVersion.toVersion(libs.versions.jvm.toolchain.get())
 }

--- a/firebase-stubs/build.gradle.kts
+++ b/firebase-stubs/build.gradle.kts
@@ -34,8 +34,13 @@ kotlin {
     // dependency in commonMain (KMP resolves commonMain deps for every
     // target; index-ai adds a jvm target on top of android + iOS). The iOS
     // app itself is unmaintained in this fork and still uses the real
-    // Firebase pods.
-    jvm()
+    // Firebase pods. The explicit bytecode target is the fork-wide rule (no
+    // toolchain pin, see index-ai/build.gradle.kts).
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
 
     iosX64 {
     }

--- a/index-ai/build.gradle.kts
+++ b/index-ai/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.androidKotlinMultiplatformLibrary)
@@ -16,6 +18,14 @@ kotlin {
         compileSdk = libs.versions.android.compileSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()
 
+        // Fork: no module pins a JVM toolchain (F-Droid's buildserver has one
+        // JDK, 21), so without an explicit target this compilation would
+        // follow the JDK running Gradle and emit different class files on 21
+        // than on 17. Every JVM-flavoured target in the tree sets 17.
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+
         withHostTestBuilder {
         }
 
@@ -26,7 +36,11 @@ kotlin {
         }
     }
 
-    jvm()
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
 
     // For iOS targets, this is also where you should
     // configure native binary output. For more information, see:

--- a/libpebble3/build.gradle.kts
+++ b/libpebble3/build.gradle.kts
@@ -19,8 +19,7 @@ room {
 val enableIosTarget = System.getProperty("os.name").contains("mac", ignoreCase = true)
 
 kotlin {
-    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
-
+    // Fork: no jvmToolchain pin (see blobannotations/build.gradle.kts).
     targets.configureEach {
         compilations.configureEach {
             compileTaskProvider.configure {
@@ -57,7 +56,11 @@ kotlin {
         }
     }
 
-    jvm()
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.valueOf("JVM_${libs.versions.jvm.toolchain.get()}"))
+        }
+    }
 
     listOf(
         iosArm64(),

--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -30,7 +30,13 @@ kotlin {
         }
     }
 
-    jvm()
+    // Fork: explicit bytecode target, no toolchain pin (see
+    // index-ai/build.gradle.kts).
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
 
     listOf(
         iosArm64(),


### PR DESCRIPTION
Two changes the F-Droid submission review asked for, plus follow-up
fixes.

The tree no longer pins a JVM toolchain. libpebble3, blobannotations, and
blobdbgen called jvmToolchain(17), which fails on a build host with a
single newer JDK and toolchain provisioning off, the F-Droid buildserver
being exactly that (JDK 21). The calls are removed and every JVM-flavoured
target sets its bytecode target to 17 explicitly, so the class files are
the same on any JDK 17 or newer. FdroidGuardrailsTest fails on a
toolchain pin in any spelling, with a positive control for each shape,
since an upstream sync would bring the calls back. CI builds on a JDK 17
and JDK 21 matrix.

androidApp/version.properties records the versionCode of the most recent
tagged release as one versionCode=<digits> line, so F-Droid's update
checker can read it from a tag checkout and the recipe can use
AutoUpdateMode instead of a manual entry per release. A Gradle task
before preBuild, a guardrail test, and a tag-only CI step check the file
against the built commit; the shape check has a positive control and all
three layers agree on the shape. CLAUDE.md and DESIGN_NOTES (F-Droid)
record the file, the release rule, and the recipe fields that read it.

The CI workflow declares permissions: contents: read.

Verification record:

- CI (assembleDebug, assembleRelease, all host suites, lint) green on the
  tip on both JDK 17 and JDK 21, locally and on GitHub; zero test
  failures.
- Every JVM-flavoured target compiles to class-file version 61 on JDK 21.
- Each version-file check shown to fail on a probe (stale file on a
  temporary tag, missing changelog, malformed tag ref, malformed file).
