### PR TITLE
Search the store only on the search action, with Algolia analytics off

### DIFF
--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -285,6 +285,41 @@ WebView routes (`RoadmapChangelogRoute`, `PebbleOsChangelogRoute`,
 `TroubleshootingRoute`) stay registered in `AppNavHost` but are
 unreachable, keeping the upstream merge surface small.
 
+## App store search
+
+Both app store feeds (Core Devices and Rebble) keep their search index on
+Algolia, and upstream queries it straight from the phone with per-feed
+search-only keys (`AppstoreSources.kt`), so every store search is a
+request to a third party, one per enabled feed. The fork keeps the
+feature (neither store offers another search API) and narrows what the
+requests carry:
+
+- The store search runs only on the search action. `SearchState` (in
+  `:util`) keeps the live field text apart from `submittedQuery`, which
+  only `submit()` sets; the locker tab's store search reads the submitted
+  query, the on-device locker filter reads the live text, and the results
+  list shows a hint instead of stale results while the two differ.
+  Emptying the field withdraws the submitted query. `SearchStateTest`
+  pins that contract.
+- `LockerViewModel` debounces search requests (`STORE_SEARCH_DEBOUNCE`,
+  300 ms of quiet) regardless of the caller's cadence, so a caller that
+  asks on every edit (upstream's behaviour, and what an upstream merge
+  would bring back) still cannot stream prefixes, and emptying the field
+  cancels a request still inside the window; `LockerViewModelTest`
+  covers both.
+- `algoliaSearchParams` in `:pebble` is the only place a request is
+  assembled: query analytics and click analytics are off, personalization
+  is off, and no user token is ever attached, so the index owner's
+  Algolia Analytics does not retain the query and nothing in the request
+  links one query to the next. `AppstoreSearchParamsTest` pins the flags
+  on the parameter object and, by driving the real client into a mock
+  engine, on the wire.
+
+What remains is inherent to the feature: the submitted query text and
+the phone's IP reach Algolia's servers, which keep request logs of their
+own. The app listing (the fastlane description and the F-Droid recipe's
+NonFreeNet note) names Algolia for that reason.
+
 ## F-Droid
 
 The fork targets inclusion in F-Droid's main repository. What that means

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -9,10 +9,11 @@ On top of the de-Googling, Gravel tightens the app's own security posture:
 - Core watch firmware updates are fetched from the public PebbleOS releases and integrity-verified before install
 - On-device voice dictation with the whisper.cpp speech engine, built from source; the speech model is an optional, integrity-pinned download you start yourself
 - Manual latitude/longitude entry replaces the play-services place search for weather
+- App store searches leave the phone only when you tap search, never while you type, and are sent with Algolia's query analytics and personalization switched off and no user token
 
 Some watchapps and watchfaces need internet or your location to work, and they will not function fully until you grant them access. That is deliberate: Gravel puts the decision in your hands rather than trusting every watchapp by default.
 
