### PR TITLE
Rewire the About and Support links away from the in-app WebView

### DIFF
--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -259,6 +259,32 @@ existing installs rides the incompatible-model sweep in
 user's local mode is stashed, and `SttModelUpdatePrompt` restores it
 once a catalog model is downloaded.
 
+## In-app links and the What's-new popup
+
+Upstream's Settings > About linked "What's new in the app" to its hosted
+changelog in an embedded WebView. That page describes upstream's
+releases, not this fork's, and its host (Notion) refuses to render
+inside a WebView at all, so the fork points the item at its own
+What's-new popup instead. `WhatsNew.kt` in `:pebble` holds the revision
+counter, the entry list, and the popup composable; the update-triggered
+auto-show wrapper (`WhatsNewDialog`) stays in `:composeApp`. One entry
+is prepended per revision bump, and `WhatsNewTest` pins that
+convention. The About item's badge, the Settings tab badge slot, and
+the auto-show all key on `lastSeenWhatsNewVersion`, so acknowledging
+the popup anywhere clears all three; upstream's `AppUpdateTracker`
+(which badged on every version change) is left intact but no longer
+read.
+
+"What's new in PebbleOS" and "Getting Started & Troubleshooting" keep
+their upstream URLs but open in the external browser: the PebbleOS
+notes share the Notion-in-WebView problem, and the help centre is
+Intercom-backed, so loading it in an embedded WebView makes the app's
+own network traffic include Intercom's endpoints, which the app's
+listing does not (and should not need to) disclose. The upstream
+WebView routes (`RoadmapChangelogRoute`, `PebbleOsChangelogRoute`,
+`TroubleshootingRoute`) stay registered in `AppNavHost` but are
+unreachable, keeping the upstream merge surface small.
+
 ## F-Droid
 
 The fork targets inclusion in F-Droid's main repository. What that means

--- a/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/OnboardingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/OnboardingScreen.kt
@@ -59,6 +59,7 @@ import coreapp.composeapp.generated.resources.gravel_logo
 import io.rebble.libpebblecommon.connection.LibPebble
 import coredevices.pebble.ui.PebbleRoutes
 import coredevices.pebble.ui.PreviewWrapper
+import coredevices.pebble.ui.WHATS_NEW_VERSION
 import coredevices.ui.PebbleElevatedButton
 import coredevices.ui.SignInButtons
 import coredevices.util.CoreConfig

--- a/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/WhatsNewDialog.kt
+++ b/composeApp/src/commonMain/kotlin/coredevices/coreapp/ui/screens/WhatsNewDialog.kt
@@ -1,52 +1,21 @@
 package coredevices.coreapp.ui.screens
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import com.russhwolf.settings.Settings
+import coredevices.pebble.ui.WHATS_NEW_VERSION
+import coredevices.pebble.ui.WhatsNewPopup
 import coredevices.util.CoreConfigHolder
 import org.koin.compose.koinInject