-The app talks to the Core Devices and Rebble web services (app store and its search index, weather, timeline, notification icons, language packs), to the PebbleOS release feed on GitHub for firmware, and to the speech model host on first download; there is no google endpoint.
+The app talks to the Core Devices and Rebble web services (app store, weather, timeline, notification icons, language packs), to Algolia, which hosts the app store's search index, whenever you search the store, to the PebbleOS release feed on GitHub for firmware, and to the speech model host on first download; there is no google endpoint.
 
 Permissions Gravel asks for are the ones the watch features need: Bluetooth and location for finding and staying connected to the watch (background location so location-based watchapps and weather keep working while the app is not open), notification access to forward notifications, contacts, call log, and phone state for caller names and call control on the watch, calendar for timeline pins, Health Connect write access to sync the watch's health data, and the list of installed apps for per-app notification settings. Each is requested when the corresponding feature is first set up.
 

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/services/AppstoreSearchParams.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/services/AppstoreSearchParams.kt
@@ -1,0 +1,43 @@
+package coredevices.pebble.services
+
+import com.algolia.client.model.search.SearchParamsObject
+import com.algolia.client.model.search.TagFilters
+
+/**
+ * The one place an Algolia search request is assembled. Both app store
+ * feeds keep their search index on Algolia and upstream queries it straight
+ * from the phone with per-feed search-only keys (`AppstoreSources.kt`), so
+ * every store search is a request to a third party that the app's listing
+ * has to disclose. Building the parameters here keeps the privacy flags
+ * identical on every call and lets `AppstoreSearchParamsTest` pin them,
+ * on the object and on the wire.
+ *
+ * What each flag buys:
+ * - `analytics = false`: Algolia's server-side default is true, which
+ *   retains the query and its metadata (hit count, country derived from
+ *   the requesting IP) in the index owner's Algolia Analytics. False
+ *   excludes the request from that retention; the query itself still has
+ *   to reach Algolia to be answered.
+ * - `clickAnalytics = false`: no queryID is minted for Insights
+ *   click/conversion events. The app never sends those events, so the ID
+ *   would only ever be a correlation handle.
+ * - `enablePersonalization = false`: no per-user ranking signals. The
+ *   client default is already false; it is pinned so a default change in
+ *   a client upgrade cannot turn it on.
+ * - `userToken` is never set: without one, nothing in the request links
+ *   one query to the next beyond the connection itself.
+ */
+internal fun algoliaSearchParams(
+    query: String,
+    tagFilters: TagFilters? = null,
+    page: Int? = null,
+    hitsPerPage: Int? = null,
+): SearchParamsObject = SearchParamsObject(
+    query = query,
+    tagFilters = tagFilters,
+    page = page,
+    hitsPerPage = hitsPerPage,
+    analytics = false,
+    clickAnalytics = false,
+    enablePersonalization = false,
+)

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/services/AppstoreService.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/services/AppstoreService.kt
@@ -5,7 +5,6 @@ import androidx.paging.PagingState
 import co.touchlab.kermit.Logger
 import com.algolia.client.api.SearchClient
 import com.algolia.client.exception.AlgoliaApiException
-import com.algolia.client.model.search.SearchParamsObject
 import com.algolia.client.model.search.TagFilters
 import coredevices.database.AppstoreCollection
 import coredevices.database.AppstoreCollectionDao
@@ -593,9 +592,7 @@ class AppstoreService(
         return try {
             val response = searchClient.searchSingleIndex(
                 indexName = source.algoliaIndexName!!,
-                searchParams = SearchParamsObject(
-                    query = uuid,
-                ),
+                searchParams = algoliaSearchParams(query = uuid),
             )
             val found = response.hits.mapNotNull {
                 val props = it.additionalProperties ?: return@mapNotNull null
@@ -632,7 +629,7 @@ class AppstoreService(
             searchClient.searchSingleIndex(
                 indexName = source.algoliaIndexName!!,
 //                searchParams = SearchParams.of(SearchParamsString(search)),
-                searchParams = SearchParamsObject(
+                searchParams = algoliaSearchParams(
                     query = search,
                     tagFilters = TagFilters.of(
                         listOf(

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/LockerScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/LockerScreen.kt
@@ -104,14 +104,20 @@ import io.rebble.libpebblecommon.util.getTempFilePath
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.io.files.SystemFileSystem
+import kotlin.time.Duration.Companion.milliseconds
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
@@ -124,7 +130,16 @@ const val REBBLE_LOGIN_URI = "https://boot.rebble.io"
 
 private val logger = Logger.withTag("LockerScreen")
 
-private data class SearchParams(
+/**
+ * Quiet period a store query has to survive before it is sent. The screen
+ * only asks for a store search on the search action, so in normal use this
+ * adds a short pause after the tap; its job is to hold as a rate cap if a
+ * caller ever asks on every edit again, so a typed word can still only go
+ * out once per window instead of as each of its prefixes.
+ */
+internal val STORE_SEARCH_DEBOUNCE = 300.milliseconds
+
+internal data class SearchParams(
     val query: String,
     val appType: AppType,
     val watchType: WatchType,
@@ -167,6 +182,17 @@ class LockerViewModel(
     var searchPager by mutableStateOf<Flow<PagingData<CommonApp>>?>(null)
         private set
     private var lastSearchParams: SearchParams? = null
+
+    /** The search the current [searchPager] was built for; exposed for tests. */
+    internal val activeSearch: SearchParams? get() = lastSearchParams
+
+    // Search requests land here and are acted on only after
+    // STORE_SEARCH_DEBOUNCE of quiet, whatever the caller's cadence, so a
+    // typed word can reach Algolia once per window and never as a stream of
+    // prefixes. null means the field was emptied and cancels a request still
+    // inside the window.
+    private val searchRequests = MutableStateFlow<SearchParams?>(null)
+    private var searchCollector: Job? = null
     val searchState = SearchState()
     // Held here, not remembered in the composable: the screen is disposed when navigating into an
     // app's detail page, which would otherwise discard the scroll position.
@@ -227,12 +253,38 @@ class LockerViewModel(
     }
 
     fun searchStore(search: String, watchType: WatchType, platform: Platform, appType: AppType) {
-        val params = SearchParams(search, appType, watchType, platform)
+        ensureSearchCollector()
+        searchRequests.value = SearchParams(search, appType, watchType, platform)
+    }
+
+    /** The search field was emptied: drop a query still waiting out the debounce. */
+    fun clearPendingSearch() {
+        searchRequests.value = null
+    }
+
+    // Started lazily: the locker tab creates this view model whether or not
+    // the user ever searches, and nothing may run at construction time.
+    @OptIn(FlowPreview::class)
+    private fun ensureSearchCollector() {
+        if (searchCollector?.isActive == true) return
+        searchCollector = viewModelScope.launch {
+            searchRequests
+                .debounce(STORE_SEARCH_DEBOUNCE)
+                // Placed after the debounce so an emptied field (null)
+                // supersedes a prefix that was still waiting.
+                .filterNotNull()
+                .collect { startSearch(it) }
+        }
+    }
+
+    private fun startSearch(params: SearchParams) {
         if (params == lastSearchParams && searchPager != null) return
         lastSearchParams = params
         searchPager = Pager(
             config = PagingConfig(pageSize = 20, enablePlaceholders = false),
-            pagingSourceFactory = { SearchPagingSource(pebbleWebServices, search, appType, watchType, platform) },
+            pagingSourceFactory = {
+                SearchPagingSource(pebbleWebServices, params.query, params.appType, params.watchType, params.platform)
+            },
         ).flow.cachedIn(viewModelScope)
     }
 }
@@ -337,9 +389,15 @@ fun LockerScreen(
             }
         }
 
-        LaunchedEffect(viewModel.searchState.query, viewModel.type.value) {
-            if (viewModel.searchState.query.isNotEmpty()) {
-                viewModel.searchStore(viewModel.searchState.query, sharedViewModel.watchType.value, platform, viewModel.type.value)
+        // The store search reads the submitted query, so typing alone sends
+        // nothing; the locker filter below stays live on the raw text because
+        // it never leaves the phone.
+        LaunchedEffect(viewModel.searchState.submittedQuery, viewModel.type.value) {
+            val submitted = viewModel.searchState.submittedQuery
+            if (submitted.isNotEmpty()) {
+                viewModel.searchStore(submitted, sharedViewModel.watchType.value, platform, viewModel.type.value)
+            } else {
+                viewModel.clearPendingSearch()
             }
         }
         val currentHearts = currentHearts()
@@ -386,6 +444,7 @@ fun LockerScreen(
                         SearchResultsList(
                             lockerEntries = lockerEntries,
                             storeResults = filteredStoreResults,
+                            storeSearchPending = viewModel.searchState.submittedQuery != viewModel.searchState.query,
                             hasUnfilteredStoreResults = hasUnfilteredStoreResults,
                             navBarNav = navBarNav,
                             topBarParams = topBarParams,
@@ -694,6 +753,8 @@ fun String.toColorKmp(): Color {
 fun SearchResultsList(
     lockerEntries: List<CommonApp>,
     storeResults: LazyPagingItems<CommonApp>?,
+    /** The field holds text that has not been submitted, so [storeResults] (if any) belong to an older query. */
+    storeSearchPending: Boolean,
     hasUnfilteredStoreResults: Boolean,
     navBarNav: NavBarNav,
     topBarParams: TopBarParams,
@@ -704,7 +765,8 @@ fun SearchResultsList(
     sharedViewModel: SharedLockerViewModel,
 ) {
     val scope = rememberCoroutineScope()
-    val isLoadingFirstPage = storeResults == null || (storeResults.loadState.refresh is LoadState.Loading && storeResults.itemCount == 0)
+    val isLoadingFirstPage = !storeSearchPending &&
+            (storeResults == null || (storeResults.loadState.refresh is LoadState.Loading && storeResults.itemCount == 0))
     if (appType == AppType.Watchface) {
         if (isLoadingFirstPage) {
             // Composing the grid before the store results land would measure it with only the
@@ -736,6 +798,10 @@ fun SearchResultsList(
                     }
                 }
                 item(span = { GridItemSpan(maxLineSpan) }) { SectionHeader("From the store") }
+                if (storeSearchPending || storeResults == null) {
+                    item(span = { GridItemSpan(maxLineSpan) }) { StoreSearchHint() }
+                    return@LazyVerticalGrid
+                }
                 items(
                     count = storeResults.itemCount,
                     key = storeResults.itemKey { "store_${it.storeId}-${it.uuid}" },
@@ -815,9 +881,11 @@ fun SearchResultsList(
                         CircularProgressIndicator()
                     }
                 }
+            } else if (storeSearchPending || storeResults == null) {
+                item { StoreSearchHint() }
             } else {
                 items(
-                    count = storeResults!!.itemCount,
+                    count = storeResults.itemCount,
                     key = storeResults.itemKey { "store_${it.uuid}" },
                 ) { index ->
                     storeResults[index]?.let { entry ->
@@ -839,7 +907,7 @@ fun SearchResultsList(
                         )
                     }
                 }
-                if (storeResults!!.loadState.append is LoadState.Loading) {
+                if (storeResults.loadState.append is LoadState.Loading) {
                     item {
                         Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                             CircularProgressIndicator()
@@ -1163,6 +1231,17 @@ fun NativeWatchfaceListItem(
             }
         }
     }
+}
+
+/** Shown in the store section until the typed text is submitted with the search action. */
+@Composable
+private fun StoreSearchHint() {
+    Text(
+        "Tap search to search the store",
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
 }
 
 @Composable

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchHomeScreen.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WatchHomeScreen.kt
@@ -464,6 +464,7 @@ fun WatchHomeScreen(
                     val focusManager = LocalFocusManager.current
                     val keyboardController = LocalSoftwareKeyboardController.current
                     val onSearchDone = {
+                        params.searchState?.submit()
                         params.searchState?.typing = false
                         keyboardController?.hide()
                         focusManager.clearFocus()

--- a/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WhatsNew.kt
+++ b/pebble/src/commonMain/kotlin/coredevices/pebble/ui/WhatsNew.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.unit.dp
  * users on update. The popup auto-shows once per user per bump (`WhatsNewDialog` in
  * composeApp) and can be reopened any time from Settings > About.
  */
-const val WHATS_NEW_VERSION = 2
+const val WHATS_NEW_VERSION = 3
 
 /** A single announced change: a short heading and a sentence or two of body. */
 data class WhatsNewEntry(val title: String, val body: String)
@@ -32,6 +32,13 @@ data class WhatsNewEntry(val title: String, val body: String)
  * changelog (that lives in git history and the repo docs).
  */
 val whatsNewEntries: List<WhatsNewEntry> = listOf(
+    WhatsNewEntry(
+        title = "Store search that waits for you",
+        body = "Searching the store now runs when you tap search, not while you type, " +
+            "so the store's search provider (Algolia) only ever sees what you submit, " +
+            "and it is asked not to keep analytics about it. Your own watchfaces and " +
+            "apps still filter as you type.",
+    ),
     WhatsNewEntry(
         title = "Changelogs and help that open properly",
         body = "\"What's new in the app\" in Settings > About now shows Gravel's own " +

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/services/AppstoreSearchParamsTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/services/AppstoreSearchParamsTest.kt
@@ -1,0 +1,78 @@
+package coredevices.pebble.services
+
+import com.algolia.client.api.SearchClient
+import com.algolia.client.configuration.ClientOptions
+import com.algolia.client.configuration.Host
+import com.algolia.client.model.search.TagFilters
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.headersOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+class AppstoreSearchParamsTest {
+
+    @Test
+    fun helperTurnsAnalyticsAndPersonalizationOffAndKeepsTheSearchItself() {
+        val filters = TagFilters.of(listOf(TagFilters.of("watchface"), TagFilters.of("android")))
+        val params = algoliaSearchParams(query = "cat", tagFilters = filters, page = 2, hitsPerPage = 20)
+
+        assertEquals(false, params.analytics)
+        assertEquals(false, params.clickAnalytics)
+        assertEquals(false, params.enablePersonalization)
+        assertNull(params.userToken)
+        assertEquals("cat", params.query)
+        assertEquals(filters, params.tagFilters)
+        assertEquals(2, params.page)
+        assertEquals(20, params.hitsPerPage)
+    }
+
+    // Flags on the parameter object only matter if the client serialises
+    // them: a client that omitted false values would silently hand the
+    // decision back to Algolia's server-side defaults. So this drives the
+    // real SearchClient into a mock engine and reads the request body back.
+    @Test
+    fun searchRequestCarriesTheFlagsOnTheWire() = runTest {
+        var body: String? = null
+        var path: String? = null
+        val engine = MockEngine { request ->
+            path = request.url.encodedPath
+            body = request.body.toByteArray().decodeToString()
+            respond(
+                content = """{"hits":[],"nbHits":0,"page":0,"nbPages":0,"hitsPerPage":20,"processingTimeMS":1,"query":"cat","params":"query=cat"}""",
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val client = SearchClient(
+            appId = "TESTAPPID",
+            apiKey = "search-only-key",
+            options = ClientOptions(engine = engine, hosts = listOf(Host("search.invalid"))),
+        )
+
+        // The client's own timeouts must run on the real clock: under
+        // runTest's virtual clock they fire before the mock engine answers.
+        withContext(Dispatchers.Default) {
+            client.searchSingleIndex(indexName = "apps", searchParams = algoliaSearchParams(query = "cat"))
+        }
+
+        assertEquals("/1/indexes/apps/query", path)
+        val json = Json.parseToJsonElement(body ?: error("no request body captured")).jsonObject
+        assertEquals(false, json["analytics"]?.jsonPrimitive?.booleanOrNull, "analytics must be sent as false: $body")
+        assertEquals(false, json["clickAnalytics"]?.jsonPrimitive?.booleanOrNull, "clickAnalytics must be sent as false: $body")
+        assertEquals(false, json["enablePersonalization"]?.jsonPrimitive?.booleanOrNull, "enablePersonalization must be sent as false: $body")
+        assertFalse("userToken" in json, "no user token may be attached: $body")
+        assertEquals("cat", json["query"]?.jsonPrimitive?.content)
+    }
+}

--- a/pebble/src/commonTest/kotlin/coredevices/pebble/ui/LockerViewModelTest.kt
+++ b/pebble/src/commonTest/kotlin/coredevices/pebble/ui/LockerViewModelTest.kt
@@ -1,0 +1,130 @@
+package coredevices.pebble.ui
+
+import coredevices.database.AppstoreSource
+import coredevices.database.AppstoreSourceDao
+import coredevices.pebble.Platform
+import coredevices.pebble.account.UsersMeResponse
+import coredevices.pebble.services.AppStoreHomeResult
+import coredevices.pebble.services.CoreUsersMe
+import coredevices.pebble.services.PebbleWebServices
+import coredevices.pebble.services.StoreSearchResult
+import coredevices.pebble.weather.WeatherResponse
+import coredevices.util.WeatherUnit
+import io.rebble.libpebblecommon.locker.AppType
+import io.rebble.libpebblecommon.metadata.WatchType
+import io.rebble.libpebblecommon.web.LockerAddResponse
+import io.rebble.libpebblecommon.web.LockerModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.fail
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.uuid.Uuid
+
+/**
+ * The debounce is the control that keeps a typed word from leaving the phone
+ * as each of its prefixes, so these tests drive the view model on a virtual
+ * clock and watch exactly when a search starts. No pager is ever collected,
+ * so the web services double fails on any call.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class LockerViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun installMain() = Dispatchers.setMain(dispatcher)
+
+    @AfterTest
+    fun restoreMain() = Dispatchers.resetMain()
+
+    private fun search(vm: LockerViewModel, query: String, type: AppType = AppType.Watchface) =
+        vm.searchStore(query, WatchType.BASALT, Platform.Android, type)
+
+    @Test
+    fun aTypedWordIsSearchedOnceTheTypingStops() = runTest(dispatcher) {
+        val vm = LockerViewModel(NoNetworkWebServices, NoSourcesDao)
+        for (prefix in listOf("c", "ca", "cat")) {
+            search(vm, prefix)
+            advanceTimeBy(100.milliseconds)
+            assertNull(vm.activeSearch, "a prefix must not be searched while typing continues ($prefix)")
+            assertNull(vm.searchPager)
+        }
+        advanceTimeBy(STORE_SEARCH_DEBOUNCE)
+        runCurrent()
+        assertEquals("cat", vm.activeSearch?.query)
+        assertNotNull(vm.searchPager)
+    }
+
+    @Test
+    fun emptyingTheFieldInsideTheWindowCancelsThePendingQuery() = runTest(dispatcher) {
+        val vm = LockerViewModel(NoNetworkWebServices, NoSourcesDao)
+        search(vm, "c")
+        advanceTimeBy(100.milliseconds)
+        vm.clearPendingSearch()
+        advanceTimeBy(STORE_SEARCH_DEBOUNCE * 3)
+        runCurrent()
+        assertNull(vm.activeSearch)
+        assertNull(vm.searchPager)
+    }
+
+    @Test
+    fun repeatingASearchKeepsThePagerAndChangingTheTypeStartsANewOne() = runTest(dispatcher) {
+        val vm = LockerViewModel(NoNetworkWebServices, NoSourcesDao)
+        search(vm, "cat")
+        advanceTimeBy(STORE_SEARCH_DEBOUNCE * 2)
+        runCurrent()
+        val first = assertNotNull(vm.searchPager)
+
+        search(vm, "cat")
+        advanceTimeBy(STORE_SEARCH_DEBOUNCE * 2)
+        runCurrent()
+        assertSame(first, vm.searchPager)
+
+        search(vm, "cat", AppType.Watchapp)
+        advanceTimeBy(STORE_SEARCH_DEBOUNCE * 2)
+        runCurrent()
+        assertNotSame(first, vm.searchPager)
+        assertEquals(AppType.Watchapp, vm.activeSearch?.appType)
+    }
+}
+
+private object NoNetworkWebServices : PebbleWebServices {
+    private fun unexpected(): Nothing = fail("the debounce must never reach the web services")
+    override suspend fun fetchUsersMePebble(): UsersMeResponse? = unexpected()
+    override suspend fun fetchUsersMeCore(): CoreUsersMe? = unexpected()
+    override suspend fun fetchPebbleLocker(): LockerModel? = unexpected()
+    override suspend fun addToLegacyLocker(uuid: String): Boolean = unexpected()
+    override suspend fun fetchAppStoreHome(type: AppType, hardwarePlatform: WatchType?, enabledOnly: Boolean, useCache: Boolean): List<AppStoreHomeResult> = unexpected()
+    override suspend fun fetchPebbleAppStoreHomes(hardwarePlatform: WatchType?, useCache: Boolean): Map<AppType, AppStoreHomeResult?> = unexpected()
+    override suspend fun searchAppStore(search: String, appType: AppType, watchType: WatchType, page: Int, pageSize: Int): List<Pair<AppstoreSource, StoreSearchResult>> = unexpected()
+    override suspend fun addToLegacyLockerWithResponse(uuid: String): LockerAddResponse? = unexpected()
+    override suspend fun addToLocker(entry: CommonAppType.Store, timelineToken: String?): Boolean = unexpected()
+    override suspend fun removeFromLegacyLocker(id: Uuid): Boolean = unexpected()
+    override suspend fun fetchUserHearts() = unexpected()
+    override suspend fun getWeather(latitude: Double, longitude: Double, units: WeatherUnit, language: String): WeatherResponse? = unexpected()
+}
+
+private object NoSourcesDao : AppstoreSourceDao {
+    private fun unexpected(): Nothing = fail("the debounce must never touch the source table")
+    override suspend fun insertSource(source: AppstoreSource): Long = unexpected()
+    override fun getAllSources(): Flow<List<AppstoreSource>> = unexpected()
+    override fun getAllEnabledSourcesFlow(): Flow<List<AppstoreSource>> = unexpected()
+    override suspend fun getAllEnabledSources(): List<AppstoreSource> = unexpected()
+    override suspend fun deleteSourceById(sourceId: Int) = unexpected()
+    override suspend fun setSourceEnabled(sourceId: Int, isEnabled: Boolean) = unexpected()
+    override suspend fun getSourceById(sourceId: Int): AppstoreSource? = unexpected()
+}

--- a/util/src/commonMain/kotlin/coredevices/pebble/ui/TopBarParams.kt
+++ b/util/src/commonMain/kotlin/coredevices/pebble/ui/TopBarParams.kt
@@ -33,7 +33,35 @@ data class TopBarParams(
 fun rememberSearchState() = remember { SearchState() }
 
 class SearchState {
-    var query by mutableStateOf("")
+    private val queryState = mutableStateOf("")
+
+    /**
+     * What the field shows. It changes on every keystroke and is meant for
+     * on-device filtering only.
+     */
+    var query: String
+        get() = queryState.value
+        set(value) {
+            queryState.value = value
+            // Emptying the field withdraws the submitted query as well, so no
+            // store results linger for text that is no longer there.
+            if (value.isEmpty()) submittedQuery = ""
+        }
+
+    /**
+     * The text the user committed with the search action. Anything that
+     * leaves the phone (the store search) reads this and never [query], so a
+     * query goes out as the user submitted it and not as each of its
+     * prefixes. Screens compare the two to tell an edited, not yet submitted
+     * field from a submitted one.
+     */
+    var submittedQuery by mutableStateOf("")
+        private set
+
+    fun submit() {
+        submittedQuery = query
+    }
+
     var typing by mutableStateOf(false)
     var show by mutableStateOf(false)
 }

--- a/util/src/commonTest/kotlin/coredevices/pebble/ui/SearchStateTest.kt
+++ b/util/src/commonTest/kotlin/coredevices/pebble/ui/SearchStateTest.kt
@@ -1,0 +1,44 @@
+package coredevices.pebble.ui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The submitted query is what the store search sends, so the contract
+ * under test is that typing never moves it, only the search action does,
+ * and that emptying the field withdraws it.
+ */
+class SearchStateTest {
+
+    @Test
+    fun typingDoesNotChangeTheSubmittedQuery() {
+        val state = SearchState()
+        for (prefix in listOf("c", "ca", "cat")) {
+            state.query = prefix
+            assertEquals("", state.submittedQuery, "typing '$prefix' must not submit")
+        }
+    }
+
+    @Test
+    fun submitCopiesTheFieldAndLaterEditsLeaveItUntilResubmitted() {
+        val state = SearchState()
+        state.query = "cat"
+        state.submit()
+        assertEquals("cat", state.submittedQuery)
+
+        state.query = "cats"
+        assertEquals("cat", state.submittedQuery, "an edit is not a submission")
+
+        state.submit()
+        assertEquals("cats", state.submittedQuery)
+    }
+
+    @Test
+    fun emptyingTheFieldWithdrawsTheSubmittedQuery() {
+        val state = SearchState()
+        state.query = "cat"
+        state.submit()
+        state.query = ""
+        assertEquals("", state.submittedQuery)
+    }
+}


### PR DESCRIPTION
Store searches ran on every keystroke and went to Algolia with analytics left at Algolia's defaults, and the listing did not name Algolia.

- The store search now runs only on the keyboard's search action. Typing filters the locker locally and the store section shows a hint until the query is submitted; emptying the field withdraws the submitted query.
- `LockerViewModel` debounces search requests (300 ms) regardless of how the UI asks, so per-edit searching cannot stream prefixes.
- `algoliaSearchParams` assembles every Algolia request with `analytics`, `clickAnalytics` and `enablePersonalization` off and no user token.
- What's-new entry, DESIGN_NOTES section, and the fastlane description names Algolia.

Tests: `SearchStateTest`, `LockerViewModelTest` (virtual clock), `AppstoreSearchParamsTest` (flags on the parameter object and on the wire, through the real client into a mock engine). Full unit line green on JDK 17.

Verified on an emulator with per-uid socket monitoring: no Algolia connection while typing, one request per submitted query and per type toggle, none on edit or clear; the What's-new notice auto-shows the new entry; no crash signatures in logcat.