-
-/**
- * Fork: the current "What's New" changelog revision. Bump this by one, and prepend an
- * entry to [whatsNewEntries], whenever there is something worth announcing to existing
- * users on update. The dialog shows once per user per bump (see [WhatsNewDialog]).
- */
-const val WHATS_NEW_VERSION = 1
-
-/** A single announced change: a short heading and a sentence or two of body. */
-data class WhatsNewEntry(val title: String, val body: String)
-
-/**
- * Newest first. Kept deliberately small: this is a "what changed for you" notice, not a
- * full changelog (that lives in git history and the repo docs).
- */
-val whatsNewEntries: List<WhatsNewEntry> = listOf(
-    WhatsNewEntry(
-        title = "Control what watchfaces and apps can reach",
-        body = "Watchfaces and apps can run code on your phone that uses the internet and " +
-            "your location. You can now turn that off, for everything or per app, in " +
-            "Settings > Apps > Watch App Permissions. It starts off for apps you already " +
-            "had installed; turn it on for the ones you trust.",
-    ),
-)
 
 /**
  * One-time update notice, shown over the home screen. Only fires when onboarding has
  * already happened (so it never overlaps the onboarding privacy choice) and the user's
  * last-seen revision is behind [WHATS_NEW_VERSION]. Dismissing stamps the current version
- * so it does not reappear.
+ * so it does not reappear. The popup itself and the entry list live in
+ * `coredevices.pebble.ui.WhatsNew`, where Settings > About reopens the same popup on
+ * demand.
  */
 @Composable
 fun WhatsNewDialog() {
@@ -62,28 +31,10 @@ fun WhatsNewDialog() {
         return
     }
 
-    AlertDialog(
-        onDismissRequest = { /* require an explicit acknowledge so it isn't missed */ },
-        title = { Text("What's new") },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                whatsNewEntries.forEach { entry ->
-                    Column {
-                        Text(
-                            entry.title,
-                            style = MaterialTheme.typography.titleSmall,
-                            fontWeight = FontWeight.SemiBold,
-                        )
-                        Spacer(Modifier.height(2.dp))
-                        Text(entry.body, style = MaterialTheme.typography.bodyMedium)
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = {
-                configHolder.update(config.copy(lastSeenWhatsNewVersion = WHATS_NEW_VERSION))
-            }) { Text("Got it") }
+    WhatsNewPopup(
+        requireExplicitAck = true,
+        onClose = {
+            configHolder.update(config.copy(lastSeenWhatsNewVersion = WHATS_NEW_VERSION))
         },
     )
 }

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchSettingsScreen.kt
@@ -1,6 +1,5 @@
 package coredevices.pebble.ui
 
-import AppUpdateTracker
 import CommonRoutes
 import CoreAppVersion
 import NextBugReportContext
@@ -93,6 +92,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
@@ -273,13 +273,11 @@ fun settingsBadgeTotal(): Int {
         AppUpdateState.NoUpdateAvailable -> 0
         is AppUpdateState.UpdateAvailable -> 1
     }
-    val appUpdateTracker: AppUpdateTracker = koinInject()
-    val appWasUpdated by appUpdateTracker.appWasUpdated.collectAsState()
-    val appUpdated = when (appWasUpdated) {
-        true -> 1
-        false -> 0
-    }
-    return permissionBadgeCount + updatesAvailable + appUpdated
+    // Fork: the third slot is an unseen What's-new notice. It keys on
+    // lastSeenWhatsNewVersion, like the About item badge and the popup itself, so
+    // acknowledging the notice anywhere clears all three together.
+    val whatsNewUnseen = if (coreConfig.lastSeenWhatsNewVersion < WHATS_NEW_VERSION) 1 else 0
+    return permissionBadgeCount + updatesAvailable + whatsNewUnseen
 }
 
 private val logger = Logger.withTag("WatchSettingsScreen")
@@ -440,8 +438,25 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
     val analyticsBackend: AnalyticsBackend = koinInject()
     val enableExperimentalDevices: EnableExperimentalDevices = koinInject()
     val experimentalDevices by enableExperimentalDevices.enabled.collectAsState()
-    val appUpdateTracker: AppUpdateTracker = koinInject()
-    val showChangelogBadge = remember { appUpdateTracker.appWasUpdated.value }
+    // Fork: About and Support web links open in the user's browser. The changelog
+    // host does not render inside an embedded WebView, and the help centre is
+    // Intercom-backed, so embedding it makes the app's own network traffic include
+    // Intercom's endpoints.
+    val uriHandler = LocalUriHandler.current
+    // Fork: state for reopening the What's-new popup from the About section. The
+    // update-triggered auto-show lives in App (WhatsNewDialog); this path is the
+    // user deliberately opening the same popup, so it is freely dismissable and
+    // stamps the revision as seen on close.
+    var showWhatsNewPopup by remember { mutableStateOf(false) }
+    if (showWhatsNewPopup) {
+        WhatsNewPopup(
+            requireExplicitAck = false,
+            onClose = {
+                coreConfigHolder.update(coreConfig.copy(lastSeenWhatsNewVersion = WHATS_NEW_VERSION))
+                showWhatsNewPopup = false
+            },
+        )
+    }
     val hasOfflineModels by produceState(false) {
         withContext(Dispatchers.Default) {
             // Installed catalog models only: a stale previous-engine dir on
@@ -540,39 +555,35 @@ fun rememberSettingsItemsState(navBarNav: NavBarNav?, snackbarDisplay: SnackbarD
                     },
                     isDebugSetting = false,
                 ),
-                navBarNav?.let { nav -> basicSettingsActionItem(
+                // Fork: opens the fork's own What's-new popup with Gravel's changes
+                // (the upstream changelog this item linked to describes upstream
+                // releases the fork does not ship). Badged until the current revision
+                // has been seen, here or via the update-triggered popup.
+                basicSettingsActionItem(
                     title = "What’s new in the app",
                     topLevelType = TopLevelType.Phone,
                     section = Section.About,
-                    action = {
-                        nav.navigateTo(CommonRoutes.RoadmapChangelogRoute)
-                    },
-                    actionIcon = Icons.AutoMirrored.Default.Launch,
-                    badge = if (showChangelogBadge) "1" else null,
-                    onDisplayed = {
-                        LaunchedEffect(Unit) {
-                            appUpdateTracker.acknowledgeCurrentVersion()
-                        }
-                    },
-                ) },
-                navBarNav?.let { nav -> basicSettingsActionItem(
+                    action = { showWhatsNewPopup = true },
+                    badge = if (coreConfig.lastSeenWhatsNewVersion < WHATS_NEW_VERSION) "1" else null,
+                ),
+                // Fork: external browser (see uriHandler above for why these three
+                // items no longer use the in-app WebView).
+                basicSettingsActionItem(
                     title = "What’s new in PebbleOS",
                     topLevelType = TopLevelType.Phone,
                     section = Section.About,
-                    action = {
-                        nav.navigateTo(CommonRoutes.PebbleOsChangelogRoute)
-                    },
+                    action = { uriHandler.openUri("https://ndocs.repebble.com/pebbleos-changelog") },
                     actionIcon = Icons.AutoMirrored.Default.Launch,
-                ) },
-                navBarNav?.let { nav -> basicSettingsActionItem(
+                ),
+                // Fork: external browser, keeping the Intercom-backed help centre out
+                // of the app's own network traffic.
+                basicSettingsActionItem(
                     title = "Getting Started & Troubleshooting",
                     topLevelType = TopLevelType.Phone,
                     section = Section.Support,
-                    action = {
-                        nav.navigateTo(CommonRoutes.TroubleshootingRoute)
-                    },
+                    action = { uriHandler.openUri("https://pbl.zip/in-app-getting-started-and-troubleshooting") },
                     actionIcon = Icons.AutoMirrored.Default.Launch,
-                ) },
+                ),
                 navBarNav?.let { nav -> basicSettingsActionItem(
                     title = "New Bug Report",
                     description = "Please report a bug if anything went wrong!",

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WhatsNew.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WhatsNew.kt
@@ -1,0 +1,87 @@
+package coredevices.pebble.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * Fork: the current "What's New" changelog revision. Bump this by one, and prepend an
+ * entry to [whatsNewEntries], whenever there is something worth announcing to existing
+ * users on update. The popup auto-shows once per user per bump (`WhatsNewDialog` in
+ * composeApp) and can be reopened any time from Settings > About.
+ */
+const val WHATS_NEW_VERSION = 2
+
+/** A single announced change: a short heading and a sentence or two of body. */
+data class WhatsNewEntry(val title: String, val body: String)
+
+/**
+ * Newest first, one entry per revision bump (WhatsNewTest pins that convention).
+ * Kept deliberately small: this is a "what changed for you" notice, not a full
+ * changelog (that lives in git history and the repo docs).
+ */
+val whatsNewEntries: List<WhatsNewEntry> = listOf(
+    WhatsNewEntry(
+        title = "Changelogs and help that open properly",
+        body = "\"What's new in the app\" in Settings > About now shows Gravel's own " +
+            "changes (this notice), any time you want to reread it. PebbleOS release " +
+            "notes and the help centre open in your browser, replacing an in-app view " +
+            "that refused to load those pages.",
+    ),
+    WhatsNewEntry(
+        title = "Control what watchfaces and apps can reach",
+        body = "Watchfaces and apps can run code on your phone that uses the internet and " +
+            "your location. You can now turn that off, for everything or per app, in " +
+            "Settings > Apps > Watch App Permissions. It starts off for apps you already " +
+            "had installed; turn it on for the ones you trust.",
+    ),
+)
+
+/**
+ * The What's-new popup, shared by the update-triggered notice (`WhatsNewDialog` in
+ * composeApp) and the Settings > About entry. [requireExplicitAck] disables
+ * tap-outside and back dismissal so the update notice cannot be swallowed by a
+ * stray tap; the on-demand path passes false and dismisses normally. [onClose]
+ * runs on any close and is where callers stamp the revision as seen.
+ */
+@Composable
+fun WhatsNewPopup(requireExplicitAck: Boolean, onClose: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = { if (!requireExplicitAck) onClose() },
+        title = { Text("What's new") },
+        text = {
+            // Scrolls because the list accumulates an entry per revision and the
+            // on-demand path shows the full history.
+            Column(
+                Modifier.verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                whatsNewEntries.forEach { entry ->
+                    Column {
+                        Text(
+                            entry.title,
+                            style = MaterialTheme.typography.titleSmall,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Spacer(Modifier.height(2.dp))
+                        Text(entry.body, style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onClose) { Text("Got it") }
+        },
+    )
+}

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/ui/WhatsNewTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/ui/WhatsNewTest.kt
@@ -1,0 +1,33 @@
+package coredevices.pebble.ui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Fork: pins the What's-new content conventions (see WhatsNew.kt). These are data
+ * invariants a later edit could silently break: forgetting the revision bump when an
+ * entry is added means the notice never auto-shows for it, and bumping without an
+ * entry re-announces stale news as if it were new.
+ */
+class WhatsNewTest {
+
+    @Test
+    fun revisionEqualsEntryCount() {
+        assertEquals(
+            WHATS_NEW_VERSION,
+            whatsNewEntries.size,
+            "One prepended entry per revision bump: WHATS_NEW_VERSION and the entry " +
+                "count must move together",
+        )
+    }
+
+    @Test
+    fun entriesHaveRealContent() {
+        assertTrue(whatsNewEntries.isNotEmpty(), "the popup must have something to show")
+        whatsNewEntries.forEach { entry ->
+            assertTrue(entry.title.isNotBlank(), "entry title must not be blank")
+            assertTrue(entry.body.isNotBlank(), "entry body must not be blank")
+        }
+    }
+}


### PR DESCRIPTION
"What's new in the app" opened a WebView of upstream's hosted changelog: a page that describes upstream's releases rather than this fork's, on a host (Notion) that refuses to render inside a WebView, so the screen only showed a compatibility error. The item now opens the fork's own What's-new popup. The entry list, revision counter, and popup composable move to coredevices.pebble.ui.WhatsNew so the settings screen can reuse them; the update-triggered auto-show (WhatsNewDialog) becomes a thin wrapper over the shared popup; a new entry announces the change and bumps the revision to 2, and WhatsNewTest pins the one-entry-per-revision convention.

The item badge and the Settings tab badge slot previously keyed on AppUpdateTracker, which flagged every version change and cleared as soon as the About list was displayed. Both now key on lastSeenWhatsNewVersion, the same gate the popup uses, so acknowledging a notice anywhere clears all three. AppUpdateTracker stays in the tree unused.

"What's new in PebbleOS" and "Getting Started & Troubleshooting" keep their upstream URLs but open in the external browser. The PebbleOS notes share the Notion rendering problem, and the help centre is Intercom-backed: loaded in an embedded WebView, it puts Intercom's endpoints into the app's own network traffic, which the store listing does not disclose; opened in the browser, that traffic never touches the app. The three WebView routes stay registered in AppNavHost but are unreachable.

Verification: the pebble, composeApp, and androidApp unit suites pass, WhatsNewTest included. Exercised end to end on an Android emulator: a fresh install onboards with every permission denied; the popup opens from Settings > About with all entries; with a stale stored revision the notice auto-shows, the Settings tab badge gains one, and acknowledging stamps the revision and clears it; both external items put the browser in the foreground; no crash signatures in logcat.